### PR TITLE
SH-67: unlock shop on total friendship earned, not current balance

### DIFF
--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -115,6 +115,7 @@ func get_friendship_point_balance() -> int:
 ## Adds friendship points and emits balance changed signal
 func add_friendship_points(points: int) -> void:
 	_progression.friendship_point_balance += points
+	_progression.total_friendship_points_earned += points
 	friendship_point_balance_changed.emit(_progression.friendship_point_balance)
 
 

--- a/scripts/progression/progression_data.gd
+++ b/scripts/progression/progression_data.gd
@@ -2,6 +2,7 @@ class_name ProgressionData
 extends RefCounted
 
 var friendship_point_balance := 0
+var total_friendship_points_earned := 0
 var item_levels: Dictionary[String, int]
 var personal_volley_best := 0
 var shop_unlocked := false
@@ -12,6 +13,7 @@ var _storage: SaveStorage
 ## Resets all progression fields to their defaults.
 func clear() -> void:
 	friendship_point_balance = 0
+	total_friendship_points_earned = 0
 	item_levels = {}
 	personal_volley_best = 0
 	shop_unlocked = false
@@ -36,6 +38,7 @@ func load_from_disk() -> bool:
 
 	var loaded := from_dict(data)
 	friendship_point_balance = loaded.friendship_point_balance
+	total_friendship_points_earned = loaded.total_friendship_points_earned
 	item_levels = loaded.item_levels
 	personal_volley_best = loaded.personal_volley_best
 	shop_unlocked = loaded.shop_unlocked
@@ -47,6 +50,7 @@ func load_from_disk() -> bool:
 func to_dict() -> Dictionary:
 	return {
 		"friendship_point_balance": friendship_point_balance,
+		"total_friendship_points_earned": total_friendship_points_earned,
 		"item_levels": item_levels,
 		"personal_volley_best": personal_volley_best,
 		"shop_unlocked": shop_unlocked,
@@ -57,6 +61,9 @@ func to_dict() -> Dictionary:
 static func from_dict(data: Dictionary) -> ProgressionData:
 	var progression := ProgressionData.new()
 	progression.friendship_point_balance = data.get("friendship_point_balance", 0)
+	progression.total_friendship_points_earned = data.get(
+		"total_friendship_points_earned", data.get("friendship_point_balance", 0)
+	)
 	progression.item_levels = _to_typed_dict(data.get("item_levels", {}))
 	progression.personal_volley_best = data.get("personal_volley_best", 0)
 	progression.shop_unlocked = data.get("shop_unlocked", data.get("clearance_unlocked", false))

--- a/scripts/progression/progression_manager.gd
+++ b/scripts/progression/progression_manager.gd
@@ -29,7 +29,7 @@ func _on_friendship_point_balance_changed(_balance: int) -> void:
 func _check_shop_unlock() -> void:
 	if _progression.shop_unlocked:
 		return
-	if _progression.friendship_point_balance >= SHOP_UNLOCK_THRESHOLD:
+	if _progression.total_friendship_points_earned >= SHOP_UNLOCK_THRESHOLD:
 		_progression.shop_unlocked = true
 		SaveManager.save()
 		shop_unlocked_changed.emit(true)

--- a/tests/unit/test_progression_data.gd
+++ b/tests/unit/test_progression_data.gd
@@ -82,3 +82,25 @@ func test_from_dict_missing_keys_use_defaults() -> void:
 	assert_eq(restored.friendship_point_balance, 0)
 	assert_eq(restored.item_levels, {})
 	assert_eq(restored.personal_volley_best, 0)
+
+
+# --- total_friendship_points_earned ---
+func test_total_friendship_points_earned_default_zero() -> void:
+	assert_eq(_data.total_friendship_points_earned, 0)
+
+
+func test_total_friendship_points_earned_round_trips() -> void:
+	_data.total_friendship_points_earned = 1234
+	var restored := ProgressionData.from_dict(_data.to_dict())
+	assert_eq(restored.total_friendship_points_earned, 1234)
+
+
+func test_from_dict_falls_back_to_balance_for_legacy_saves() -> void:
+	var restored := ProgressionData.from_dict({"friendship_point_balance": 75})
+	assert_eq(restored.total_friendship_points_earned, 75)
+
+
+func test_clear_resets_total_friendship_points_earned() -> void:
+	_data.total_friendship_points_earned = 500
+	_data.clear()
+	assert_eq(_data.total_friendship_points_earned, 0)

--- a/tests/unit/test_shop_unlock.gd
+++ b/tests/unit/test_shop_unlock.gd
@@ -42,6 +42,22 @@ class TestShopUnlock:
 		_item_manager.add_friendship_points(10)
 		assert_signal_not_emitted(_progression_manager, "shop_unlocked_changed")
 
+	func test_shop_unlocks_when_total_earned_reaches_threshold_even_after_spending() -> void:
+		var threshold: int = _progression_manager.SHOP_UNLOCK_THRESHOLD
+		_item_manager.add_friendship_points(threshold - 10)
+		_item_manager.subtract_friendship_points(threshold - 20)
+		assert_false(_progression_manager.is_shop_unlocked(), "not yet at threshold total")
+		_item_manager.add_friendship_points(15)
+		assert_true(
+			_progression_manager.is_shop_unlocked(),
+			"cumulative earnings crossed threshold after spending"
+		)
+
+	func test_spending_does_not_reduce_total_earned() -> void:
+		_item_manager.add_friendship_points(100)
+		_item_manager.subtract_friendship_points(100)
+		assert_eq(_item_manager._progression.total_friendship_points_earned, 100)
+
 
 class TestShopPersistence:
 	extends GutTest


### PR DESCRIPTION
## Summary

- Adds a `total_friendship_points_earned` counter to `ProgressionData` that only grows on `add_friendship_points` and is never decremented by spending
- `ProgressionManager._check_shop_unlock()` now compares against the cumulative total instead of the current balance, so a player who earns and spends before crossing the threshold still unlocks the shop once their lifetime earnings reach 50
- Legacy saves without the new field fall back to the current balance, so existing runs don't regress
- Six new tests covering the new field (round-trip, legacy fallback, clear reset) and the behaviour (unlock after earn-then-spend-then-earn, spending doesn't reduce total)

Stacks on top of #85 (SH-32) because the progression manager being fixed was introduced there. Rebase onto `main` once #85 merges.

Fixes SH-67.

## Test plan

- [x] `ggut` passes (207 tests, up from 201)
- [x] `pre-commit run` clean (format, lint, gut)
- [ ] Manual: earn 30 FP, spend 30 FP via dev panel, earn 25 FP, confirm shop HUD button appears
- [ ] Manual: load an existing save, confirm no regression in unlock state

🤖 Generated with [Claude Code](https://claude.com/claude-code)