### PR TITLE
Dev HUD version label

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Write version
+        run: git describe --always > version.txt
+
       - name: Strip dev addons
         run: |
           sed -i '/GodotIQRuntime=/d' project.godot
@@ -55,9 +58,6 @@ jobs:
           sed -i 's|"res://addons/gut/plugin.cfg", ||g' project.godot
           sed -i 's|, "res://addons/gut/plugin.cfg"||g' project.godot
           rm -rf addons/coverage
-
-      - name: Write version
-        run: git describe --always --dirty > version.txt
 
       - name: Export Web
         id: export


### PR DESCRIPTION
## Summary
- Add a dev HUD version label displaying the current git commit hash
- Guard git fallback behind an editor check to avoid runtime errors in exports
- Include version.txt in the export and fix CI to write version before stripping dev addons (avoids -dirty suffix)

## Test plan
- [ ] Run the game locally and verify the version label appears in the dev HUD
- [ ] Confirm version.txt is included in the exported build
- [ ] Verify the CI publish workflow writes a clean hash (no -dirty suffix) by checking the step order

🤖 Generated with [Claude Code](https://claude.com/claude-code)