### PR TITLE
SH-108 fix: restore case overlay refresh after mark_owned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ logs/
 .windsurfrules
 .github/copilot-instructions.md
 
+# Personal lefthook overrides
+lefthook-local.yml
+scripts/local/
+
 # Mood board reference images (copyrighted material, local only)
 designs/01-prototype/mood-boards/
 

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -38,8 +38,8 @@ func can_be_dragged() -> bool:
 
 
 func mark_owned() -> void:
-	# _refresh_case_overlay runs via item_level_changed after ItemManager.take().
 	_owned = true
+	_refresh_case_overlay()
 
 
 func is_owned() -> bool:

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -37,6 +37,7 @@ func can_be_dragged() -> bool:
 	return can_be_owned()
 
 
+# Explicit refresh: item_level_changed fires in take() before this runs. todo: SH-109.
 func mark_owned() -> void:
 	_owned = true
 	_refresh_case_overlay()

--- a/tests/unit/test_shop_item.gd
+++ b/tests/unit/test_shop_item.gd
@@ -62,6 +62,13 @@ class TestShopItemContract:
 		_item.mark_owned()
 		assert_true(_item.can_be_dragged())
 
+	func test_purchase_hides_case_overlay_and_unfreezes_body() -> void:
+		_item_manager._progression.friendship_point_balance = 1000
+		_item_manager.take(_definition.key)
+		_item.mark_owned()
+		assert_false(_item.case_overlay.visible)
+		assert_false(_item.freeze)
+
 
 class TestShopItemArt:
 	extends GutTest


### PR DESCRIPTION
Purchasing a shop item by dragging it past `ShopArea` was leaving the body frozen mid-air with the display-case cover redrawn over the item. Both symptoms traced to a single missed refresh.

`ItemManager.take()` emits `item_level_changed` synchronously, so `shop_item.gd` receives the signal before `shop.gd` can call `mark_owned()`. At that moment `_owned` is still false and `can_acquire()` already sees the incremented level, so `_refresh_case_overlay()` flips the cover back on and `_refresh_freeze()` pins the RigidBody2D kinematically. `mark_owned()` then set `_owned = true` and returned, leaving the stale overlay and freeze in place.

An earlier review round had dropped a second `_refresh_case_overlay()` call from `mark_owned()` on the grounds that it was redundant with the signal-driven refresh. It is not: the two call sites observe different `_owned` states, and only the post-mark one reflects reality. Restoring that call fixes both the cover and the freeze in one line, since `_refresh_freeze()` runs from the overlay refresh.

Narrower alternatives were considered: deferring the signal emission inside `ItemManager.take()`, or having `shop.gd` flip `_owned` before calling `take()`. Both spread the ordering contract across multiple files, whereas keeping the invariant local to `ShopItem` means any future caller of `mark_owned()` gets correct visual state for free.