### PR TITLE
SH-109 refactor: refactored signal related shenanigans

### DIFF
--- a/scripts/shop/shop.gd
+++ b/scripts/shop/shop.gd
@@ -55,9 +55,7 @@ func _on_body_exited_shop_area(body: Node2D) -> void:
 	var shop_item: ShopItem = body
 	if shop_item.is_owned():
 		return
-	if not _item_manager.take(shop_item.item_definition.key):
-		return
-	shop_item.mark_owned()
+	_item_manager.take(shop_item.item_definition.key)
 
 
 func _update_friendship_label(balance: int) -> void:

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -13,7 +13,6 @@ var _item_manager: Node
 var _art_instance: ItemArt
 var _dragging: bool = false
 var _drag_offset: Vector2 = Vector2.ZERO
-var _owned: bool = false
 var _last_input_frame: int = -1
 
 
@@ -25,26 +24,22 @@ func configure(item_manager: Node, definition: ItemDefinition) -> void:
 
 
 func can_be_owned() -> bool:
-	if _owned or item_definition == null or _item_manager == null:
+	if item_definition == null or _item_manager == null:
 		return false
 	return _item_manager.can_acquire(item_definition.key)
 
 
 ## Pickup permission: owned items stay draggable, unowned must be affordable.
 func can_be_dragged() -> bool:
-	if _owned:
+	if is_owned():
 		return true
 	return can_be_owned()
 
 
-# Explicit refresh: item_level_changed fires in take() before this runs. todo: SH-109.
-func mark_owned() -> void:
-	_owned = true
-	_refresh_case_overlay()
-
-
 func is_owned() -> bool:
-	return _owned
+	if item_definition == null or _item_manager == null:
+		return false
+	return _item_manager.get_level(item_definition.key) > 0
 
 
 func is_dragging() -> bool:
@@ -68,8 +63,7 @@ func _physics_process(_delta: float) -> void:
 	global_position = get_global_mouse_position() + _drag_offset
 
 
-# Release is handled here rather than in _on_input_event so a fast drag that
-# outruns the body's collision shape still delivers mouse-up and ends the drag.
+# Release handled here so a fast drag that outruns collision still ends the drag.
 func _input(event: InputEvent) -> void:
 	if not _dragging:
 		return
@@ -127,8 +121,7 @@ func _on_item_level_changed(item_key: String) -> void:
 func _refresh_case_overlay() -> void:
 	if case_overlay == null:
 		return
-	# Owned items have left the shop's price-gate; case stays off regardless.
-	if _owned:
+	if is_owned():
 		case_overlay.visible = false
 		_refresh_freeze()
 		return
@@ -140,4 +133,4 @@ func _refresh_case_overlay() -> void:
 func _refresh_freeze() -> void:
 	if _dragging:
 		return
-	freeze = not _owned and not can_be_owned()
+	freeze = not is_owned() and not can_be_owned()

--- a/tests/integration/test_shop_drag_drop.gd
+++ b/tests/integration/test_shop_drag_drop.gd
@@ -88,7 +88,7 @@ func test_exiting_shop_area_when_unaffordable_does_not_purchase() -> void:
 
 func test_exiting_shop_area_when_already_owned_does_nothing() -> void:
 	var item: ShopItem = _shop_item("grip_tape")
-	item.mark_owned()
+	_item_manager.take("grip_tape")
 	var balance_before: int = _item_manager.get_friendship_point_balance()
 	await _drag_item_out_of_shop_area(item)
 	assert_eq(_item_manager.get_friendship_point_balance(), balance_before)

--- a/tests/unit/test_shop_item.gd
+++ b/tests/unit/test_shop_item.gd
@@ -37,16 +37,17 @@ class TestShopItemContract:
 		_item_manager.take(_definition.key)
 		assert_false(_item.can_be_owned())
 
-	func test_can_be_owned_returns_false_after_mark_owned() -> void:
+	func test_can_be_owned_returns_false_after_take() -> void:
 		_item_manager._progression.friendship_point_balance = 1000
-		_item.mark_owned()
+		_item_manager.take(_definition.key)
 		assert_false(_item.can_be_owned())
 
 	func test_is_owned_defaults_to_false() -> void:
 		assert_false(_item.is_owned())
 
-	func test_mark_owned_sets_owned_flag() -> void:
-		_item.mark_owned()
+	func test_is_owned_returns_true_after_take() -> void:
+		_item_manager._progression.friendship_point_balance = 1000
+		_item_manager.take(_definition.key)
 		assert_true(_item.is_owned())
 
 	func test_can_be_dragged_mirrors_can_be_owned_when_not_owned() -> void:
@@ -57,15 +58,15 @@ class TestShopItemContract:
 		_item_manager._progression.friendship_point_balance = 0
 		assert_false(_item.can_be_dragged())
 
-	func test_can_be_dragged_returns_true_after_mark_owned_even_when_unaffordable() -> void:
+	func test_can_be_dragged_returns_true_when_owned_even_if_unaffordable() -> void:
+		_item_manager._progression.friendship_point_balance = 1000
+		_item_manager.take(_definition.key)
 		_item_manager._progression.friendship_point_balance = 0
-		_item.mark_owned()
 		assert_true(_item.can_be_dragged())
 
 	func test_purchase_hides_case_overlay_and_unfreezes_body() -> void:
 		_item_manager._progression.friendship_point_balance = 1000
 		_item_manager.take(_definition.key)
-		_item.mark_owned()
 		assert_false(_item.case_overlay.visible)
 		assert_false(_item.freeze)
 


### PR DESCRIPTION
Follow-up to SH-108, which patched a bug by refreshing the case overlay twice inside `ShopItem.mark_owned()`. That patch worked but sat on top of the real smell: `ShopItem._owned` was duplicated state. The source of truth for "is this item owned" is `ItemManager.get_level(key) > 0`, and `ShopItem` kept its own boolean in lockstep via `mark_owned()`. Any listener that ran on `item_level_changed` between `take()` emitting the signal and `shop.gd` calling `mark_owned()` saw an inconsistent world: level bumped, flag still false.

The fix removes the duplicated state. `is_owned()` now reads `_item_manager.get_level(item_definition.key) > 0`, so it cannot disagree with the manager. `mark_owned()` is deleted, and `shop.gd` no longer calls it after `take()`. The signal-driven refresh now reads the same source of truth that `take()` just wrote, so a single refresh renders correctly and no caller-ordering contract is needed.

Considered alternative: deferring the `item_level_changed.emit` inside `ItemManager.take()` with `call_deferred`. That would have fixed the symptom but preserved the underlying duplication, left the ordering trap in place for any other listener (HUD, analytics, achievements, future kit UI), and forced `await` into several existing signal-assert tests. Removing the duplicated field closes the hazard class rather than this one instance of it.

Test changes mirror the API: assertions previously using `mark_owned()` now drive ownership through `_item_manager.take()` (or direct level manipulation where `take()` isn't applicable, e.g. asserting draggability when unaffordable). The SH-108 regression test still passes against the new code path.