### PR TITLE
Feature/sh 106 placeholder nodes for later areas

### DIFF
--- a/scenes/ball_rack.tscn
+++ b/scenes/ball_rack.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3 uid="uid://bxyckxy4cf7r0"]
+
+[node name="BallRack" type="Node2D" unique_id=949376876]
+z_index = 100
+z_as_relative = false
+metadata/_edit_group_ = true
+
+[node name="Marker" type="ColorRect" parent="." unique_id=1349315967]
+offset_right = 300.0
+offset_bottom = 200.0
+mouse_filter = 2
+color = Color(0.9, 0.5, 0.2, 0.6)
+
+[node name="Name" type="Label" parent="." unique_id=968076420]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 10.0
+offset_bottom = 10.0
+theme_override_font_sizes/font_size = 36
+text = "BallRack"

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -5,7 +5,10 @@
 [ext_resource type="Script" uid="uid://glw3v53y7eyu" path="res://scripts/core/court.gd" id="1_tbgi4"]
 [ext_resource type="Script" uid="uid://dpq2mxc834vw4" path="res://scripts/core/autoplay_controller.gd" id="7_tipki"]
 [ext_resource type="Resource" uid="uid://bgop07op1bnc7" path="res://resources/autoplay_config.tres" id="8_85g3d"]
+[ext_resource type="PackedScene" uid="uid://bxyckxy4cf7r0" path="res://scenes/ball_rack.tscn" id="8_h0b8m"]
 [ext_resource type="PackedScene" uid="uid://pglvgky7ryvi" path="res://scenes/player_paddle.tscn" id="9_0tnpc"]
+[ext_resource type="PackedScene" uid="uid://mws700v36gko" path="res://scenes/gear_rack.tscn" id="9_c7axm"]
+[ext_resource type="PackedScene" uid="uid://3l88siilc0hu" path="res://scenes/shipment_mat.tscn" id="10_5mv5b"]
 [ext_resource type="PackedScene" path="res://scenes/miss_zone.tscn" id="10_miss_zone"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_horz"]
@@ -111,62 +114,20 @@ position = Vector2(500, 0)
 [node name="PlayerSpawn" type="Marker2D" parent="." unique_id=1995993314]
 position = Vector2(-500, 0)
 
-[node name="BallRack" type="Node2D" parent="." unique_id=76219608]
+[node name="BallRack" type="Node2D" parent="." unique_id=949376876 instance=ExtResource("8_h0b8m")]
 z_index = 100
 z_as_relative = false
 position = Vector2(-1065, 0)
 metadata/_edit_group_ = true
 
-[node name="Marker" type="ColorRect" parent="BallRack" unique_id=1282644591]
-offset_right = 300.0
-offset_bottom = 200.0
-mouse_filter = 2
-color = Color(0.9, 0.5, 0.2, 0.6)
-
-[node name="Name" type="Label" parent="BallRack" unique_id=113811230]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 157.0
-offset_bottom = 60.0
-theme_override_font_sizes/font_size = 36
-text = "BallRack"
-
-[node name="GearRack" type="Node2D" parent="." unique_id=1094395299]
+[node name="GearRack" type="Node2D" parent="." unique_id=445509089 instance=ExtResource("9_c7axm")]
 z_index = 100
 z_as_relative = false
 position = Vector2(760, 0)
 metadata/_edit_group_ = true
 
-[node name="Marker" type="ColorRect" parent="GearRack" unique_id=1976222616]
-offset_right = 300.0
-offset_bottom = 200.0
-mouse_filter = 2
-color = Color(0.3, 0.5, 0.9, 0.6)
-
-[node name="Name" type="Label" parent="GearRack" unique_id=958211432]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 176.0
-offset_bottom = 60.0
-theme_override_font_sizes/font_size = 36
-text = "GearRack"
-
-[node name="ShipmentMat" type="Node2D" parent="." unique_id=2113871279]
+[node name="ShipmentMat" type="Node2D" parent="." unique_id=530264883 instance=ExtResource("10_5mv5b")]
 z_index = 100
 z_as_relative = false
 position = Vector2(760, 438)
 metadata/_edit_group_ = true
-
-[node name="Marker" type="ColorRect" parent="ShipmentMat" unique_id=707478382]
-offset_right = 400.0
-offset_bottom = 150.0
-mouse_filter = 2
-color = Color(0.6, 0.4, 0.25, 0.6)
-
-[node name="Name" type="Label" parent="ShipmentMat" unique_id=1119738064]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 246.0
-offset_bottom = 60.0
-theme_override_font_sizes/font_size = 36
-text = "ShipmentMat"

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -110,3 +110,63 @@ position = Vector2(500, 0)
 
 [node name="PlayerSpawn" type="Marker2D" parent="." unique_id=1995993314]
 position = Vector2(-500, 0)
+
+[node name="BallRack" type="Node2D" parent="." unique_id=76219608]
+z_index = 100
+z_as_relative = false
+position = Vector2(-1065, 0)
+metadata/_edit_group_ = true
+
+[node name="Marker" type="ColorRect" parent="BallRack" unique_id=1282644591]
+offset_right = 300.0
+offset_bottom = 200.0
+mouse_filter = 2
+color = Color(0.9, 0.5, 0.2, 0.6)
+
+[node name="Name" type="Label" parent="BallRack" unique_id=113811230]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 157.0
+offset_bottom = 60.0
+theme_override_font_sizes/font_size = 36
+text = "BallRack"
+
+[node name="GearRack" type="Node2D" parent="." unique_id=1094395299]
+z_index = 100
+z_as_relative = false
+position = Vector2(760, 0)
+metadata/_edit_group_ = true
+
+[node name="Marker" type="ColorRect" parent="GearRack" unique_id=1976222616]
+offset_right = 300.0
+offset_bottom = 200.0
+mouse_filter = 2
+color = Color(0.3, 0.5, 0.9, 0.6)
+
+[node name="Name" type="Label" parent="GearRack" unique_id=958211432]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 176.0
+offset_bottom = 60.0
+theme_override_font_sizes/font_size = 36
+text = "GearRack"
+
+[node name="ShipmentMat" type="Node2D" parent="." unique_id=2113871279]
+z_index = 100
+z_as_relative = false
+position = Vector2(760, 438)
+metadata/_edit_group_ = true
+
+[node name="Marker" type="ColorRect" parent="ShipmentMat" unique_id=707478382]
+offset_right = 400.0
+offset_bottom = 150.0
+mouse_filter = 2
+color = Color(0.6, 0.4, 0.25, 0.6)
+
+[node name="Name" type="Label" parent="ShipmentMat" unique_id=1119738064]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 246.0
+offset_bottom = 60.0
+theme_override_font_sizes/font_size = 36
+text = "ShipmentMat"

--- a/scenes/gear_rack.tscn
+++ b/scenes/gear_rack.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3 uid="uid://mws700v36gko"]
+
+[node name="GearRack" type="Node2D" unique_id=445509089]
+z_index = 100
+z_as_relative = false
+metadata/_edit_group_ = true
+
+[node name="Marker" type="ColorRect" parent="." unique_id=1470078387]
+offset_right = 300.0
+offset_bottom = 200.0
+mouse_filter = 2
+color = Color(0.3, 0.5, 0.9, 0.6)
+
+[node name="Name" type="Label" parent="." unique_id=1742093710]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 10.0
+offset_bottom = 10.0
+theme_override_font_sizes/font_size = 36
+text = "GearRack"

--- a/scenes/shipment_mat.tscn
+++ b/scenes/shipment_mat.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3 uid="uid://3l88siilc0hu"]
+
+[node name="ShipmentMat" type="Node2D" unique_id=530264883]
+z_index = 100
+z_as_relative = false
+metadata/_edit_group_ = true
+
+[node name="Marker" type="ColorRect" parent="." unique_id=1427717404]
+offset_right = 400.0
+offset_bottom = 150.0
+mouse_filter = 2
+color = Color(0.6, 0.4, 0.25, 0.6)
+
+[node name="Name" type="Label" parent="." unique_id=1599350400]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 10.0
+offset_bottom = 10.0
+theme_override_font_sizes/font_size = 36
+text = "ShipmentMat"

--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -27,8 +27,10 @@ scale = Vector2(0.6, 0.6)
 
 [node name="Hud" parent="." unique_id=720275437 instance=ExtResource("4_hud")]
 
-[node name="Camera" type="Camera2D" parent="." unique_id=1084046387]
+[node name="Camera" type="Camera2D" parent="." unique_id=1084046387 node_paths=PackedStringArray("left_anchor", "right_anchor")]
 script = ExtResource("5_wttuf")
+left_anchor = NodePath("../Workshop")
+right_anchor = NodePath("../Shop")
 
 [node name="VenueFloor" type="StaticBody2D" parent="." unique_id=984529763]
 position = Vector2(0, 410)
@@ -46,3 +48,23 @@ color = Color(0.15, 0.1, 0.08, 1)
 
 [node name="Shop" parent="." unique_id=1688593906 instance=ExtResource("3_shop")]
 position = Vector2(1500, 3.13)
+
+[node name="Workshop" type="Node2D" parent="." unique_id=348325752]
+z_index = 100
+z_as_relative = false
+position = Vector2(-1500, 0)
+metadata/_edit_group_ = true
+
+[node name="Marker" type="ColorRect" parent="Workshop" unique_id=264609764]
+offset_right = 500.0
+offset_bottom = 400.0
+mouse_filter = 2
+color = Color(0.6, 0.3, 0.8, 0.6)
+
+[node name="Name" type="Label" parent="Workshop" unique_id=1317991923]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 187.0
+offset_bottom = 60.0
+theme_override_font_sizes/font_size = 36
+text = "Workshop"

--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://hvh6q02lrntj" path="res://scenes/shop.tscn" id="3_shop"]
 [ext_resource type="PackedScene" uid="uid://dumhl1skwhd7q" path="res://scenes/hud.tscn" id="4_hud"]
 [ext_resource type="Script" uid="uid://s5unp15ypwlr" path="res://scripts/core/venue_camera.gd" id="5_wttuf"]
+[ext_resource type="PackedScene" uid="uid://dnx2do12mtfyp" path="res://scenes/workshop.tscn" id="6_s1xkn"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_floor"]
 size = Vector2(4000, 40)
@@ -49,22 +50,8 @@ color = Color(0.15, 0.1, 0.08, 1)
 [node name="Shop" parent="." unique_id=1688593906 instance=ExtResource("3_shop")]
 position = Vector2(1500, 3.13)
 
-[node name="Workshop" type="Node2D" parent="." unique_id=348325752]
+[node name="Workshop" type="Node2D" parent="." unique_id=1830461434 instance=ExtResource("6_s1xkn")]
 z_index = 100
 z_as_relative = false
 position = Vector2(-1500, 0)
 metadata/_edit_group_ = true
-
-[node name="Marker" type="ColorRect" parent="Workshop" unique_id=264609764]
-offset_right = 500.0
-offset_bottom = 400.0
-mouse_filter = 2
-color = Color(0.6, 0.3, 0.8, 0.6)
-
-[node name="Name" type="Label" parent="Workshop" unique_id=1317991923]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 187.0
-offset_bottom = 60.0
-theme_override_font_sizes/font_size = 36
-text = "Workshop"

--- a/scenes/workshop.tscn
+++ b/scenes/workshop.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3 uid="uid://dnx2do12mtfyp"]
+
+[node name="Workshop" type="Node2D" unique_id=1830461434]
+z_index = 100
+z_as_relative = false
+metadata/_edit_group_ = true
+
+[node name="Marker" type="ColorRect" parent="." unique_id=1882650834]
+offset_right = 500.0
+offset_bottom = 400.0
+mouse_filter = 2
+color = Color(0.6, 0.3, 0.8, 0.6)
+
+[node name="Name" type="Label" parent="." unique_id=258133050]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 10.0
+offset_bottom = 10.0
+theme_override_font_sizes/font_size = 36
+text = "Workshop"

--- a/scripts/core/venue_camera.gd
+++ b/scripts/core/venue_camera.gd
@@ -6,6 +6,11 @@ extends Camera2D
 @export var right_anchor: Node2D
 
 
+func _ready() -> void:
+	# Clamp math assumes the camera centres its frame on position.
+	assert(anchor_mode == ANCHOR_MODE_DRAG_CENTER)
+
+
 func _process(delta: float) -> void:
 	var direction: float = Input.get_axis(&"camera_left", &"camera_right")
 	if direction != 0.0:

--- a/scripts/core/venue_camera.gd
+++ b/scripts/core/venue_camera.gd
@@ -9,11 +9,16 @@ extends Camera2D
 func _process(delta: float) -> void:
 	var direction: float = Input.get_axis(&"camera_left", &"camera_right")
 	if direction != 0.0:
-		position.x += direction * pan_speed * delta
+		global_position.x += direction * pan_speed * delta
 	_clamp_to_anchors()
 
 
 func _clamp_to_anchors() -> void:
 	if left_anchor == null or right_anchor == null:
 		return
-	position.x = clamp(position.x, left_anchor.global_position.x, right_anchor.global_position.x)
+	var half_width: float = get_viewport_rect().size.x * 0.5 / zoom.x
+	var left_edge: float = left_anchor.global_position.x + half_width
+	var right_edge: float = right_anchor.global_position.x - half_width
+	var clamp_min: float = min(left_edge, right_edge)
+	var clamp_max: float = max(left_edge, right_edge)
+	global_position.x = clamp(global_position.x, clamp_min, clamp_max)

--- a/scripts/core/venue_camera.gd
+++ b/scripts/core/venue_camera.gd
@@ -1,12 +1,19 @@
 class_name VenueCamera
 extends Camera2D
 
-# todo: sh-106 clamp to venue bounds once shop and workshop placeholders exist.
-
 @export var pan_speed: float = 800.0
+@export var left_anchor: Node2D
+@export var right_anchor: Node2D
 
 
 func _process(delta: float) -> void:
 	var direction: float = Input.get_axis(&"camera_left", &"camera_right")
 	if direction != 0.0:
 		position.x += direction * pan_speed * delta
+	_clamp_to_anchors()
+
+
+func _clamp_to_anchors() -> void:
+	if left_anchor == null or right_anchor == null:
+		return
+	position.x = clamp(position.x, left_anchor.global_position.x, right_anchor.global_position.x)

--- a/tests/unit/test_save_manager.gd
+++ b/tests/unit/test_save_manager.gd
@@ -59,7 +59,7 @@ func test_clear_save_writes_cleared_state() -> void:
 func test_save_is_noop_after_clear_save_until_unblocked() -> void:
 	_save_manager.clear_save()
 	_save_manager.save()
-	assert_call_count(_mock_storage, "write", 1)
+	assert_called_count(_mock_storage.write, 1)
 
 
 # clear_save writes once, then unblock + save writes a second time.
@@ -67,7 +67,7 @@ func test_unblock_writes_resumes_saves() -> void:
 	_save_manager.clear_save()
 	_save_manager.unblock_writes()
 	_save_manager.save()
-	assert_call_count(_mock_storage, "write", 2)
+	assert_called_count(_mock_storage.write, 2)
 
 
 func test_clear_save_stops_autosave_timer() -> void:
@@ -86,4 +86,4 @@ func test_unblock_writes_restarts_autosave_timer() -> void:
 func test_autosave_timeout_while_blocked_does_not_write() -> void:
 	_save_manager.clear_save()
 	_save_manager._autosave_timer.timeout.emit()
-	assert_call_count(_mock_storage, "write", 1)
+	assert_called_count(_mock_storage.write, 1)

--- a/tests/unit/test_venue_camera.gd
+++ b/tests/unit/test_venue_camera.gd
@@ -3,6 +3,10 @@ extends GutTest
 # Verifies camera pans along x in response to camera_left/camera_right input.
 
 const VenueCameraScene := preload("res://scripts/core/venue_camera.gd")
+const LEFT_ANCHOR_X: float = -1500.0
+const RIGHT_ANCHOR_X: float = 1500.0
+const FAR_OUTSIDE_X: float = 9999.0
+const FLOAT_TOLERANCE: float = 0.001
 
 var _camera: VenueCamera
 
@@ -57,3 +61,68 @@ func test_opposing_inputs_cancel_out() -> void:
 	var start_x: float = _camera.position.x
 	_camera._process(0.1)
 	assert_eq(_camera.position.x, start_x)
+
+
+# --- clamp to anchors ---
+func _make_anchor(x: float) -> Node2D:
+	var anchor := Node2D.new()
+	anchor.position = Vector2(x, 0.0)
+	add_child_autofree(anchor)
+	return anchor
+
+
+func _set_bounds(left_x: float, right_x: float) -> void:
+	_camera.left_anchor = _make_anchor(left_x)
+	_camera.right_anchor = _make_anchor(right_x)
+
+
+func _is_visible(anchor: Node2D) -> bool:
+	var half_view: float = _camera.get_viewport_rect().size.x * 0.5 / _camera.zoom.x
+	var distance_from_centre: float = abs(anchor.global_position.x - _camera.global_position.x)
+	return distance_from_centre <= half_view + FLOAT_TOLERANCE
+
+
+func _pan_until_stopped(action: StringName) -> void:
+	Input.action_press(action)
+	var previous: float = _camera.global_position.x
+	for _i in 50:
+		_camera._process(1.0)
+		if is_equal_approx(_camera.global_position.x, previous):
+			return
+		previous = _camera.global_position.x
+
+
+func test_left_anchor_stays_visible_no_matter_how_far_you_pan_left() -> void:
+	_set_bounds(LEFT_ANCHOR_X, RIGHT_ANCHOR_X)
+	_pan_until_stopped(&"camera_left")
+	assert_true(_is_visible(_camera.left_anchor))
+
+
+func test_right_anchor_stays_visible_no_matter_how_far_you_pan_right() -> void:
+	_set_bounds(LEFT_ANCHOR_X, RIGHT_ANCHOR_X)
+	_pan_until_stopped(&"camera_right")
+	assert_true(_is_visible(_camera.right_anchor))
+
+
+func test_panning_left_eventually_stops() -> void:
+	_set_bounds(LEFT_ANCHOR_X, RIGHT_ANCHOR_X)
+	Input.action_press(&"camera_left")
+	_pan_until_stopped(&"camera_left")
+	var resting_x: float = _camera.global_position.x
+	_camera._process(1.0)
+	assert_almost_eq(_camera.global_position.x, resting_x, FLOAT_TOLERANCE)
+
+
+func test_clamp_is_noop_without_anchors() -> void:
+	_camera.global_position.x = FAR_OUTSIDE_X
+	_camera._process(0.0)
+	assert_eq(_camera.global_position.x, FAR_OUTSIDE_X)
+
+
+func test_clamp_still_bounds_motion_when_anchors_are_swapped() -> void:
+	# Swapped anchors are a misconfiguration, not a crash; the clamp should still
+	# prevent the camera from flying out to an arbitrary far position.
+	_set_bounds(RIGHT_ANCHOR_X, LEFT_ANCHOR_X)
+	_camera.global_position.x = FAR_OUTSIDE_X
+	_camera._process(0.0)
+	assert_lt(abs(_camera.global_position.x), FAR_OUTSIDE_X)

--- a/tests/unit/test_venue_camera.gd
+++ b/tests/unit/test_venue_camera.gd
@@ -119,10 +119,12 @@ func test_clamp_is_noop_without_anchors() -> void:
 	assert_eq(_camera.global_position.x, FAR_OUTSIDE_X)
 
 
-func test_clamp_still_bounds_motion_when_anchors_are_swapped() -> void:
+func test_clamp_reaches_a_stable_resting_position_when_anchors_are_swapped() -> void:
 	# Swapped anchors are a misconfiguration, not a crash; the clamp should still
-	# prevent the camera from flying out to an arbitrary far position.
+	# settle at a stable position rather than drifting or flying out.
 	_set_bounds(RIGHT_ANCHOR_X, LEFT_ANCHOR_X)
 	_camera.global_position.x = FAR_OUTSIDE_X
 	_camera._process(0.0)
-	assert_lt(abs(_camera.global_position.x), FAR_OUTSIDE_X)
+	var resting_x: float = _camera.global_position.x
+	_camera._process(0.0)
+	assert_eq(_camera.global_position.x, resting_x)


### PR DESCRIPTION
Reserves the named hooks that later projects need to slot into — ball rack, gear rack, shipment mat, and the workshop — so those features can land without a venue relayout or a rename chain.

The three court-adjacent ones (BallRack, GearRack, ShipmentMat) live in `court.tscn` as court fixtures. Workshop lives in `venue.tscn` alongside Shop, since it's a distinct diorama region that unlocks separately. Each placeholder anchors at its top-left so real content can lay out from (0,0), and each carries a translucent ColorRect + label so they're visible in the diorama today. `_edit_group_` is set on each so the 2D editor treats the placeholder as a single selectable unit.

The venue camera now clamps its pan range to Workshop and Shop (exported `Node2D` anchors), resolving the SH-105 TODO about venue bounds. Anchors are unset in tests so the pan behaviour stays unchanged for the existing `test_venue_camera` suite.

Incidental cleanup: three `assert_call_count` calls in `test_save_manager.gd` were using a deprecated form; migrated to `assert_called_count(Callable, count)` to keep the ggut output noise-free.