### PR TITLE
docs: updated court docs based on new impl

### DIFF
--- a/designs/01-prototype/08-kit.md
+++ b/designs/01-prototype/08-kit.md
@@ -8,7 +8,7 @@ The kit is every item the player owns. This doc covers where inactive items sit,
 
 ## Storage for inactive items
 
-Two areas sit as siblings at the player's end of `venue.tscn`. Each is both the parent for its items at rest and the drop target for deactivation.
+Two areas sit at the player's end of the court, as children of `court.tscn`. Each is both the parent for its items at rest and the drop target for deactivation.
 
 - **BallRack**: inactive ball items. The court's ball manager reads from here.
 - **GearRack**: inactive equipment. Items here are dragged onto the main character to equip.
@@ -109,6 +109,6 @@ Kit-driven `add_friendship_points` skips autosave; a 30-second timer flushes. Us
 
 Not filing yet.
 
-1. `BallRack` and `GearRack` in `venue.tscn`; drag targets wired per role.
+1. `BallRack` and `GearRack` in `court.tscn`; drag targets wired per role.
 2. Timeout gesture: main character walks off on timeout call, back on at timeout end.
 3. Passive FP (cadence, formula, offline catch-up, save throttling).

--- a/designs/01-prototype/08-shipments.md
+++ b/designs/01-prototype/08-shipments.md
@@ -29,7 +29,7 @@ Wall-clock timing: shipments tick while the game is closed. On resume, any shipm
 
 ## Arrival
 
-The box lands on the `ShipmentMat` in `venue.tscn`. The friend walks in from the shop, sets the box down, returns. Prototype uses a placeholder animation.
+The box lands on the `ShipmentMat` in `court.tscn`. The friend walks in from the shop, sets the box down, returns. Prototype uses a placeholder animation.
 
 These items come from offshore: they are expensive and unique, and the wait reflects real shipping time. The timer runs both while the game is open and while it is closed, just like reality. Per-order timing can vary (a local supplier vs. an overseas specialist).
 

--- a/designs/01-prototype/08-venue.md
+++ b/designs/01-prototype/08-venue.md
@@ -15,10 +15,10 @@ venue.tscn
 ├── Court                      (play area; paddles, ball, walls)
 │   ├── VolleyCounter          (diegetic scoreboard on the court)
 │   ├── PersonalBest           (diegetic plaque on the court)
-│   └── FriendshipPoints       (diegetic counter on the court)
-├── BallRack                   (inactive balls; see 08-kit.md)
-├── GearRack                   (inactive equipment; see 08-kit.md)
-├── ShipmentMat                (where boxes land; see 08-shipments.md)
+│   ├── FriendshipPoints       (diegetic counter on the court)
+│   ├── BallRack               (inactive balls; see 08-kit.md)
+│   ├── GearRack               (inactive equipment; see 08-kit.md)
+│   └── ShipmentMat            (where boxes land; see 08-shipments.md)
 ├── Shop                       (see 08-shop.md; hidden until friend unlocked)
 │   ├── FriendCharacter
 │   ├── ShopTable


### PR DESCRIPTION
Follow-up to SH-106. The implementation decided that BallRack, GearRack, and ShipmentMat belong inside `court.tscn` as court fixtures rather than venue-level siblings, while Workshop stays at the venue level next to Shop. The prototype docs still described the old flat layout, so they drifted from what the scene tree actually looks like.

Updates the three design notes that referenced the old structure: `08-venue.md`'s venue-scene tree now nests the three racks under Court, and `08-kit.md` plus `08-shipments.md` point at `court.tscn` rather than `venue.tscn` for the rack and shipment mat locations. Workshop and Shop references are unchanged because those are still accurate.

No code or behaviour changes here; the scene split itself shipped with SH-106.