### PR TITLE
SH-110 fix: added camera edge markers so camera can be properly clamped

### DIFF
--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -30,8 +30,8 @@ scale = Vector2(0.6, 0.6)
 
 [node name="Camera" type="Camera2D" parent="." unique_id=1084046387 node_paths=PackedStringArray("left_anchor", "right_anchor")]
 script = ExtResource("5_wttuf")
-left_anchor = NodePath("../Workshop")
-right_anchor = NodePath("../Shop")
+left_anchor = NodePath("../LeftEdge")
+right_anchor = NodePath("../RightEdge")
 
 [node name="VenueFloor" type="StaticBody2D" parent="." unique_id=984529763]
 position = Vector2(0, 410)
@@ -50,8 +50,11 @@ color = Color(0.15, 0.1, 0.08, 1)
 [node name="Shop" parent="." unique_id=1688593906 instance=ExtResource("3_shop")]
 position = Vector2(1500, 3.13)
 
-[node name="Workshop" type="Node2D" parent="." unique_id=1830461434 instance=ExtResource("6_s1xkn")]
-z_index = 100
-z_as_relative = false
+[node name="Workshop" parent="." unique_id=1830461434 instance=ExtResource("6_s1xkn")]
 position = Vector2(-1500, 0)
-metadata/_edit_group_ = true
+
+[node name="LeftEdge" type="Marker2D" parent="." unique_id=679568217]
+position = Vector2(-1700, 0)
+
+[node name="RightEdge" type="Marker2D" parent="." unique_id=858790739]
+position = Vector2(1920, 0)


### PR DESCRIPTION
The venue camera was clamped to the Workshop and Shop origin positions, which meant any visual that extended past those nodes (notably the Shop table on the right) fell outside the pannable range. That also tied the camera's framing to the placement of two gameplay nodes: moving the Shop or Workshop would silently change how wide the camera could see.

This PR introduces dedicated `LeftEdge` and `RightEdge` `Marker2D` nodes in the venue scene and repoints the camera at those. The clamp math in `venue_camera.gd` is unchanged, since it already treats its anchors as the outermost visible points. The edge markers are pure positional structure, giving the scene an explicit statement of the camera's horizontal range that layout work on other nodes cannot accidentally disturb.

`LeftEdge` sits at x=-1700 and `RightEdge` at x=1920. Both extend the visible range past the current Workshop and Shop placeholder visuals with headroom for real content to land in either area without immediately re-tuning the clamp. They move independently of the Workshop and Shop nodes themselves.

Also folds in a small editor-driven cleanup on the Workshop instance: redundant `z_index`, `z_as_relative`, and `metadata/_edit_group_` overrides that duplicated values already declared in `workshop.tscn`. Behaviour is identical; the fields just stop being restated at the instance site.

Closes SH-110.