### PR TITLE
chore: bump GodotIQ addon to 0.5.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,3 +184,4 @@ So that [benefit or reason]
 - API key: `$LINEAR_API_KEY`. Endpoint: `https://api.linear.app/graphql`.
 - **All new tickets** → Status: **Backlog** (`d41fb73e-32af-40b2-a7e5-5052900ab0fc`). Label: **Feature** (`b19a1a7b-af6b-4897-a52f-eb2e2e07083e`). Do NOT assign to a cycle. Do NOT use Triage — that is for external/incoming tickets only. Josh promotes tickets to Ready and adds them to cycles himself.
 - **Assign tech/design tickets to Josh Hartley** (`19ea3ec5-a428-44f7-b085-a10fd3dd2cef`).
+

--- a/addons/godotiq/godotiq_server.gd
+++ b/addons/godotiq/godotiq_server.gd
@@ -4,7 +4,7 @@ extends Node
 ## dispatches requests to editor handlers or forwards to the running game.
 
 const DEFAULT_PORT := 6007
-const ADDON_VERSION := "0.5.0"
+const ADDON_VERSION := "0.5.1"
 const SCREENSHOT_TIMEOUT_MS := 30000
 const PERF_TIMEOUT_MS := 5000
 const INPUT_TIMEOUT_MS := 65000

--- a/addons/godotiq/plugin.cfg
+++ b/addons/godotiq/plugin.cfg
@@ -3,5 +3,5 @@
 name="GodotIQ"
 description="AI-assisted Godot development via MCP bridge"
 author="Salvatore Farruggio"
-version="0.5.0"
+version="0.5.1"
 script="godotiq_plugin.gd"


### PR DESCRIPTION
Routine addon bump. `godotiq install-addon` refreshed the in-repo plugin from the upstream 0.5.1 release, which touches `godotiq_server.gd` and the `plugin.cfg` version. Paired with a local `uv tool upgrade godotiq` on the MCP server side so the editor bridge and the tool binary stay on matching versions.

The CLAUDE.md bump is just a trailing newline the installer re-adds — kept in this PR rather than carried as a dirty working tree.

No gameplay or scene changes; the addon reload was exercised by disabling and re-enabling the plugin in-editor.