### PR TITLE
chore: require pre-PR merge-main sync in PARALLEL workflow

### DIFF
--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -8,8 +8,9 @@ Live scratchpad for parallel agent work on individual Linear tickets. One agent 
 
 1. **Claim a ticket.** Branch first (`git checkout -b sh-XX-...`), then add a row to the Active table with agent name, ticket ID, branch, and start timestamp. Commit the claim on the branch so it ships with the PR, not on main.
 2. **Log progress.** Append one line per meaningful step to the Activity Log at the bottom. Keep it terse: `[SH-XX] <agent>: <what happened>`.
-3. **Finish.** Move the row from Active to Done, note the commit SHA and PR number. After `gh pr create`, dispatch a code-reviewer sub-agent against the PR, apply every suggested fix as commits on the PR branch, push, then report. Don't wait for human approval of the auto-fixes; Josh reviews after.
-4. **Block or spin.** If you loop on the same issue twice, escalate to Josh immediately (see Escalation). Do not try a third variant silently.
+3. **Sync before opening.** Before `gh pr create`, `git fetch origin main && git merge origin/main` into your branch. Resolve any conflicts, re-run `ggut`, push. This catches conflicts locally where you can fix them, instead of surfacing them in the PR view for Josh to chase.
+4. **Finish.** Move the row from Active to Done, note the commit SHA and PR number. After `gh pr create`, dispatch a code-reviewer sub-agent against the PR, apply every suggested fix as commits on the PR branch, push, then report. Don't wait for human approval of the auto-fixes; Josh reviews after.
+5. **Block or spin.** If you loop on the same issue twice, escalate to Josh immediately (see Escalation). Do not try a third variant silently.
 
 ---
 


### PR DESCRIPTION
SH-52 hit a merge conflict on PR view because the branch had been opened before `chore/ai-coordination-folder` landed on main, and the overlap on `ai/PARALLEL.md` wasn't surfaced until GitHub ran the merge. Conflicts found in the PR view cost a round-trip; conflicts found locally cost one `ggut` run.

Adds a new step between "Log progress" and "Finish" in `ai/PARALLEL.md` that requires fetching main and merging it into the feature branch before `gh pr create`. Agents now resolve conflicts on their own machine, re-run tests, and push once — so the PR opens clean.

Also renumbers the trailing "Block or spin" step to keep the list consistent.