### PR TITLE
chore: add optional follow-up review rule (comment-only)

### DIFF
--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -12,6 +12,8 @@ Live scratchpad for parallel agent work on individual Linear tickets. One agent 
 4. **Finish.** Move the row from Active to Done, note the commit SHA and PR number. After `gh pr create`, dispatch a code-reviewer sub-agent against the PR, apply every suggested fix as commits on the PR branch, push, then report. Don't wait for human approval of the auto-fixes; Josh reviews after.
 5. **Block or spin.** If you loop on the same issue twice, escalate to Josh immediately (see Escalation). Do not try a third variant silently.
 
+**Optional: follow-up review.** If Josh asks for another review on an existing PR, dispatch a fresh code-reviewer and post its findings as a PR comment using `gh pr comment <N> --body "..."`. Do **not** auto-apply fixes; Josh may respond inline or mark comments resolved. Initial review fixes still auto-commit per step 4; only follow-up reviews are comment-only.
+
 ---
 
 ## Ground rules


### PR DESCRIPTION
Adds a short rule after the numbered list in PARALLEL.md for a case the workflow didn't cover: when Josh asks for a second pass on an existing PR, the reviewer's output should land as a PR comment rather than as commits. Josh may then reply inline or mark the comment resolved, which is the shape he wants for iterative feedback; auto-applying a follow-up review would overwrite the first human pass he just did.

The initial post-creation review (step 4) still auto-commits fixes as before.