### PR TITLE
chore: route reviewer judgment calls to PR comments

### DIFF
--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -9,7 +9,10 @@ Live scratchpad for parallel agent work on individual Linear tickets. One agent 
 1. **Claim a ticket.** Branch first (`git checkout -b sh-XX-...`), then add a row to the Active table with agent name, ticket ID, branch, and start timestamp. Commit the claim on the branch so it ships with the PR, not on main.
 2. **Log progress.** Append one line per meaningful step to the Activity Log at the bottom. Keep it terse: `[SH-XX] <agent>: <what happened>`.
 3. **Sync before opening, and sync again before any later push.** Before `gh pr create`, run `git fetch origin main && git merge origin/main` into your branch, resolve conflicts, re-run `ggut`, then push. After the PR exists, do the same check whenever you resume work, after a reviewer asks for changes, and before Josh is asked to merge: other PRs may have landed on main and made this branch stale. `git rev-list --count HEAD..origin/main` gives you the "behind by N" count; zero means you're up to date. This catches conflicts locally instead of surfacing them in the PR view for Josh to chase.
-4. **Finish.** Move the row from Active to Done, note the commit SHA and PR number. After `gh pr create`, dispatch a code-reviewer sub-agent against the PR, apply every suggested fix as commits on the PR branch, push.
+4. **Finish.** Move the row from Active to Done, note the commit SHA and PR number. After `gh pr create`, dispatch a code-reviewer sub-agent against the PR. Split the findings:
+   - **Mechanical fixes** (typos, dead code, obvious bugs, style violations, missing null checks): apply as commits on the PR branch and push.
+   - **Judgment calls** (design tradeoffs, naming debates, architectural suggestions): post as a single formatted list in one PR comment via `gh pr comment <N> --body "..."`.
+   Hand off to Josh only after both have landed. Do not flag judgment items in chat; the PR view is the single source of truth.
 5. **Re-sync before handoff.** Before reporting the PR to Josh for merge, run `git rev-list --count HEAD..origin/main`. If non-zero, merge `origin/main` in, re-run `ggut`, push. Then report. Don't wait for human approval of the auto-fixes; Josh reviews after.
 6. **Block or spin.** If you loop on the same issue twice, escalate to Josh immediately (see Escalation). Do not try a third variant silently.
 

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -11,12 +11,20 @@ Live scratchpad for parallel agent work on individual Linear tickets. One agent 
 3. **Sync before opening, and sync again before any later push.** Before `gh pr create`, run `git fetch origin main && git merge origin/main` into your branch, resolve conflicts, re-run `ggut`, then push. After the PR exists, do the same check whenever you resume work, after a reviewer asks for changes, and before Josh is asked to merge: other PRs may have landed on main and made this branch stale. `git rev-list --count HEAD..origin/main` gives you the "behind by N" count; zero means you're up to date. This catches conflicts locally instead of surfacing them in the PR view for Josh to chase.
 4. **Finish.** Move the row from Active to Done, note the commit SHA and PR number. After `gh pr create`, dispatch a code-reviewer sub-agent against the PR. Split the findings:
    - **Mechanical fixes** (typos, dead code, obvious bugs, style violations, missing null checks): apply as commits on the PR branch and push.
-   - **Judgment calls** (design tradeoffs, naming debates, architectural suggestions): post as a single formatted list in one PR comment via `gh pr comment <N> --body "..."`.
+   - **Judgment calls** (design tradeoffs, naming debates, architectural suggestions): post each as a line-anchored review comment so Josh can mark them Resolved in the Files changed tab. If there are zero judgment calls, post nothing and hand off silently. Template:
+     ```
+     gh api -X POST repos/J-Melon/volley-vendetta/pulls/<N>/comments \
+       -f body="..." \
+       -f commit_id="<sha of your latest push>" \
+       -f path="<file>" \
+       -F line=<line> \
+       -f side=RIGHT
+     ```
    Hand off to Josh only after both have landed. Do not flag judgment items in chat; the PR view is the single source of truth.
 5. **Re-sync before handoff.** Before reporting the PR to Josh for merge, run `git rev-list --count HEAD..origin/main`. If non-zero, merge `origin/main` in, re-run `ggut`, push. Then report. Don't wait for human approval of the auto-fixes; Josh reviews after.
 6. **Block or spin.** If you loop on the same issue twice, escalate to Josh immediately (see Escalation). Do not try a third variant silently.
 
-**Optional: follow-up review.** If Josh asks for another review on an existing PR, dispatch a fresh code-reviewer and post its findings as a PR comment using `gh pr comment <N> --body "..."`. Do **not** auto-apply fixes; Josh may respond inline or mark comments resolved. Initial review fixes still auto-commit per step 4; only follow-up reviews are comment-only.
+**Optional: follow-up review.** If Josh asks for another review on an existing PR, dispatch a fresh code-reviewer and post each finding as a line-anchored review comment using the `gh api .../pulls/<N>/comments` template above. If the reviewer returns nothing, post nothing. Do **not** auto-apply fixes; Josh may respond inline or mark comments resolved. Initial review fixes still auto-commit per step 4; only follow-up reviews are comment-only.
 
 ---
 


### PR DESCRIPTION
The parallel workflow already splits review into two passes: an automatic one after `gh pr create`, and an optional follow-up when Josh asks for another look. The follow-up rule lives at the bottom of step 4 and already routes its findings to PR comments. The initial pass, though, used to funnel everything through commits and then expected the agent to raise judgment items separately in chat, which fragmented the review trail.

This change codifies the split on the first pass too. Mechanical fixes keep their current path as commits on the branch. Judgment calls go into one formatted PR comment via `gh pr comment <N>`. Handoff to Josh waits on both. The PR view becomes the single place where open review items live, and chat stops carrying review state that the PR should own.