### PR TITLE
SH-143: run tests on every PR so required check always reports

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -71,8 +71,12 @@ jobs:
             # one dirty PR never blocks the sweep for the rest.
             if gh pr update-branch "$PR"; then
               echo "PR #${PR} updated."
+              # Clear the conflict label if it was applied previously; the branch
+              # is now clean against main.
+              gh pr edit "$PR" --remove-label has-conflicts 2>/dev/null || true
             else
-              echo "::warning::PR #${PR} could not be auto-updated (likely merge conflict or protected state); leaving it for the author."
+              echo "::warning::PR #${PR} could not be auto-updated (likely merge conflict); labelling has-conflicts."
+              gh pr edit "$PR" --add-label has-conflicts 2>/dev/null || true
             fi
 
             echo "::endgroup::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "designs/**"
-      - "docs/**"
-      - "**/*.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
 
 concurrency:
   group: tests-${{ github.ref }}


### PR DESCRIPTION
Drops `paths-ignore` from test.yml. Branch protection requires `Run Tests` to pass, so doc-only PRs were sitting in Expected Waiting state indefinitely. Running tests on every PR costs ~30s thanks to the existing Godot + import caches.