### PR TITLE
SH-144: pin Dependabot labels and disable auto-rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       - J-Melon
     reviewers:
       - J-Melon
+    labels:
+      - dependencies
+      - github-actions
 
   - package-ecosystem: pip
     directory: /
@@ -17,3 +20,6 @@ updates:
       - J-Melon
     reviewers:
       - J-Melon
+    labels:
+      - dependencies
+      - python

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     labels:
       - dependencies
       - github-actions
+    rebase-strategy: disabled
 
   - package-ecosystem: pip
     directory: /
@@ -23,3 +24,4 @@ updates:
     labels:
       - dependencies
       - python
+    rebase-strategy: disabled


### PR DESCRIPTION
Renames `github_actions` label to `github-actions` (hyphen convention). Locks both ecosystems' labels explicitly in `.github/dependabot.yml` so Dependabot stops recreating the underscore variant. Also sets `rebase-strategy: disabled` per ecosystem so Dependabot stops rebasing its branches — matches the repo's never-rebase rule; main gets merged in by the auto-update workflow instead.