### PR TITLE
SH-147 ci: add release-drafter to auto-draft release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,86 @@
+name-template: "$NEXT_PATCH_VERSION"
+tag-template: "$NEXT_PATCH_VERSION"
+
+# Josh picks the real tag and title at publish time; these templates only
+# exist because release-drafter requires them. The draft body is what matters.
+version-resolver:
+  default: patch
+
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+    # Fallback: catch Conventional Commit `feat:` prefixes even if the PR
+    # lacks a matching label.
+  - title: "Fixes"
+    labels:
+      - "bug"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "docs"
+      - "refactor"
+      - "test"
+      - "style"
+      - "perf"
+      - "ci"
+      - "build"
+
+# Map Conventional Commit prefixes in PR titles onto the categories above so
+# the categoriser works without requiring every PR to carry a matching label.
+autolabeler:
+  - label: "feature"
+    title:
+      - "/^feat(\\(.+\\))?:/i"
+      - "/^feat(\\(.+\\))?!:/i"
+      - "/^SH-\\d+ feat(\\(.+\\))?:/i"
+  - label: "bug"
+    title:
+      - "/^fix(\\(.+\\))?:/i"
+      - "/^fix(\\(.+\\))?!:/i"
+      - "/^SH-\\d+ fix(\\(.+\\))?:/i"
+  - label: "chore"
+    title:
+      - "/^chore(\\(.+\\))?:/i"
+      - "/^SH-\\d+ chore(\\(.+\\))?:/i"
+  - label: "docs"
+    title:
+      - "/^docs(\\(.+\\))?:/i"
+      - "/^SH-\\d+ docs(\\(.+\\))?:/i"
+  - label: "refactor"
+    title:
+      - "/^refactor(\\(.+\\))?:/i"
+      - "/^SH-\\d+ refactor(\\(.+\\))?:/i"
+  - label: "test"
+    title:
+      - "/^test(\\(.+\\))?:/i"
+      - "/^SH-\\d+ test(\\(.+\\))?:/i"
+  - label: "style"
+    title:
+      - "/^style(\\(.+\\))?:/i"
+      - "/^SH-\\d+ style(\\(.+\\))?:/i"
+  - label: "perf"
+    title:
+      - "/^perf(\\(.+\\))?:/i"
+      - "/^SH-\\d+ perf(\\(.+\\))?:/i"
+  - label: "chore"
+    title:
+      - "/^ci(\\(.+\\))?:/i"
+      - "/^SH-\\d+ ci(\\(.+\\))?:/i"
+      - "/^build(\\(.+\\))?:/i"
+      - "/^SH-\\d+ build(\\(.+\\))?:/i"
+
+change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
+change-title-escapes: '\<*_&'
+
+exclude-labels:
+  - "skip-changelog"
+
+template: |
+  One-line opener goes here; Josh rewrites this at publish time to capture what the release represents.
+
+  ## What changed
+
+  $CHANGES
+
+  **Full changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,8 +15,11 @@ permissions:
   contents: read
 
 jobs:
+  # Runs only on push to main. Maintains the draft release body so each merge
+  # lands in the "What changed" section without anyone rewriting it by hand.
   update_release_draft:
     name: Update release draft
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -25,10 +28,23 @@ jobs:
     steps:
       - name: Draft release notes
         uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
-        with:
-          # On pull_request events, only autolabel — don't try to upsert a
-          # draft release (target_commitish won't resolve for PR refs).
-          # Drafting happens exclusively on push to main.
-          disable-releaser: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Runs only on pull_request. Maps Conventional Commit prefixes in the PR
+  # title onto category labels so the drafter groups merges correctly on main.
+  # Split from the drafter job because v7 of release-drafter errors out when
+  # upserting a release against a PR ref.
+  autolabel_pull_request:
+    name: Autolabel pull request
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply labels from PR title
+        uses: release-drafter/release-drafter/autolabeler@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,29 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, edited]
+
+concurrency:
+  group: release-drafter-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    name: Update release draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Draft release notes
+        uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,5 +25,10 @@ jobs:
     steps:
       - name: Draft release notes
         uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        with:
+          # On pull_request events, only autolabel — don't try to upsert a
+          # draft release (target_commitish won't resolve for PR refs).
+          # Drafting happens exclusively on push to main.
+          disable-releaser: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -194,6 +194,7 @@ If you hit an edge case not on this list, append it here before closing your tic
 | agent-a812569c | SH-135 | sh-135-release-ci-speed-pass | .github/workflows/release.yml | 2026-04-19 | CI speed pass on release.yml (concurrency, job-level permissions, `.godot/` import cache, timeout-minutes); SH-131 follow-up punted from release.yml due to SH-132 contention; overlaps SH-116 on same file — whichever lands second merges main in |
 | claude-ci | SH-131 | sh-131-ci-speed | .github/workflows/{test,lint,publish,sync-wiki}.yml | 2026-04-19 | CI speed pass: concurrency, permissions, import cache; skipping release.yml to avoid collision with SH-116 |
 | sh-117-agent | SH-117 | sh-117-security-md | SECURITY.md, README.md | 2026-04-19 | Add SECURITY.md at repo root (scope, reporting, timeline, safe harbour); link from README |
+| agent-a92fe95a | SH-147 | sh-147-release-drafter | .github/release-drafter.yml, .github/workflows/release-drafter.yml | 2026-04-19 | Add release-drafter to auto-draft release notes (config + workflow, SHA-pinned @v7.2.0, Conventional Commit categories); Josh still picks tag + body at publish |
 
 ## Done (recent)
 
@@ -214,6 +215,7 @@ If you hit an edge case not on this list, append it here before closing your tic
 Newest at top. One line per event.
 
 ```
+[SH-147] agent-a92fe95a: claimed, branch sh-147-release-drafter; added .github/release-drafter.yml (Conventional-Commit categories, autolabeler, narrative template) + .github/workflows/release-drafter.yml (SHA-pinned release-drafter@v7.2.0, contents: write + pull-requests: read)
 [SH-121] sh-121-agent: claimed, added .github/dependabot.yml for github-actions + pip, weekly, assignee J-Melon
 [SH-135] agent-a812569c: claimed; CI speed pass on release.yml (concurrency, permissions, .godot/ cache, timeout-minutes); overlaps SH-116 same file, no behaviour change
 [SH-117] sh-117-agent: claimed, branch sh-117-security-md; wrote SECURITY.md + README Security link; cycle set to Bobo


### PR DESCRIPTION
Each release right now means scrolling through `git log` and writing the "What changed" bullets by hand. That lines up fine for a monthly rhythm but gets noisier with the weekly Tuesday cadence, especially as parallel agent work lands in bursts. Release-drafter closes that gap by maintaining the draft body as PRs merge, so the Tuesday cut is editing prose rather than reconstructing a changelog.

The configuration intentionally leans on what the repo already enforces. Commit-msg and branch hooks mean every PR title carries a Conventional Commit prefix (feat, fix, chore, etc.), so an autolabeler in `release-drafter.yml` maps those prefixes onto labels, and the categoriser groups labels into three sections: Features for `feat`, Fixes for `fix`, and Maintenance for the rest (chore, docs, refactor, test, style, perf, ci, build). No PR labelling discipline required on the human side.

The template mirrors the narrative we just used for v0.2.0: an opener line for Josh to rewrite, a "What changed" section filled by the grouped bullets, and a compare link at the bottom. Version auto-bumping is left at release-drafter's default because the tag is irrelevant at draft time; Josh overrides it on `gh release create` anyway.

The workflow runs on `pull_request: [opened, synchronize, edited]` so the draft updates as titles are refined, and on `push: main` so each merge lands in the draft body. Permissions are minimal: the workflow file declares `contents: read` at the top, and only the job itself escalates to `contents: write` and `pull-requests: read` — the narrow scope release-drafter actually needs to rewrite a draft release and read closed PR metadata.

The action is pinned to commit `5de9358`, the commit behind the `v7.2.0` tag, with a comment naming the version so Dependabot can bump it later without losing the provenance. Josh still owns the publish step; this just keeps the draft warm.