### PR TITLE
SH-150: update repo URLs after transfer to shuck-dev/volley

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ticket writing guide
-    url: https://github.com/J-Melon/volley-vendetta/blob/main/designs/process/ticket-writing.md
+    url: https://github.com/shuck-dev/volley/blob/main/designs/process/ticket-writing.md
     about: How our tickets are structured, what the labels mean, and how to read them.
   - name: Contributing guide
-    url: https://github.com/J-Melon/volley-vendetta/blob/main/CONTRIBUTING.md
+    url: https://github.com/shuck-dev/volley/blob/main/CONTRIBUTING.md
     about: How to claim, submit, and test your work.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,4 +30,4 @@ The game expands with its audience.
 
 ---
 
-For active tickets and day-to-day work, see the [GitHub issues](https://github.com/J-Melon/volley-vendetta/issues).
+For active tickets and day-to-day work, see the [GitHub issues](https://github.com/shuck-dev/volley/issues).

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -23,7 +23,7 @@ Live scratchpad for parallel agent work on individual Linear tickets. One agent 
    - **Mechanical fixes** (typos, dead code, obvious bugs, style violations, missing null checks): apply as commits on the PR branch and push.
    - **Judgment calls** (design tradeoffs, naming debates, architectural suggestions): post each as a line-anchored review comment so Josh can mark them Resolved in the Files changed tab. **Follow [Conventional Comments](https://conventionalcomments.org/)**: prefix each with one of `praise:`, `nitpick:`, `suggestion:`, `issue:`, `question:`, `thought:`, `chore:`, `note:` (optionally with decorators like `(non-blocking)`). One idea per comment. If a specialist has zero judgment calls, it stays silent individually; only the final handoff leaves `LGTM` if every matching specialist returned clean. Template:
      ```
-     gh api -X POST repos/J-Melon/volley-vendetta/pulls/<N>/comments \
+     gh api -X POST repos/shuck-dev/volley/pulls/<N>/comments \
        -f body="..." \
        -f commit_id="<sha of your latest push>" \
        -f path="<file>" \

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -30,7 +30,7 @@ Applies to every ticket, every discipline.
 
 **Acceptance criteria are testable observations.** Each line is something a reviewer can check by looking at the game, the asset, or the player's behaviour. Avoid method names, file paths, and references to current code. Someone picking up the ticket a month later, or a contributor who has never opened the project, should still be able to tell when it is done.
 
-**Link the context a stranger needs.** Link the design doc, the [art bible](https://github.com/J-Melon/volley-vendetta/blob/main/designs/art/bible.md), the parent artifact, the bug's originating feature. Do not say "see the kit design"; paste an absolute GitHub URL like `https://github.com/J-Melon/volley-vendetta/blob/main/designs/01-prototype/08-kit.md`. Absolute URLs survive both Linear and GitHub; repo-relative paths only resolve on GitHub and break when the ticket mirrors across.
+**Link the context a stranger needs.** Link the design doc, the [art bible](https://github.com/shuck-dev/volley/blob/main/designs/art/bible.md), the parent artifact, the bug's originating feature. Do not say "see the kit design"; paste an absolute GitHub URL like `https://github.com/shuck-dev/volley/blob/main/designs/01-prototype/08-kit.md`. Absolute URLs survive both Linear and GitHub; repo-relative paths only resolve on GitHub and break when the ticket mirrors across.
 
 **Name the scope boundary.** A good ticket says what is in and what is out. "Walk-off, equip pose, walk-on. Not in scope: the drag-and-drop tech (#141), the character concepts (#95)." Scope boundaries protect a new contributor from accidentally expanding the work and from cutting too deep. Use `#N` GitHub issue references when cross-linking tickets; GitHub renders them as links, and Linear's GitHub integration resolves them when the ticket mirrors.
 
@@ -105,7 +105,7 @@ Labels: `spike`, `feature`, `bug`.
 
 Labels: `study`, `asset`, `revision`.
 
-The discipline-level reference is the [art bible](https://github.com/J-Melon/volley-vendetta/blob/main/designs/art/bible.md): a living document of silhouette rules, palette, line, mood, era, faction. Tickets lean on the bible rather than repeating it. Chris Solarski (*Drawing Basics and Video Game Art*, 2012) and Riot's public art team posts set the pattern.
+The discipline-level reference is the [art bible](https://github.com/shuck-dev/volley/blob/main/designs/art/bible.md): a living document of silhouette rules, palette, line, mood, era, faction. Tickets lean on the bible rather than repeating it. Chris Solarski (*Drawing Basics and Video Game Art*, 2012) and Riot's public art team posts set the pattern.
 
 **Study** (explore). Concept work. Carries: function in world, silhouette and read at distance, mood words, reference board, constraints (palette band, era, faction). "Done" is when the study answers the direction question the art director asked, per Samwise Didier (Blizzard, GDC) and Jaime Jones (Bungie, GDC 2018). Polish is not the point; coverage of options is.
 


### PR DESCRIPTION
Repo moved from `J-Melon/volley-vendetta` to `shuck-dev/volley`. Sweeps four tracked files with hardcoded old URLs: `designs/process/ticket-writing.md`, `ROADMAP.md`, `ai/PARALLEL.md`, `.github/ISSUE_TEMPLATE/config.yml`. GitHub auto-redirects old URLs so nothing broke, but doc hygiene matters for new readers.