### PR TITLE
docs: tighten Linear naming rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,8 @@ So that [benefit or reason]
 - Each clause on its own line. Acceptance criteria: short, testable checklist items.
 - **User Story** for player/end-user needs. **System Story** for internal/infrastructure work.
 - **Bug Report** for defects — use steps to reproduce and clear expected vs actual.
+- **Issue titles ≤50 chars.** Push symptoms, qualifiers, file paths into the body.
+- **Project names are Title Case, two words max per level.** "Security Hygiene", not "Security hygiene pass".
 
 ### Linear API Access
 

--- a/designs/process/project-management.md
+++ b/designs/process/project-management.md
@@ -1,0 +1,33 @@
+# Project management
+
+How Shuck shapes, sizes, splits, names, and orders Linear projects. Ticket-level guidance lives in [`ticket-writing.md`](ticket-writing.md); this doc is about the layer above.
+
+## What a project holds
+
+A project holds every ticket about one thing. Court covers the equip loop, the court visuals, and the court sfx. Cast covers concept art, animation, and character audio. Workshop covers the tinkerer's corner end to end: the space, the character, the mechanics, the sound.
+
+Projects are thing-based and span disciplines. They are not discipline buckets. Art and tech and audio for the same thing live in the same project so the work around that thing stays coherent.
+
+## How to size
+
+A project should fit inside one milestone's worth of work. If the scope can't ship together, it's probably two things, not one.
+
+Foundations (Art Foundation, Music Direction) and ops projects (Demo Release, Security Hygiene) are exceptions. They exist to enable other projects or to carry cross-cutting work and are sized by the window they own, not by a single shipping milestone.
+
+## When to split, when not to
+
+Split when the project has grown past one milestone, when two scopes inside it now have different target dates, or when the work has diverged into two things that happen to share a name.
+
+Do not split by discipline inside a project. A separate "Court Art" project alongside "Court Tech" breaks the principle above; use priority and `blocks` across tickets within one Court project instead.
+
+## Naming
+
+Project names are Title Case, two words max. "Art Foundation", "Game Feel", "Partner Unlock". If the concept needs more words, pick a tighter noun or split it into sibling projects. If splitting, each sibling follows the same rule.
+
+## Ordering work across projects
+
+Three levers, in order of preference:
+
+1. **`blocks` between tickets.** Use this when a specific deliverable in one project gates a specific deliverable in another. The dependency is explicit and survives re-planning.
+2. **Cycles.** Josh places a project's tickets into the active cycle when they're ready to ship. Unstarted projects stay in Backlog.
+3. **Priority.** Use within a project to order tickets that share a cycle. Avoid using priority across projects as a substitute for `blocks`.

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -36,7 +36,7 @@ Applies to every ticket, every discipline.
 
 **Leave room for conversation, but publish the conversation.** Borrowed from Ron Jeffries' Three Cs (card, conversation, confirmation): the ticket is a promise of a conversation. For a contributor, the conversation has to happen in the ticket thread or the linked design doc; verbal context does not reach them. Over-specifying still kills iteration, so leave room, and document decisions in comments as they happen.
 
-**Titles are short and punchy.** Symptoms, qualifiers, and context belong in the body. "Timeout and Equip" reads better than "Implement the timeout system so the main character can equip items".
+**Titles are short and punchy.** Aim for 50 characters or fewer. Symptoms, qualifiers, file paths, and context belong in the body. "Timeout and Equip" reads better than "Implement the timeout system so the main character can equip items".
 
 **INVEST as a sanity check.** Independent, Negotiable, Valuable, Estimable, Small, Testable (Bill Wake, 2003). Use it to spot tickets that should be split, merged, or rewritten. Independence matters extra for open-source: a contributor should be able to ship the ticket without a long chain of dependencies pulling them into unrelated systems.
 

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -295,6 +295,8 @@ Internal to Shuck. Covers cycles, estimates, priority, and typed relationships t
 
 **Confirm before filing.** Draft the ticket, list candidates, wait for approval before creating in Linear. Don't file proactively to close perceived gaps; only file when the cycle needs the work.
 
+**Project names are Title Case, two words max per level.** "Art Foundation", "Game Feel", not "Security hygiene pass". Nested hierarchies follow the same rule per level, e.g. "Desktop Experience > Tech". If the concept needs more words, pick a tighter noun or split it into sibling projects.
+
 ---
 
 ## Sources

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -295,7 +295,7 @@ Internal to Shuck. Covers cycles, estimates, priority, and typed relationships t
 
 **Confirm before filing.** Draft the ticket, list candidates, wait for approval before creating in Linear. Don't file proactively to close perceived gaps; only file when the cycle needs the work.
 
-**Project names are Title Case, two words max per level.** "Art Foundation", "Game Feel", not "Security hygiene pass". Nested hierarchies follow the same rule per level, e.g. "Desktop Experience > Tech". If the concept needs more words, pick a tighter noun or split it into sibling projects.
+**Projects are the layer above tickets.** Naming, sizing, splitting, and ordering of Linear projects live in [`project-management.md`](project-management.md).
 
 ---
 


### PR DESCRIPTION
Two small additions to designs/process/ticket-writing.md: a concrete 50-char aim for ticket titles, and a Title Case, two-words-max rule per level for project names. Both give the agents that file tickets a number to anchor to.