### PR TITLE
docs: cycle management and project dates policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,5 +187,5 @@ So that [benefit or reason]
 
 - API key: `$LINEAR_API_KEY`. Endpoint: `https://api.linear.app/graphql`.
 - **All new tickets** → Status: **Backlog** (`d41fb73e-32af-40b2-a7e5-5052900ab0fc`). Label: **Feature** (`b19a1a7b-af6b-4897-a52f-eb2e2e07083e`). Do NOT assign to a cycle. Do NOT use Triage — that is for external/incoming tickets only. Josh promotes tickets to Ready and adds them to cycles himself.
-- **Assign tech/design tickets to Josh Hartley** (`19ea3ec5-a428-44f7-b085-a10fd3dd2cef`).
+- **Assignee follows cycle membership.** Leave Backlog tickets unassigned. Assign Josh Hartley (`19ea3ec5-a428-44f7-b085-a10fd3dd2cef`) only when a ticket enters the active cycle.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,8 @@ So that [benefit or reason]
 - Each clause on its own line. Acceptance criteria: short, testable checklist items.
 - **User Story** for player/end-user needs. **System Story** for internal/infrastructure work.
 - **Bug Report** for defects — use steps to reproduce and clear expected vs actual.
+- **Issue titles ≤50 chars.** Push symptoms, qualifiers, file paths into the body.
+- **Project names are Title Case, two words max per level.** "Security Hygiene", not "Security hygiene pass".
 
 ### Linear API Access
 

--- a/designs/process/project-management.md
+++ b/designs/process/project-management.md
@@ -31,3 +31,25 @@ Three levers, in order of preference:
 1. **`blocks` between tickets.** Use this when a specific deliverable in one project gates a specific deliverable in another. The dependency is explicit and survives re-planning.
 2. **Cycles.** Josh places a project's tickets into the active cycle when they're ready to ship. Unstarted projects stay in Backlog.
 3. **Priority.** Use within a project to order tickets that share a cycle. Avoid using priority across projects as a substitute for `blocks`.
+
+## Project dates
+
+`startDate` and `targetDate` on a Linear project express the initiative's timeline: when that project needs to land for the initiative to hit its own deadline. Josh owns those dates. Agents do not set or change them, on any project, including new ones.
+
+Move a date only when a project is done (it goes to Completed, `completedAt` carries the real closure date, the original `targetDate` stays as a historical marker) or when a project is confirmed behind and Josh directs the reschedule. A stale-looking date on an open project is a live signal, not noise.
+
+Warn when a project has no dates. A missing `startDate` or `targetDate` is a gap to surface in cycle prep or health reads, so Josh can set it against the initiative timeline.
+
+## Cycle management
+
+Cycles are the scheduling layer below projects. Shuck's cycles are two weeks long, run Tuesday through Monday, and use the Monday before the next cycle as a buffer day for closeout and planning.
+
+**Only the current cycle is planned.** The next cycle exists with a name for continuity but its contents are not chosen ahead of time. Plan a cycle when it becomes current; treat "prep the next cycle" as naming it, not populating it.
+
+**Cycles are named alphabetically after famous puppets.** One letter per cycle, marching A → Z. Check the most recent cycle's letter before proposing the next one (for example, if the last named cycle was Bobo, the next is a C puppet).
+
+**Cycle descriptions are flat short sentences.** Linear's compact cycle preview collapses markdown lists and renders bullet characters as literal text, so no "Goals:" header, no bullet list — one flat line of full-stop-separated sentences.
+
+**Any project with a target date inside a cycle must be either scoped into that cycle or have its dates moved.** Don't let a project silently miss its `targetDate`: either promote its remaining tickets to Ready and pull them into the cycle, or Josh moves the dates. This applies to parallel and foundation projects too.
+
+**Promote to Ready before entering the cycle.** Backlog is unscoped; tickets move to Ready once they have everything a human or the headless bot needs to pick them up (spec, AC, design links via Linear's native attachment fields, any `blocks` or `relatedTo` wired). Only then do they enter the cycle.

--- a/designs/process/project-management.md
+++ b/designs/process/project-management.md
@@ -1,0 +1,33 @@
+# Project management
+
+How Shuck shapes, sizes, splits, names, and orders Linear projects. Ticket-level guidance lives in [`ticket-writing.md`](ticket-writing.md); this doc is about the layer above.
+
+## What a project holds
+
+A project holds every ticket about one thing. Court covers the equip loop, the court visuals, and the court sfx. Cast covers concept art, animation, and character audio. Workshop covers the tinkerer's corner end to end: the space, the character, the mechanics, the sound.
+
+Projects are thing-based and span disciplines. They are not discipline buckets. Art and tech and audio for the same thing live in the same project so the work around that thing stays coherent.
+
+## How to size
+
+A project should fit inside one milestone's worth of work. If the scope can't ship together, it's probably two things, not one.
+
+Foundations (Art Foundation, Music Direction) and ops projects (Demo Release, Security Hygiene) are exceptions. They exist to enable other projects or to carry cross-cutting work and are sized by the window they own, not by a single shipping milestone.
+
+## When to split, when not to
+
+Split when the project has grown past one milestone, when two scopes inside it now have different target dates, or when the work has diverged into two things that happen to share a name.
+
+Do not split by discipline inside a project. A separate "Court Art" project alongside "Court Tech" breaks the principle above; use priority and `blocks` across tickets within one Court project instead.
+
+## Naming
+
+Project names are Title Case, two words max. "Art Foundation", "Game Feel", "Partner Unlock". If the concept needs more words, pick a tighter noun or split it into sibling projects. If splitting, each sibling follows the same rule.
+
+## Ordering work across projects
+
+Three levers, in order of preference:
+
+1. **`blocks` between tickets.** Use this when a specific deliverable in one project gates a specific deliverable in another. The dependency is explicit and survives re-planning.
+2. **Cycles.** Josh places a project's tickets into the active cycle when they're ready to ship. Unstarted projects stay in Backlog.
+3. **Priority.** Use within a project to order tickets that share a cycle. Avoid using priority across projects as a substitute for `blocks`.

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -36,7 +36,7 @@ Applies to every ticket, every discipline.
 
 **Leave room for conversation, but publish the conversation.** Borrowed from Ron Jeffries' Three Cs (card, conversation, confirmation): the ticket is a promise of a conversation. For a contributor, the conversation has to happen in the ticket thread or the linked design doc; verbal context does not reach them. Over-specifying still kills iteration, so leave room, and document decisions in comments as they happen.
 
-**Titles are short and punchy.** Symptoms, qualifiers, and context belong in the body. "Timeout and Equip" reads better than "Implement the timeout system so the main character can equip items".
+**Titles are short and punchy.** Aim for 50 characters or fewer. Symptoms, qualifiers, file paths, and context belong in the body. "Timeout and Equip" reads better than "Implement the timeout system so the main character can equip items".
 
 **INVEST as a sanity check.** Independent, Negotiable, Valuable, Estimable, Small, Testable (Bill Wake, 2003). Use it to spot tickets that should be split, merged, or rewritten. Independence matters extra for open-source: a contributor should be able to ship the ticket without a long chain of dependencies pulling them into unrelated systems.
 

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -295,6 +295,8 @@ Internal to Shuck. Covers cycles, estimates, priority, and typed relationships t
 
 **Confirm before filing.** Draft the ticket, list candidates, wait for approval before creating in Linear. Don't file proactively to close perceived gaps; only file when the cycle needs the work.
 
+**Project names are Title Case, two words max per level.** "Art Foundation", "Game Feel", not "Security hygiene pass". Nested hierarchies follow the same rule per level, e.g. "Desktop Experience > Tech". If the concept needs more words, pick a tighter noun or split it into sibling projects.
+
 ---
 
 ## Sources

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -295,7 +295,7 @@ Internal to Shuck. Covers cycles, estimates, priority, and typed relationships t
 
 **Confirm before filing.** Draft the ticket, list candidates, wait for approval before creating in Linear. Don't file proactively to close perceived gaps; only file when the cycle needs the work.
 
-**Project names are Title Case, two words max per level.** "Art Foundation", "Game Feel", not "Security hygiene pass". Nested hierarchies follow the same rule per level, e.g. "Desktop Experience > Tech". If the concept needs more words, pick a tighter noun or split it into sibling projects.
+**Projects are the layer above tickets.** Naming, sizing, splitting, and ordering of Linear projects live in [`project-management.md`](project-management.md).
 
 ---
 


### PR DESCRIPTION
Documents the cycle-management and project-date rules worked out during cycle #3 planning: current-only planning horizon, alphabetical puppet naming, Tuesday-to-Monday schedule with buffer Monday, flat-sentence cycle descriptions, projects-in-or-moved, Ready before cycle entry, and Josh-owned project dates (agents warn on missing).