### PR TITLE
ci: guard human-approved label against non-maintainers

### DIFF
--- a/.github/workflows/human-approved-guard.yml
+++ b/.github/workflows/human-approved-guard.yml
@@ -1,0 +1,43 @@
+name: Human-approved label guard
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  verify-sender:
+    name: Strip human-approved if applied by non-maintainer
+    if: github.event.label.name == 'human-approved'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check sender and strip label if unauthorised
+        uses: actions/github-script@v8
+        env:
+          ALLOWED_USER: J-Melon
+        with:
+          script: |
+            const actor = context.payload.sender && context.payload.sender.login;
+            const allowed = process.env.ALLOWED_USER;
+            if (actor === allowed) {
+              core.info(`human-approved applied by ${actor}; keeping.`);
+              return;
+            }
+            core.warning(`human-approved applied by ${actor}; removing.`);
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'human-approved',
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `The \`human-approved\` label is reserved for @${allowed}. Removing the label applied by @${actor}.`,
+            });


### PR DESCRIPTION
Adds a workflow that strips the `human-approved` label if applied by anyone other than J-Melon, with a short comment explaining the restriction. Required checks on main now include `human-approved` and `no-action-required`, so the gate is meaningful only if the label cannot be self-applied by contributors.