### PR TITLE
ci: rename required checks for clarity

### DIFF
--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -53,7 +53,7 @@ jobs:
 
             const checks = [
               {
-                name: 'human-approved',
+                name: 'Human Approved',
                 conclusion: humanApproved ? 'success' : 'failure',
                 title: humanApproved ? 'Josh signed off' : 'Waiting on human-approved label',
                 summary: humanApproved
@@ -61,12 +61,12 @@ jobs:
                   : 'Apply the `human-approved` label once you have reviewed the PR.',
               },
               {
-                name: 'no-action-required',
+                name: 'AI Review Passed',
                 conclusion: actionRequired ? 'failure' : 'success',
-                title: actionRequired ? 'AI reviewer left items to resolve' : 'No action-required label',
+                title: actionRequired ? 'AI reviewer left items to resolve' : 'AI review passed',
                 summary: actionRequired
                   ? 'Resolve the `action-required` items and remove the label before merging.'
-                  : 'The `action-required` label is absent.',
+                  : 'No unresolved AI reviewer comments.',
               },
             ];
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   lint:
-    name: Run Lint
+    name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   test:
-    name: Run Tests
+    name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -113,8 +113,8 @@ Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARA
 
 Two required status checks drive the merge gate:
 
-- **`human-approved`**: succeeds only when the `human-approved` label is present.
-- **`no-action-required`**: succeeds only when the `action-required` label is absent.
+- **`Human Approved`**: succeeds only when the `human-approved` label is present.
+- **`AI Review Passed`**: succeeds only when the `action-required` label is absent.
 
 Both must pass before auto-merge fires. The checks are posted by `.github/workflows/approval-gate.yml` on label events.
 


### PR DESCRIPTION
Three linked renames. `no-action-required` becomes `ai-review-passed` so the check name reads as an affirmative pass rather than a double negative. The `Run` prefix drops off the Tests and Lint job names so the required-checks list reads `Tests, Lint, human-approved, ai-review-passed` without redundancy. Ruleset on main is already updated to the new names; this PR brings the workflow files into line.