### PR TITLE
ci: restore approval-gate concurrency (bisect 1/3)

### DIFF
--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -14,6 +14,10 @@ permissions:
   checks: write
   pull-requests: write
 
+concurrency:
+  group: approval-gate-${{ github.event.pull_request.number || github.event.inputs.pr }}
+  cancel-in-progress: false
+
 jobs:
   gate:
     name: Post approval checks


### PR DESCRIPTION
First of three bisect PRs to identify what in the original approval-gate.yml broke the parser.

**Adds back**: top-level `concurrency` block (with safer expression that handles workflow_dispatch).

**If this merges and pull_request_target still fires**, concurrency wasn't the culprit → next PR adds back `pull_request_review_thread` + `clear-on-resolve`.

**If this breaks the gate again**, concurrency is the culprit → revert, keep gate working without it.