### PR TITLE
ci: restore pull_request_review_thread clear-on-resolve (bisect 3/3)

### DIFF
--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -9,6 +9,8 @@ on:
         type: string
   pull_request_target:
     types: [opened, reopened, labeled, unlabeled, synchronize]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
 
 permissions:
   checks: write
@@ -21,6 +23,7 @@ concurrency:
 jobs:
   gate:
     name: Post approval checks
+    if: github.event_name != 'pull_request_review_thread'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -109,3 +112,53 @@ jobs:
                 });
               }
             }
+
+  clear-on-resolve:
+    name: Clear action-required when all threads resolved
+    if: github.event_name == 'pull_request_review_thread'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Strip action-required if no unresolved threads remain
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 100) {
+                      nodes { isResolved }
+                      pageInfo { hasNextPage }
+                    }
+                  }
+                }
+              }`;
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: pr.number,
+            });
+            const threads = result.repository.pullRequest.reviewThreads;
+            if (threads.pageInfo.hasNextPage) {
+              core.setFailed('PR has more than 100 review threads; paginate this query.');
+              return;
+            }
+            const unresolved = threads.nodes.filter(thread => !thread.isResolved).length;
+            if (unresolved > 0) {
+              core.info(`${unresolved} unresolved thread(s); leaving action-required in place.`);
+              return;
+            }
+            const hasLabel = pr.labels.some(label => label.name === 'action-required');
+            if (!hasLabel) {
+              core.info('action-required label not present; nothing to do.');
+              return;
+            }
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              name: 'action-required',
+            });
+            core.info('All threads resolved; removed action-required label.');


### PR DESCRIPTION
Last of the bisect series. Adds back the review-thread listener that strips `action-required` once all review threads are resolved.

If the workflow goes back to failing (name reverts to file path in the API), we know this block is the parse blocker and split it into its own workflow file. If it stays as "Approval Gate", something already corrected fixed it.