### PR TITLE
chore: live-update smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ designs/research/drafts/
 # OS junk
 .DS_Store
 Thumbs.db
+
+# live-update smoke PR touch, safe to revert


### PR DESCRIPTION
Throwaway PR to watch the check-list refresh live in the browser after whitelisting alive.github.com in uBlock. Close without merging once you've confirmed live updates work.