### PR TITLE
ci: prefix labels for picker ordering (@ for human, 🤖 for bots)

### DIFF
--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -38,12 +38,12 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            if (pr.labels.some(label => label.name === 'human-approved')) {
+            if (pr.labels.some(label => label.name === '@human-approved')) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                name: 'human-approved',
+                name: '@human-approved',
               });
             }
 
@@ -85,8 +85,8 @@ jobs:
             // commit so the queue sees them.
             const targetSha = sha || pr.head.sha;
 
-            const humanApproved = labels.has('human-approved');
-            const actionRequired = labels.has('action-required');
+            const humanApproved = labels.has('@human-approved');
+            const actionRequired = labels.has('🤖 action-required');
 
             const checks = [
               {
@@ -98,15 +98,15 @@ jobs:
                 conclusion: humanApproved ? 'success' : 'action_required',
                 title: humanApproved ? 'Josh signed off' : 'Waiting on human-approved label',
                 summary: humanApproved
-                  ? 'The `human-approved` label is present.'
-                  : 'Apply the `human-approved` label once you have reviewed the PR.',
+                  ? 'The `@human-approved` label is present.'
+                  : 'Apply the `@human-approved` label once you have reviewed the PR.',
               },
               {
                 name: 'AI Review Passed',
                 conclusion: actionRequired ? 'failure' : 'success',
                 title: actionRequired ? 'AI reviewer left items to resolve' : 'AI review passed',
                 summary: actionRequired
-                  ? 'Resolve the `action-required` items and remove the label before merging.'
+                  ? 'Resolve the `🤖 action-required` items and remove the label before merging.'
                   : 'No unresolved AI reviewer comments.',
               },
             ];

--- a/.github/workflows/human-approved-guard.yml
+++ b/.github/workflows/human-approved-guard.yml
@@ -11,8 +11,8 @@ permissions:
 
 jobs:
   verify-sender:
-    name: Strip human-approved if applied by non-maintainer
-    if: github.event.label.name == 'human-approved'
+    name: Strip @human-approved if applied by non-maintainer
+    if: github.event.label.name == '@human-approved'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -25,19 +25,19 @@ jobs:
             const actor = context.payload.sender && context.payload.sender.login;
             const allowed = process.env.ALLOWED_USER;
             if (actor === allowed) {
-              core.info(`human-approved applied by ${actor}; keeping.`);
+              core.info(`@human-approved applied by ${actor}; keeping.`);
               return;
             }
-            core.warning(`human-approved applied by ${actor}; removing.`);
+            core.warning(`@human-approved applied by ${actor}; removing.`);
             await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              name: 'human-approved',
+              name: '@human-approved',
             });
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `The \`human-approved\` label is reserved for @${allowed}. Removing the label applied by @${actor}.`,
+              body: `The \`@human-approved\` label is reserved for @${allowed}. Removing the label applied by @${actor}.`,
             });

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -22,7 +22,7 @@ Live scratchpad for parallel agent work. One agent per Linear ticket. Log progre
    - **Mechanical fixes** (typos, dead code, obvious bugs, style): commit on the PR branch.
    - **Everything else**: short line-anchored review comments following [Conventional Comments](https://conventionalcomments.org/) (`praise:`, `nitpick:`, `suggestion:`, `issue:`, `question:`, `thought:`, `chore:`, `note:`, with decorators like `(non-blocking)`). **One idea per comment, two sentences max.** If it needs more context, open an issue and link from the comment.
 
-   After all specialists finish: clean → `gh pr edit <N> --add-label ai-approved`. Any comments → `--add-label action-required` instead. No `LGTM` or summary comments. Line-anchored comment template:
+   After all specialists finish: clean → `gh pr edit <N> --add-label '🤖 ai-approved'`. Any comments → `--add-label '🤖 action-required'` instead. No `LGTM` or summary comments. Line-anchored comment template:
 
    ```
    gh api -X POST repos/shuck-dev/volley/pulls/<N>/comments \

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -100,21 +100,21 @@ Separate from intent labels, a small set of GitHub labels are applied automatica
 
 ### AI review state
 
-- **`ai-approved`**: specialist reviewers from `.claude/agents/` passed the PR with no outstanding comments.
-- **`action-required`**: at least one specialist reviewer left a line-anchored review comment. Blocks merge until resolved. Removed automatically once every review thread on the PR is marked Resolved.
+- **`🤖 ai-approved`**: specialist reviewers from `.claude/agents/` passed the PR with no outstanding comments.
+- **`🤖 action-required`**: at least one specialist reviewer left a line-anchored review comment. Blocks merge until resolved. Removed automatically once every review thread on the PR is marked Resolved.
 
-Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `ai-approved` is an advisory signal, not a merge decision.
+Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `🤖 ai-approved` is an advisory signal, not a merge decision.
 
 ### Human review state
 
-- **`human-approved`**: Josh has reviewed and signed off. Required for merge.
+- **`@human-approved`**: Josh has reviewed and signed off. Required for merge.
 
 ### Merge gate
 
 Two required status checks drive the merge gate:
 
-- **`Human Approved`**: succeeds only when the `human-approved` label is present.
-- **`AI Review Passed`**: succeeds only when the `action-required` label is absent.
+- **`Human Approved`**: succeeds only when the `@human-approved` label is present.
+- **`AI Review Passed`**: succeeds only when the `🤖 action-required` label is absent.
 
 Both must pass before auto-merge fires. The checks are posted by `.github/workflows/approval-gate.yml` on label events.
 


### PR DESCRIPTION
Renames the three approval labels so the picker shows `@human-approved` at the top and bot-owned `🤖 action-required` / `🤖 ai-approved` drop to the end. Repo labels already renamed; this PR brings in-tree references in sync.