### PR TITLE
ci: extend Approver Check to gate bot labels too

### DIFF
--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -38,12 +38,12 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            if (pr.labels.some(label => label.name === '@human-approved')) {
+            if (pr.labels.some(label => label.name === '👮 human-approved')) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                name: '@human-approved',
+                name: '👮 human-approved',
               });
             }
 
@@ -85,7 +85,7 @@ jobs:
             // commit so the queue sees them.
             const targetSha = sha || pr.head.sha;
 
-            const humanApproved = labels.has('@human-approved');
+            const humanApproved = labels.has('👮 human-approved');
             const actionRequired = labels.has('🤖 action-required');
 
             const checks = [
@@ -98,8 +98,8 @@ jobs:
                 conclusion: humanApproved ? 'success' : 'action_required',
                 title: humanApproved ? 'Josh signed off' : 'Waiting on human-approved label',
                 summary: humanApproved
-                  ? 'The `@human-approved` label is present.'
-                  : 'Apply the `@human-approved` label once you have reviewed the PR.',
+                  ? 'The `👮 human-approved` label is present.'
+                  : 'Apply the `👮 human-approved` label once you have reviewed the PR.',
               },
               {
                 name: 'AI Review Passed',

--- a/.github/workflows/human-approved-guard.yml
+++ b/.github/workflows/human-approved-guard.yml
@@ -11,33 +11,52 @@ permissions:
 
 jobs:
   verify-sender:
-    name: Strip @human-approved if applied by non-maintainer
-    if: github.event.label.name == '@human-approved'
+    name: Strip restricted label if applied by unauthorised actor
+    if: >-
+      github.event.label.name == '@human-approved' ||
+      github.event.label.name == '🤖 action-required' ||
+      github.event.label.name == '🤖 ai-approved'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Check sender and strip label if unauthorised
         uses: actions/github-script@v7
         env:
-          ALLOWED_USER: J-Melon
+          MAINTAINER: J-Melon
         with:
           script: |
-            const actor = context.payload.sender && context.payload.sender.login;
-            const allowed = process.env.ALLOWED_USER;
-            if (actor === allowed) {
-              core.info(`@human-approved applied by ${actor}; keeping.`);
+            // Each restricted label has its own allow-list. @human-approved
+            // is Josh-only. The bot labels can be applied by Josh OR by
+            // github-actions workflow runs (sender.login is then
+            // 'github-actions[bot]').
+            const labelName = context.payload.label.name;
+            const maintainer = process.env.MAINTAINER;
+            const policy = {
+              '@human-approved': new Set([maintainer]),
+              '🤖 action-required': new Set([maintainer, 'github-actions[bot]']),
+              '🤖 ai-approved': new Set([maintainer, 'github-actions[bot]']),
+            };
+            const allowed = policy[labelName];
+            if (!allowed) {
+              core.info(`No policy for ${labelName}; leaving it alone.`);
               return;
             }
-            core.warning(`@human-approved applied by ${actor}; removing.`);
+            const actor = context.payload.sender && context.payload.sender.login;
+            if (allowed.has(actor)) {
+              core.info(`${labelName} applied by ${actor}; keeping.`);
+              return;
+            }
+            core.warning(`${labelName} applied by ${actor}; removing.`);
             await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              name: '@human-approved',
+              name: labelName,
             });
+            const allowedList = Array.from(allowed).map(u => `@${u}`).join(' or ');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `The \`@human-approved\` label is reserved for @${allowed}. Removing the label applied by @${actor}.`,
+              body: `The \`${labelName}\` label is reserved for ${allowedList}. Removing the label applied by @${actor}.`,
             });

--- a/.github/workflows/human-approved-guard.yml
+++ b/.github/workflows/human-approved-guard.yml
@@ -13,7 +13,7 @@ jobs:
   verify-sender:
     name: Strip restricted label if applied by unauthorised actor
     if: >-
-      github.event.label.name == '@human-approved' ||
+      github.event.label.name == '👮 human-approved' ||
       github.event.label.name == '🤖 action-required' ||
       github.event.label.name == '🤖 ai-approved'
     runs-on: ubuntu-latest
@@ -25,14 +25,14 @@ jobs:
           MAINTAINER: J-Melon
         with:
           script: |
-            // Each restricted label has its own allow-list. @human-approved
+            // Each restricted label has its own allow-list. 👮 human-approved
             // is Josh-only. The bot labels can be applied by Josh OR by
             // github-actions workflow runs (sender.login is then
             // 'github-actions[bot]').
             const labelName = context.payload.label.name;
             const maintainer = process.env.MAINTAINER;
             const policy = {
-              '@human-approved': new Set([maintainer]),
+              '👮 human-approved': new Set([maintainer]),
               '🤖 action-required': new Set([maintainer, 'github-actions[bot]']),
               '🤖 ai-approved': new Set([maintainer, 'github-actions[bot]']),
             };

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -107,13 +107,13 @@ Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARA
 
 ### Human review state
 
-- **`@human-approved`**: Josh has reviewed and signed off. Required for merge.
+- **`👮 human-approved`**: Josh has reviewed and signed off. Required for merge.
 
 ### Merge gate
 
 Two required status checks drive the merge gate:
 
-- **`Human Approved`**: succeeds only when the `@human-approved` label is present.
+- **`Human Approved`**: succeeds only when the `👮 human-approved` label is present.
 - **`AI Review Passed`**: succeeds only when the `🤖 action-required` label is absent.
 
 Both must pass before auto-merge fires. The checks are posted by `.github/workflows/approval-gate.yml` on label events.


### PR DESCRIPTION
Policy table in the Approver Check workflow now covers all three restricted labels:

- `@human-approved` — Josh only
- `🤖 action-required` — Josh or github-actions[bot]
- `🤖 ai-approved` — Josh or github-actions[bot]

Prevents an unauthorised collaborator from spoofing an AI approval or action-required label.