### PR TITLE
ci: split release-drafter to remove skipped-check noise

### DIFF
--- a/.github/workflows/autolabel-pr.yml
+++ b/.github/workflows/autolabel-pr.yml
@@ -1,0 +1,28 @@
+name: Autolabel PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+concurrency:
+  group: autolabel-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # Maps Conventional Commit prefixes in the PR title onto category labels
+  # so the release-drafter workflow on main groups merges correctly.
+  # Split out of the drafter workflow so skipped-on-PR / skipped-on-push
+  # check noise is gone.
+  autolabel:
+    name: Apply labels from PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Autolabel
+        uses: release-drafter/release-drafter/autolabeler@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, edited]
 
 concurrency:
   group: release-drafter-${{ github.ref }}
@@ -15,11 +13,10 @@ permissions:
   contents: read
 
 jobs:
-  # Runs only on push to main. Maintains the draft release body so each merge
-  # lands in the "What changed" section without anyone rewriting it by hand.
+  # Maintains the draft release body so each merge lands in the
+  # "What changed" section without anyone rewriting it by hand.
   update_release_draft:
     name: Update release draft
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -28,23 +25,5 @@ jobs:
     steps:
       - name: Draft release notes
         uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Runs only on pull_request. Maps Conventional Commit prefixes in the PR
-  # title onto category labels so the drafter groups merges correctly on main.
-  # Split from the drafter job because v7 of release-drafter errors out when
-  # upserting a release against a PR ref.
-  autolabel_pull_request:
-    name: Autolabel pull request
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Apply labels from PR title
-        uses: release-drafter/release-drafter/autolabeler@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
One workflow with two event-gated jobs produced a "Skipped" entry on every PR. Splits into two single-event workflows so the skip disappears.