### PR TITLE
ci: align checkout and github-script versions

### DIFF
--- a/.github/workflows/daily-cycle.yml
+++ b/.github/workflows/daily-cycle.yml
@@ -90,7 +90,7 @@ jobs:
       skip_reason: ${{ steps.pick.outputs.skip_reason || steps.earlyskip.outputs.skip_reason }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Kill-switch check
         id: killswitch
@@ -366,7 +366,7 @@ jobs:
       issues: write
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/human-approved-guard.yml
+++ b/.github/workflows/human-approved-guard.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Check sender and strip label if unauthorised
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           MAINTAINER: J-Melon
         with:


### PR DESCRIPTION
Low-risk alignment pass:

- `actions/checkout@v4` → `@v6` in daily-cycle.yml (rest of repo was already v6)
- `actions/github-script@v7` → `@v8` in human-approved-guard.yml (matches approval-gate, avoids deprecated Node 20 runtime)

v9 (latest github-script) deferred to a follow-up with testing.