### PR TITLE
ci: Human Approved skips first post; flips to action_required on un-approve

### DIFF
--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -38,12 +38,12 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            if (pr.labels.some(label => label.name === '👮 human-approved')) {
+            if (pr.labels.some(label => label.name === '✨ human-approved')) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                name: '👮 human-approved',
+                name: '✨ human-approved',
               });
             }
 
@@ -85,8 +85,8 @@ jobs:
             // commit so the queue sees them.
             const targetSha = sha || pr.head.sha;
 
-            const humanApproved = labels.has('👮 human-approved');
-            const actionRequired = labels.has('🤖 action-required');
+            const humanApproved = labels.has('✨ human-approved');
+            const actionRequired = labels.has('~action-required');
 
             // Three-state UX for Human Approved:
             //
@@ -112,12 +112,12 @@ jobs:
                 name: 'Human Approved',
                 pending: !humanApproved,
                 pendingTitle: 'Needs human review',
-                pendingSummary: 'Apply the `👮 human-approved` label once you have reviewed the PR.',
+                pendingSummary: 'Apply the `✨ human-approved` label once you have reviewed the PR.',
                 conclusion: humanApproved ? 'success' : 'action_required',
                 title: humanApproved ? 'Josh signed off' : 'Approval was withdrawn',
                 summary: humanApproved
-                  ? 'The `👮 human-approved` label is present.'
-                  : 'The `👮 human-approved` label was previously applied and has been removed (likely by a new commit). Re-apply it after re-reviewing.',
+                  ? 'The `✨ human-approved` label is present.'
+                  : 'The `✨ human-approved` label was previously applied and has been removed (likely by a new commit). Re-apply it after re-reviewing.',
               },
               {
                 name: 'AI Review Passed',
@@ -125,7 +125,7 @@ jobs:
                 conclusion: actionRequired ? 'failure' : 'success',
                 title: actionRequired ? 'AI reviewer left items to resolve' : 'AI review passed',
                 summary: actionRequired
-                  ? 'Resolve the `🤖 action-required` items and remove the label before merging.'
+                  ? 'Resolve the `~action-required` items and remove the label before merging.'
                   : 'No unresolved AI reviewer comments.',
               },
             ];

--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -2,7 +2,7 @@ name: Approval Gate
 
 # `pull_request_review_thread` is NOT a valid workflow trigger in GitHub
 # Actions (it's a webhook event only). Previous attempts to use it silently
-# broke the workflow — GitHub's schema rejected the file, producing
+# broke the workflow; GitHub's schema rejected the file, producing
 # startup-failure runs that never posted check runs. Do not add it back.
 on:
   workflow_dispatch:
@@ -93,7 +93,7 @@ jobs:
             // 1. Label absent on a fresh PR → post status=queued with custom
             //    text "Needs human review". Yellow pending dot in the UI,
             //    blocks merge, and the message is ours rather than GitHub's
-            //    default "Expected — Waiting for status to be reported".
+            //    default GitHub waiting copy.
             //    `queued` is more honest than `in_progress`: the gate is
             //    scheduled but isn't actually running, it's idle waiting
             //    for input.

--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -86,7 +86,7 @@ jobs:
             const targetSha = sha || pr.head.sha;
 
             const humanApproved = labels.has('✨ human-approved');
-            const actionRequired = labels.has('~action-required');
+            const actionRequired = labels.has('zz action-required');
 
             // Three-state UX for Human Approved:
             //
@@ -125,7 +125,7 @@ jobs:
                 conclusion: actionRequired ? 'failure' : 'success',
                 title: actionRequired ? 'AI reviewer left items to resolve' : 'AI review passed',
                 summary: actionRequired
-                  ? 'Resolve the `~action-required` items and remove the label before merging.'
+                  ? 'Resolve the `zz action-required` items and remove the label before merging.'
                   : 'No unresolved AI reviewer comments.',
               },
             ];

--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -38,12 +38,12 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            if (pr.labels.some(label => label.name === '✨ human-approved')) {
+            if (pr.labels.some(label => label.name === 'approved-human')) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
-                name: '✨ human-approved',
+                name: 'approved-human',
               });
             }
 
@@ -85,8 +85,8 @@ jobs:
             // commit so the queue sees them.
             const targetSha = sha || pr.head.sha;
 
-            const humanApproved = labels.has('✨ human-approved');
-            const actionRequired = labels.has('zz action-required');
+            const humanApproved = labels.has('approved-human');
+            const actionRequired = labels.has('zaphod-blocked');
 
             // Three-state UX for Human Approved:
             //
@@ -112,12 +112,12 @@ jobs:
                 name: 'Human Approved',
                 pending: !humanApproved,
                 pendingTitle: 'Needs human review',
-                pendingSummary: 'Apply the `✨ human-approved` label once you have reviewed the PR.',
+                pendingSummary: 'Apply the `approved-human` label once you have reviewed the PR.',
                 conclusion: humanApproved ? 'success' : 'action_required',
                 title: humanApproved ? 'Josh signed off' : 'Approval was withdrawn',
                 summary: humanApproved
-                  ? 'The `✨ human-approved` label is present.'
-                  : 'The `✨ human-approved` label was previously applied and has been removed (likely by a new commit). Re-apply it after re-reviewing.',
+                  ? 'The `approved-human` label is present.'
+                  : 'The `approved-human` label was previously applied and has been removed (likely by a new commit). Re-apply it after re-reviewing.',
               },
               {
                 name: 'AI Review Passed',
@@ -125,7 +125,7 @@ jobs:
                 conclusion: actionRequired ? 'failure' : 'success',
                 title: actionRequired ? 'AI reviewer left items to resolve' : 'AI review passed',
                 summary: actionRequired
-                  ? 'Resolve the `zz action-required` items and remove the label before merging.'
+                  ? 'Resolve the `zaphod-blocked` items and remove the label before merging.'
                   : 'No unresolved AI reviewer comments.',
               },
             ];

--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -90,39 +90,43 @@ jobs:
 
             // Three-state UX for Human Approved:
             //
-            // 1. Label absent on a fresh PR (no prior check) → DON'T POST.
-            //    The ruleset surfaces this as the native "Expected — Waiting
-            //    for status to be reported" pending state. Most accurate
-            //    representation: the gate hasn't reached a verdict yet.
+            // 1. Label absent on a fresh PR → post status=queued with custom
+            //    text "Needs human review". Yellow pending dot in the UI,
+            //    blocks merge, and the message is ours rather than GitHub's
+            //    default "Expected — Waiting for status to be reported".
+            //    `queued` is more honest than `in_progress`: the gate is
+            //    scheduled but isn't actually running, it's idle waiting
+            //    for input.
             // 2. Label applied → success (green ✓).
             // 3. Label was applied and is now absent (e.g. the synchronize
             //    handler stripped it on a new commit) → action_required.
             //    Loud red/orange signal so a previously-approved PR doesn't
-            //    silently fall back to "waiting" without anyone noticing
-            //    the approval went away.
+            //    silently fall back to yellow without anyone noticing the
+            //    approval went away.
             //
-            // AI Review Passed has a meaningful default state on every PR
-            // (no action-required label = passing), so it always posts.
+            // AI Review Passed has a meaningful default on every PR (no
+            // action-required label = passing), so it always posts a
+            // completed check with a definitive conclusion.
             const checks = [
               {
                 name: 'Human Approved',
-                shouldPost: 'human-approved',
+                pending: !humanApproved,
+                pendingTitle: 'Needs human review',
+                pendingSummary: 'Apply the `👮 human-approved` label once you have reviewed the PR.',
                 conclusion: humanApproved ? 'success' : 'action_required',
-                title: humanApproved ? 'Josh signed off' : 'Waiting on 👮 human-approved label',
+                title: humanApproved ? 'Josh signed off' : 'Approval was withdrawn',
                 summary: humanApproved
                   ? 'The `👮 human-approved` label is present.'
-                  : 'Apply the `👮 human-approved` label once you have reviewed the PR.',
-                conditionMet: humanApproved,
+                  : 'The `👮 human-approved` label was previously applied and has been removed (likely by a new commit). Re-apply it after re-reviewing.',
               },
               {
                 name: 'AI Review Passed',
-                shouldPost: 'always',
+                pending: false,
                 conclusion: actionRequired ? 'failure' : 'success',
                 title: actionRequired ? 'AI reviewer left items to resolve' : 'AI review passed',
                 summary: actionRequired
                   ? 'Resolve the `🤖 action-required` items and remove the label before merging.'
                   : 'No unresolved AI reviewer comments.',
-                conditionMet: !actionRequired,
               },
             ];
 
@@ -135,21 +139,37 @@ jobs:
               });
               const hasExisting = existing.data.check_runs.length > 0;
 
-              // The "skip first post" rule: if the condition isn't met yet
-              // and we've never posted on this commit, leave the slot empty
-              // so the ruleset shows native "Expected — Waiting".
-              if (!check.conditionMet && !hasExisting && check.shouldPost === 'human-approved') {
-                core.info(`Skipping first post of ${check.name}; ruleset will show "Expected — Waiting".`);
-                continue;
+              let payload;
+              if (check.pending && !hasExisting) {
+                // First post on this commit, condition not yet met → queued
+                // with custom text. Subsequent events on the same commit
+                // either resolve it (success / action_required) or stay in
+                // queued via update.
+                payload = {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  status: 'queued',
+                  output: { title: check.pendingTitle, summary: check.pendingSummary },
+                };
+              } else if (check.pending && hasExisting) {
+                // Existing check + condition no longer met → un-approve
+                // path, surface as action_required with the un-approve copy.
+                payload = {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  status: 'completed',
+                  conclusion: check.conclusion,
+                  output: { title: check.title, summary: check.summary },
+                };
+              } else {
+                payload = {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  status: 'completed',
+                  conclusion: check.conclusion,
+                  output: { title: check.title, summary: check.summary },
+                };
               }
-
-              const payload = {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                status: 'completed',
-                conclusion: check.conclusion,
-                output: { title: check.title, summary: check.summary },
-              };
               if (hasExisting) {
                 await github.rest.checks.update({
                   ...payload,

--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -88,29 +88,41 @@ jobs:
             const humanApproved = labels.has('👮 human-approved');
             const actionRequired = labels.has('🤖 action-required');
 
-            // Each entry either resolves the check to a definitive state
-            // (success / failure) when we know the answer, or leaves it
-            // "in progress" so the PR UI shows a yellow pending dot rather
-            // than a red X when the human hasn't labelled yet. The ruleset
-            // still blocks merge on anything that isn't success.
+            // Three-state UX for Human Approved:
+            //
+            // 1. Label absent on a fresh PR (no prior check) → DON'T POST.
+            //    The ruleset surfaces this as the native "Expected — Waiting
+            //    for status to be reported" pending state. Most accurate
+            //    representation: the gate hasn't reached a verdict yet.
+            // 2. Label applied → success (green ✓).
+            // 3. Label was applied and is now absent (e.g. the synchronize
+            //    handler stripped it on a new commit) → action_required.
+            //    Loud red/orange signal so a previously-approved PR doesn't
+            //    silently fall back to "waiting" without anyone noticing
+            //    the approval went away.
+            //
+            // AI Review Passed has a meaningful default state on every PR
+            // (no action-required label = passing), so it always posts.
             const checks = [
               {
                 name: 'Human Approved',
-                pending: !humanApproved,
-                conclusion: 'success',
+                shouldPost: 'human-approved',
+                conclusion: humanApproved ? 'success' : 'action_required',
                 title: humanApproved ? 'Josh signed off' : 'Waiting on 👮 human-approved label',
                 summary: humanApproved
                   ? 'The `👮 human-approved` label is present.'
                   : 'Apply the `👮 human-approved` label once you have reviewed the PR.',
+                conditionMet: humanApproved,
               },
               {
                 name: 'AI Review Passed',
-                pending: false,
+                shouldPost: 'always',
                 conclusion: actionRequired ? 'failure' : 'success',
                 title: actionRequired ? 'AI reviewer left items to resolve' : 'AI review passed',
                 summary: actionRequired
                   ? 'Resolve the `🤖 action-required` items and remove the label before merging.'
                   : 'No unresolved AI reviewer comments.',
+                conditionMet: !actionRequired,
               },
             ];
 
@@ -121,21 +133,24 @@ jobs:
                 ref: targetSha,
                 check_name: check.name,
               });
-              const payload = check.pending
-                ? {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    status: 'in_progress',
-                    output: { title: check.title, summary: check.summary },
-                  }
-                : {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    status: 'completed',
-                    conclusion: check.conclusion,
-                    output: { title: check.title, summary: check.summary },
-                  };
-              if (existing.data.check_runs.length > 0) {
+              const hasExisting = existing.data.check_runs.length > 0;
+
+              // The "skip first post" rule: if the condition isn't met yet
+              // and we've never posted on this commit, leave the slot empty
+              // so the ruleset shows native "Expected — Waiting".
+              if (!check.conditionMet && !hasExisting && check.shouldPost === 'human-approved') {
+                core.info(`Skipping first post of ${check.name}; ruleset will show "Expected — Waiting".`);
+                continue;
+              }
+
+              const payload = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                status: 'completed',
+                conclusion: check.conclusion,
+                output: { title: check.title, summary: check.summary },
+              };
+              if (hasExisting) {
                 await github.rest.checks.update({
                   ...payload,
                   check_run_id: existing.data.check_runs[0].id,

--- a/.github/workflows/human-approved-guard.yml
+++ b/.github/workflows/human-approved-guard.yml
@@ -13,9 +13,9 @@ jobs:
   verify-sender:
     name: Strip restricted label if applied by unauthorised actor
     if: >-
-      github.event.label.name == '👮 human-approved' ||
-      github.event.label.name == '🤖 action-required' ||
-      github.event.label.name == '🤖 ai-approved'
+      github.event.label.name == '✨ human-approved' ||
+      github.event.label.name == '~action-required' ||
+      github.event.label.name == '~ai-approved'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -25,16 +25,16 @@ jobs:
           MAINTAINER: J-Melon
         with:
           script: |
-            // Each restricted label has its own allow-list. 👮 human-approved
+            // Each restricted label has its own allow-list. ✨ human-approved
             // is Josh-only. The bot labels can be applied by Josh OR by
             // github-actions workflow runs (sender.login is then
             // 'github-actions[bot]').
             const labelName = context.payload.label.name;
             const maintainer = process.env.MAINTAINER;
             const policy = {
-              '👮 human-approved': new Set([maintainer]),
-              '🤖 action-required': new Set([maintainer, 'github-actions[bot]']),
-              '🤖 ai-approved': new Set([maintainer, 'github-actions[bot]']),
+              '✨ human-approved': new Set([maintainer]),
+              '~action-required': new Set([maintainer, 'github-actions[bot]']),
+              '~ai-approved': new Set([maintainer, 'github-actions[bot]']),
             };
             const allowed = policy[labelName];
             if (!allowed) {

--- a/.github/workflows/human-approved-guard.yml
+++ b/.github/workflows/human-approved-guard.yml
@@ -14,8 +14,8 @@ jobs:
     name: Strip restricted label if applied by unauthorised actor
     if: >-
       github.event.label.name == '✨ human-approved' ||
-      github.event.label.name == '~action-required' ||
-      github.event.label.name == '~ai-approved'
+      github.event.label.name == 'zz action-required' ||
+      github.event.label.name == 'zz ai-approved'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -33,8 +33,8 @@ jobs:
             const maintainer = process.env.MAINTAINER;
             const policy = {
               '✨ human-approved': new Set([maintainer]),
-              '~action-required': new Set([maintainer, 'github-actions[bot]']),
-              '~ai-approved': new Set([maintainer, 'github-actions[bot]']),
+              'zz action-required': new Set([maintainer, 'github-actions[bot]']),
+              'zz ai-approved': new Set([maintainer, 'github-actions[bot]']),
             };
             const allowed = policy[labelName];
             if (!allowed) {

--- a/.github/workflows/human-approved-guard.yml
+++ b/.github/workflows/human-approved-guard.yml
@@ -13,9 +13,9 @@ jobs:
   verify-sender:
     name: Strip restricted label if applied by unauthorised actor
     if: >-
-      github.event.label.name == '✨ human-approved' ||
-      github.event.label.name == 'zz action-required' ||
-      github.event.label.name == 'zz ai-approved'
+      github.event.label.name == 'approved-human' ||
+      github.event.label.name == 'zaphod-blocked' ||
+      github.event.label.name == 'zaphod-approved'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -25,16 +25,16 @@ jobs:
           MAINTAINER: J-Melon
         with:
           script: |
-            // Each restricted label has its own allow-list. ✨ human-approved
+            // Each restricted label has its own allow-list. approved-human
             // is Josh-only. The bot labels can be applied by Josh OR by
             // github-actions workflow runs (sender.login is then
             // 'github-actions[bot]').
             const labelName = context.payload.label.name;
             const maintainer = process.env.MAINTAINER;
             const policy = {
-              '✨ human-approved': new Set([maintainer]),
-              'zz action-required': new Set([maintainer, 'github-actions[bot]']),
-              'zz ai-approved': new Set([maintainer, 'github-actions[bot]']),
+              'approved-human': new Set([maintainer]),
+              'zaphod-blocked': new Set([maintainer, 'github-actions[bot]']),
+              'zaphod-approved': new Set([maintainer, 'github-actions[bot]']),
             };
             const allowed = policy[labelName];
             if (!allowed) {

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -22,7 +22,7 @@ Live scratchpad for parallel agent work. One agent per Linear ticket. Log progre
    - **Mechanical fixes** (typos, dead code, obvious bugs, style): commit on the PR branch.
    - **Everything else**: short line-anchored review comments following [Conventional Comments](https://conventionalcomments.org/) (`praise:`, `nitpick:`, `suggestion:`, `issue:`, `question:`, `thought:`, `chore:`, `note:`, with decorators like `(non-blocking)`). **One idea per comment, two sentences max.** If it needs more context, open an issue and link from the comment.
 
-   After all specialists finish: clean → `gh pr edit <N> --add-label '🤖 ai-approved'`. Any comments → `--add-label '🤖 action-required'` instead. No `LGTM` or summary comments. Line-anchored comment template:
+   After all specialists finish: clean → `gh pr edit <N> --add-label '~ai-approved'`. Any comments → `--add-label '~action-required'` instead. No `LGTM` or summary comments. Line-anchored comment template:
 
    ```
    gh api -X POST repos/shuck-dev/volley/pulls/<N>/comments \

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -22,7 +22,7 @@ Live scratchpad for parallel agent work. One agent per Linear ticket. Log progre
    - **Mechanical fixes** (typos, dead code, obvious bugs, style): commit on the PR branch.
    - **Everything else**: short line-anchored review comments following [Conventional Comments](https://conventionalcomments.org/) (`praise:`, `nitpick:`, `suggestion:`, `issue:`, `question:`, `thought:`, `chore:`, `note:`, with decorators like `(non-blocking)`). **One idea per comment, two sentences max.** If it needs more context, open an issue and link from the comment.
 
-   After all specialists finish: clean → `gh pr edit <N> --add-label 'zz ai-approved'`. Any comments → `--add-label 'zz action-required'` instead. No `LGTM` or summary comments. Line-anchored comment template:
+   After all specialists finish: clean → `gh pr edit <N> --add-label 'zaphod-approved'`. Any comments → `--add-label 'zaphod-blocked'` instead. No `LGTM` or summary comments. Line-anchored comment template:
 
    ```
    gh api -X POST repos/shuck-dev/volley/pulls/<N>/comments \

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -32,7 +32,7 @@ Live scratchpad for parallel agent work. One agent per Linear ticket. Log progre
 6. **Hand off.** Re-sync against main, then report the PR to Josh. Don't flag comments in chat; the PR is the source of truth.
 7. **Block or spin.** Loop on the same issue twice → escalate (see below). Do not try a third variant silently.
 
-**Follow-up review** (Josh asks for another pass on an existing PR): dispatch a fresh reviewer, post each finding as a line-anchored comment using the template above. If nothing to say, post nothing. Do not auto-apply fixes on follow-ups — Josh responds inline or marks threads Resolved.
+**Follow-up review** (Josh asks for another pass on an existing PR): dispatch a fresh reviewer, post each finding as a line-anchored comment using the template above. If nothing to say, post nothing. Do not auto-apply fixes on follow-ups; Josh responds inline or marks threads Resolved.
 
 ---
 
@@ -42,7 +42,7 @@ Live scratchpad for parallel agent work. One agent per Linear ticket. Log progre
 - **Worktree cleanup on merge.** After a PR merges: `git worktree remove ../volley-sh-N && git branch -D sh-N-...`. Alive agent is responsible; otherwise periodic `git worktree list && git worktree prune`.
 - **Never rebase; merge main in.** Use `git merge main`, never `git rebase`. If a rebase is genuinely needed, stop and ask Josh. Josh merges PRs, not agents.
 - **No amending, no force-push.** Add a new commit on top instead of `--amend`. Don't `push --force` or `--force-with-lease`. Intermediate noise is fine; squash-merge collapses it. Only amend/force when Josh explicitly asks.
-- **Fresh branch after a PR merges.** Never pile commits onto a branch whose PR already merged. If `git push` says `remote: Create a pull request for '<branch>'` on a branch you thought was live, origin deleted it — stop and cut a fresh branch off `origin/main`.
+- **Fresh branch after a PR merges.** Never pile commits onto a branch whose PR already merged. If `git push` says `remote: Create a pull request for '<branch>'` on a branch you thought was live, origin deleted it; stop and cut a fresh branch off `origin/main`.
 - **`./scripts/ci/run_gut.sh` after every code change.** Iterate until green. Lefthook fires on `git commit`; don't invoke it manually.
 - **Merge queue serialises main.** Clicking "Merge when ready" pulls the PR into a `merge_group` ref, re-runs lint+test against `main + PR`, then fast-forwards main. The pre-PR `git merge origin/main` still matters: the queue catches mechanical staleness, not semantic conflicts.
 - **Godot tool discipline.** Prefer GodotIQ MCP tools over raw file ops. Never delete-and-rebuild scenes; `node_ops` + `save_scene` for `.tscn`. Godot 4 quirks live in [`godot-quirks.md`](godot-quirks.md).
@@ -58,9 +58,9 @@ Pick the lowest tier that answers the question.
 
 | Tier | Scope | Parallelism | Editor? |
 |---|---|---|---|
-| **0 — Static** | `run_gut.sh`, `validate`, `file_context`, `signal_map`, `impact_check`, `.gd` edits, grep, read | High, headless | No |
-| **1 — Scene edits** | `node_ops`, `build_scene`, `save_scene`, `placement`, `scene_map`, `spatial_audit` | Serial, or parallel via worktrees | Yes, per worktree |
-| **2 — Runtime** | `run(play)`, `state_inspect`, `verify_motion`, `screenshot`, `input`, `ui_map`, `perf_snapshot` | Single-agent, exclusive | Yes, exclusive |
+| **0: Static** | `run_gut.sh`, `validate`, `file_context`, `signal_map`, `impact_check`, `.gd` edits, grep, read | High, headless | No |
+| **1: Scene edits** | `node_ops`, `build_scene`, `save_scene`, `placement`, `scene_map`, `spatial_audit` | Serial, or parallel via worktrees | Yes, per worktree |
+| **2: Runtime** | `run(play)`, `state_inspect`, `verify_motion`, `screenshot`, `input`, `ui_map`, `perf_snapshot` | Single-agent, exclusive | Yes, exclusive |
 
 **Default Tier 0.** Josh's no-playtest rule.
 

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -22,7 +22,7 @@ Live scratchpad for parallel agent work. One agent per Linear ticket. Log progre
    - **Mechanical fixes** (typos, dead code, obvious bugs, style): commit on the PR branch.
    - **Everything else**: short line-anchored review comments following [Conventional Comments](https://conventionalcomments.org/) (`praise:`, `nitpick:`, `suggestion:`, `issue:`, `question:`, `thought:`, `chore:`, `note:`, with decorators like `(non-blocking)`). **One idea per comment, two sentences max.** If it needs more context, open an issue and link from the comment.
 
-   After all specialists finish: clean → `gh pr edit <N> --add-label '~ai-approved'`. Any comments → `--add-label '~action-required'` instead. No `LGTM` or summary comments. Line-anchored comment template:
+   After all specialists finish: clean → `gh pr edit <N> --add-label 'zz ai-approved'`. Any comments → `--add-label 'zz action-required'` instead. No `LGTM` or summary comments. Line-anchored comment template:
 
    ```
    gh api -X POST repos/shuck-dev/volley/pulls/<N>/comments \

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -105,7 +105,7 @@ Separate from intent labels, a small set of GitHub labels are applied automatica
 
 Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `zaphod-approved` is an advisory signal, not a merge decision.
 
-> **About the name.** "Zaphod" is the pan-galactic president from *The Hitchhiker's Guide to the Galaxy* — a two-headed alien whose extra head was added "to do all the lying, swearing and lounging about." The repo's AI reviewer is a chorus of specialists from `.claude/agents/`, so labelling their collective output under one figure with multiple heads fits. The leading `z` is also a sort hack: GitHub's label picker uses the Unicode Collation Algorithm, which treats most punctuation and emoji as primary-ignorable, so the only reliable way to push a label to the bottom of the picker is a text prefix that sorts late alphabetically. `z*` does that; `zaphod-*` happens to do that AND name the labels.
+> **About the name.** "Zaphod" is the pan-galactic president from *The Hitchhiker's Guide to the Galaxy*: a two-headed alien whose extra head was added "to do all the lying, swearing and lounging about." The repo's AI reviewer is a chorus of specialists from `.claude/agents/`, so labelling their collective output under one figure with multiple heads fits. The leading `z` is also a sort hack: GitHub's label picker uses the Unicode Collation Algorithm, which treats most punctuation and emoji as primary-ignorable, so the only reliable way to push a label to the bottom of the picker is a text prefix that sorts late alphabetically. `z*` does that; `zaphod-*` happens to do that AND name the labels.
 
 ### Human review state
 

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -100,10 +100,10 @@ Separate from intent labels, a small set of GitHub labels are applied automatica
 
 ### AI review state
 
-- **`~ai-approved`**: specialist reviewers from `.claude/agents/` passed the PR with no outstanding comments.
-- **`~action-required`**: at least one specialist reviewer left a line-anchored review comment. Blocks merge until resolved. Removed automatically once every review thread on the PR is marked Resolved.
+- **`zz ai-approved`**: specialist reviewers from `.claude/agents/` passed the PR with no outstanding comments.
+- **`zz action-required`**: at least one specialist reviewer left a line-anchored review comment. Blocks merge until resolved. Removed automatically once every review thread on the PR is marked Resolved.
 
-Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `~ai-approved` is an advisory signal, not a merge decision.
+Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `zz ai-approved` is an advisory signal, not a merge decision.
 
 ### Human review state
 
@@ -114,7 +114,7 @@ Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARA
 Two required status checks drive the merge gate:
 
 - **`Human Approved`**: succeeds only when the `✨ human-approved` label is present.
-- **`AI Review Passed`**: succeeds only when the `~action-required` label is absent.
+- **`AI Review Passed`**: succeeds only when the `zz action-required` label is absent.
 
 Both must pass before auto-merge fires. The checks are posted by `.github/workflows/approval-gate.yml` on label events.
 

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -100,21 +100,23 @@ Separate from intent labels, a small set of GitHub labels are applied automatica
 
 ### AI review state
 
-- **`zz ai-approved`**: specialist reviewers from `.claude/agents/` passed the PR with no outstanding comments.
-- **`zz action-required`**: at least one specialist reviewer left a line-anchored review comment. Blocks merge until resolved. Removed automatically once every review thread on the PR is marked Resolved.
+- **`zaphod-approved`**: specialist reviewers from `.claude/agents/` passed the PR with no outstanding comments.
+- **`zaphod-blocked`**: at least one specialist reviewer left a line-anchored review comment. Blocks merge until resolved. Removed automatically once every review thread on the PR is marked Resolved.
 
-Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `zz ai-approved` is an advisory signal, not a merge decision.
+Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `zaphod-approved` is an advisory signal, not a merge decision.
+
+> **About the name.** "Zaphod" is the pan-galactic president from *The Hitchhiker's Guide to the Galaxy* — a two-headed alien whose extra head was added "to do all the lying, swearing and lounging about." The repo's AI reviewer is a chorus of specialists from `.claude/agents/`, so labelling their collective output under one figure with multiple heads fits. The leading `z` is also a sort hack: GitHub's label picker uses the Unicode Collation Algorithm, which treats most punctuation and emoji as primary-ignorable, so the only reliable way to push a label to the bottom of the picker is a text prefix that sorts late alphabetically. `z*` does that; `zaphod-*` happens to do that AND name the labels.
 
 ### Human review state
 
-- **`✨ human-approved`**: Josh has reviewed and signed off. Required for merge.
+- **`approved-human`**: Josh has reviewed and signed off. Required for merge.
 
 ### Merge gate
 
 Two required status checks drive the merge gate:
 
-- **`Human Approved`**: succeeds only when the `✨ human-approved` label is present.
-- **`AI Review Passed`**: succeeds only when the `zz action-required` label is absent.
+- **`Human Approved`**: succeeds only when the `approved-human` label is present.
+- **`AI Review Passed`**: succeeds only when the `zaphod-blocked` label is absent.
 
 Both must pass before auto-merge fires. The checks are posted by `.github/workflows/approval-gate.yml` on label events.
 

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -100,21 +100,21 @@ Separate from intent labels, a small set of GitHub labels are applied automatica
 
 ### AI review state
 
-- **`🤖 ai-approved`**: specialist reviewers from `.claude/agents/` passed the PR with no outstanding comments.
-- **`🤖 action-required`**: at least one specialist reviewer left a line-anchored review comment. Blocks merge until resolved. Removed automatically once every review thread on the PR is marked Resolved.
+- **`~ai-approved`**: specialist reviewers from `.claude/agents/` passed the PR with no outstanding comments.
+- **`~action-required`**: at least one specialist reviewer left a line-anchored review comment. Blocks merge until resolved. Removed automatically once every review thread on the PR is marked Resolved.
 
-Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `🤖 ai-approved` is an advisory signal, not a merge decision.
+Applied by the orchestrator after `gh pr create` per the step 4 flow in `ai/PARALLEL.md`. These reflect AI reviewer output only; `~ai-approved` is an advisory signal, not a merge decision.
 
 ### Human review state
 
-- **`👮 human-approved`**: Josh has reviewed and signed off. Required for merge.
+- **`✨ human-approved`**: Josh has reviewed and signed off. Required for merge.
 
 ### Merge gate
 
 Two required status checks drive the merge gate:
 
-- **`Human Approved`**: succeeds only when the `👮 human-approved` label is present.
-- **`AI Review Passed`**: succeeds only when the `🤖 action-required` label is absent.
+- **`Human Approved`**: succeeds only when the `✨ human-approved` label is present.
+- **`AI Review Passed`**: succeeds only when the `~action-required` label is absent.
 
 Both must pass before auto-merge fires. The checks are posted by `.github/workflows/approval-gate.yml` on label events.
 


### PR DESCRIPTION
Follow-up to #271. Replaces the always-post in_progress pattern with a three-state model: don't post on first push (ruleset shows native "Expected — Waiting"), success on label apply, action_required if the label is later stripped. The loud red-X on un-approve is deliberate — previously-approved PRs that lose their approval deserve a visible signal, not a silent slide back to yellow.