### PR TITLE
ci: zaphod prefix on dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     reviewers:
       - J-Melon
     labels:
-      - dependencies
-      - github-actions
+      - zaphod-dep
+      - zaphod-dep-action
     rebase-strategy: disabled
 
   - package-ecosystem: pip
@@ -22,6 +22,6 @@ updates:
     reviewers:
       - J-Melon
     labels:
-      - dependencies
-      - python
+      - zaphod-dep
+      - zaphod-dep-pip
     rebase-strategy: disabled

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -124,8 +124,8 @@ Both must pass before auto-merge fires. The checks are posted by `.github/workfl
 
 ### Dependency updates
 
-- **`dependencies`**: the PR updates a third-party package. Applied by Dependabot.
-- **`github-actions`**: the dependency is a GitHub Action.
-- **`python`**: the dependency is a Python package from `requirements-dev.txt`.
+- **`zaphod-dep`**: the PR updates a third-party package. Applied by Dependabot.
+- **`zaphod-dep-action`**: the dependency is a GitHub Action.
+- **`zaphod-dep-pip`**: the dependency is a Python package from `requirements-dev.txt`.
 
-Pinned in `.github/dependabot.yml` per ecosystem.
+Pinned in `.github/dependabot.yml` per ecosystem. The `zaphod-` prefix groups every bot-applied label together at the bottom of the picker — Dependabot is treated as another head of the same Zaphod that handles AI review.


### PR DESCRIPTION
Bot-applied labels all live under the `zaphod-*` namespace now, so the picker bottom is one tidy cluster.

- `dependencies` → `zaphod-dep`
- `github-actions` → `zaphod-dep-action`
- new `zaphod-dep-pip` (previous `python` label was missing)