### PR TITLE
ci: DCO skips merge commits and bot authors

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -50,9 +50,11 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # `git log BASE..HEAD` lists exactly the commits the PR adds to the
-          # base branch, skipping any main commits already present.
-          commits=$(git log --format='%H' "${BASE_SHA}..${HEAD_SHA}")
+          # `git log BASE..HEAD --no-merges` lists exactly the commits the PR
+          # adds to the base branch, skipping commits already on main AND
+          # skipping merge commits (merges aren't authored content; the
+          # upstream DCO app skips them too).
+          commits=$(git log --no-merges --format='%H' "${BASE_SHA}..${HEAD_SHA}")
           if [[ -z "$commits" ]]; then
               echo "No new commits in PR; nothing to check."
               exit 0
@@ -61,6 +63,14 @@ jobs:
           while IFS= read -r sha; do
               author_name=$(git log -1 --format='%an' "$sha")
               author_email=$(git log -1 --format='%ae' "$sha")
+              # Skip bot authors (dependabot[bot], github-actions[bot], etc.).
+              # GitHub bots commit via API and don't add Signed-off-by; the
+              # DCO they're attesting to is implicit in their being a trusted
+              # automation account, not a human contribution.
+              if [[ "$author_name" == *"[bot]" ]]; then
+                  printf '  skip  %s  %s  (bot author: %s)\n' "${sha:0:7}" "$(git log -1 --format='%s' "$sha")" "$author_name"
+                  continue
+              fi
               expected="Signed-off-by: ${author_name} <${author_email}>"
               # Search the full commit message (subject + body) for the
               # exact Signed-off-by line matching the commit's author.


### PR DESCRIPTION
Two follow-ups to #276:

1. `--no-merges` on the `git log` call so merge commits aren't checked (they don't carry sign-offs).
2. Skip `*[bot]` author commits (Dependabot, GitHub Actions, etc.) so bot PRs aren't blocked.

Both align with upstream DCO-app behaviour and unblock the queued Dependabot PRs.