### PR TITLE
fix: create fresh check-runs in approval-gate to unblock merge queue

### DIFF
--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -130,6 +130,15 @@ jobs:
               },
             ];
 
+            // listForRef still drives the three-state UX detection: on the
+            // same sha, a prior run signals the un-approve path rather than
+            // the fresh-PR path. But we always create a new check-run rather
+            // than updating the prior one. GitHub's merge queue evaluator
+            // does not consistently count `checks.update` results as
+            // satisfying required status checks on the current head sha;
+            // freshly created runs always do. The cost is a modestly
+            // longer check-runs list in the UI, which GitHub collapses to
+            // the latest per name when displaying status.
             for (const check of checks) {
               const existing = await github.rest.checks.listForRef({
                 owner: context.repo.owner,
@@ -142,44 +151,35 @@ jobs:
               let payload;
               if (check.pending && !hasExisting) {
                 // First post on this commit, condition not yet met → queued
-                // with custom text. Subsequent events on the same commit
-                // either resolve it (success / action_required) or stay in
-                // queued via update.
+                // with custom text. Any subsequent event on the same commit
+                // creates a new run that either resolves it (success /
+                // action_required) or posts queued again.
                 payload = {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
                   status: 'queued',
                   output: { title: check.pendingTitle, summary: check.pendingSummary },
                 };
               } else if (check.pending && hasExisting) {
-                // Existing check + condition no longer met → un-approve
-                // path, surface as action_required with the un-approve copy.
+                // Prior run on this sha + condition no longer met → the
+                // un-approve path. Post as action_required with the
+                // un-approve copy.
                 payload = {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
                   status: 'completed',
                   conclusion: check.conclusion,
                   output: { title: check.title, summary: check.summary },
                 };
               } else {
                 payload = {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
                   status: 'completed',
                   conclusion: check.conclusion,
                   output: { title: check.title, summary: check.summary },
                 };
               }
-              if (hasExisting) {
-                await github.rest.checks.update({
-                  ...payload,
-                  check_run_id: existing.data.check_runs[0].id,
-                });
-              } else {
-                await github.rest.checks.create({
-                  ...payload,
-                  name: check.name,
-                  head_sha: targetSha,
-                });
-              }
+
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: check.name,
+                head_sha: targetSha,
+                ...payload,
+              });
             }


### PR DESCRIPTION
The merge queue evaluator on the `main` ruleset does not consistently count `checks.update` results as satisfying required status checks on the current head SHA. PR #282 merged only via `--admin` because every required check showed `success` in the check-runs REST API while `enqueuePullRequest` returned "Pull request 2 of 4 required status checks are expected."

`approval-gate.yml` now always creates new check-runs rather than updating prior ones. The three-state UX (queued on a fresh PR, success when approved, action_required on un-approve) stays intact; detection still uses `listForRef`, the behaviour change is that we create a new run every time rather than mutating the prior one. Expected minor cost: a longer check-runs list on PRs that cycle labels multiple times on one commit, which GitHub collapses to the latest per name in the UI.

This PR is also a regression test. If it lands through the merge queue without an `--admin` override, the fix is confirmed.