### PR TITLE
ci: prune redundant approval-gate and autolabel-pr runs

### DIFF
--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -31,6 +31,17 @@ jobs:
     name: Post approval checks
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # Skip the job when a labeled/unlabeled event touches a category label
+    # (feature, bug, autolabel additions) rather than an approval label.
+    # Category labels carry no approval signal, so re-running the gate
+    # wastes a billed minute per event. Approval labels (approved-human,
+    # zaphod-approved, zaphod-blocked) must always run; synchronize,
+    # opened, reopened, merge_group, and workflow_dispatch always run.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'approved-human' ||
+      startsWith(github.event.label.name, 'zaphod-')
     steps:
       - name: Strip human-approved on new commits
         if: github.event_name == 'pull_request_target' && github.event.action == 'synchronize'

--- a/.github/workflows/autolabel-pr.yml
+++ b/.github/workflows/autolabel-pr.yml
@@ -2,7 +2,10 @@ name: Autolabel PR
 
 on:
   pull_request:
-    types: [opened, synchronize, edited]
+    # synchronize omitted: PR titles do not change between pushes, and
+    # edited already covers title edits. Dropping synchronize saves a
+    # billed minute per extra commit on a PR.
+    types: [opened, edited]
 
 concurrency:
   group: autolabel-pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Skips approval-gate when a labeled / unlabeled event touches a category label (feature, bug, the drafter set) rather than an approval label. `approved-human` and `zaphod-*` still trigger a full gate run; everything else on `pull_request_target` keeps its existing behaviour.

Drops the `synchronize` trigger from autolabel-pr. PR titles do not change between pushes; the `edited` trigger already covers title edits.

Together these remove roughly one billed minute per PR and one per extra commit on a multi-push PR. Billing is zero today (public repo, unlimited standard-runner minutes), but the pruning also tightens feedback by removing runs that posted no new information.