### PR TITLE
docs: swarm README and post-review helper (SH-156, SH-157, SH-158)

### DIFF
--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -179,6 +179,8 @@ When the verdict is `zaphod-blocked`, the organiser posts a GitHub pull request 
 
 Reviewers never post standalone issue comments on PRs; all actionable feedback lives as line-anchored review comments so Josh can resolve them as they are addressed.
 
+Every review comment gets a threaded reply from whoever addresses it, naming the concrete edit and the commit SHA. That holds for Josh's comments and for reviewer-agent comments the organiser posted on their behalf. Silent fixes are not acceptable even when the diff would make the change obvious; the reply is what closes the loop inline for mobile readers and leaves a per-comment audit trail. Questions get answered, not resolved by code; preference-level nits that are kept as-is get a one-line reason, once, and the reviewer decides from there. Use `gh api repos/OWNER/REPO/pulls/{pr}/comments/{comment_id}/replies` to thread; never post a new top-level comment in place of a reply.
+
 On any follow-up push, the organiser re-dispatches the relevant reviewers and re-applies whatever they return. The prior verdict does not carry, and a `reviewer-re-run` workflow strips `zaphod-*` labels on every new commit to force the re-apply.
 
 The organiser may queue auto-merge with `gh pr merge --auto --squash` once `zaphod-approved` is on the PR. Auto-merge will not fire until `approved-human` lands, so Josh stays the gate. Direct merge is forbidden. No rebases, no amends, no force pushes, ever.

--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -175,7 +175,9 @@ When the verdict is `zaphod-approved`, the organiser applies the label with `gh 
 
 When the verdict is `zaphod-blocked`, the organiser posts a GitHub pull request review with the summary as the review body and each `item` as an inline review comment on its line, via `gh api repos/:owner/:repo/pulls/:pr/reviews` with `event: COMMENT`. Inline review comments are resolvable in the PR UI, so fixes close threads naturally. The organiser then applies `zaphod-blocked`.
 
-Reviewers never post standalone issue comments on PRs; all actionable feedback lives as line-anchored review comments so Josh can resolve them as they are addressed. The organiser uses `--body-file -` or JSON-on-stdin for every GitHub write, never inline shell interpolation.
+`scripts/swarm/post-review.sh` wraps that posting surface: pass a PR number and a verdict JSON file in the shape above, and the script handles structure validation, payload construction with `jq`, the `gh api` post, and the label. It pipes JSON via stdin rather than shell-interpolating comment text, so reviewer prose can carry any punctuation without escaping back into the shell. Approved verdicts apply the label only; blocked verdicts post the review first.
+
+Reviewers never post standalone issue comments on PRs; all actionable feedback lives as line-anchored review comments so Josh can resolve them as they are addressed.
 
 On any follow-up push, the organiser re-dispatches the relevant reviewers and re-applies whatever they return. The prior verdict does not carry, and a `reviewer-re-run` workflow strips `zaphod-*` labels on every new commit to force the re-apply.
 

--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -183,6 +183,14 @@ On any follow-up push, the organiser re-dispatches the relevant reviewers and re
 
 The organiser may queue auto-merge with `gh pr merge --auto --squash` once `zaphod-approved` is on the PR. Auto-merge will not fire until `approved-human` lands, so Josh stays the gate. Direct merge is forbidden. No rebases, no amends, no force pushes, ever.
 
+### Reviewer dispatch discipline
+
+Reviewer agents must review the PR under review, not whatever the working tree happens to show. Three rules make that hold:
+
+- **Reviewers see the PR's diff, not the disk.** If a reviewer's toolset includes `Bash`, the organiser instructs it to read via `gh pr diff <N>` (or `gh api repos/:owner/:repo/pulls/:pr/files`). If the reviewer lacks `Bash` (the existing reactive pool is `Read, Grep, Glob` only), the organiser pre-fetches the diff and pastes it into the prompt. Reading the on-disk file is only safe when the working tree is guaranteed to match the PR branch, which is rarely true in parallel swarm work.
+- **Organiser holds the branch between dispatch and return.** Switching branches while a reviewer is in flight changes what the reviewer reads. The organiser either stays on the PR branch until every reviewer in the fan-out has reported, or dispatches reviewers with `isolation: "worktree"` so they read an isolated checkout of that branch.
+- **Reviewer verdicts are diff-scoped, not session-scoped.** A verdict applies to the commit it was taken against. The `reviewer-re-run.yml` workflow strips `zaphod-*` labels on every new commit so the next push invalidates the prior verdict automatically; reviewers re-run against the new tip.
+
 ## Fail early on ambiguity
 
 The organiser checks AC and scope against the entity, the design docs, and memory before dispatching. If any of that is unclear, it stops and asks Josh a single precise question. Guessing is not allowed at the entry gate; the cost of a five-minute wait is lower than the cost of five parallel agents building the wrong thing.

--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -34,6 +34,10 @@ Three new reviewers join the eight reactive ones that already ride PRs today.
 
 Existing reviewers, unchanged: `code-quality`, `gdscript-conventions`, `signals-lifecycle`, `test-coverage`, `godot-scene`, `asset-pipeline`, `ci-and-workflows`, `docs-and-writing`.
 
+### Registry reload
+
+Claude Code caches the agent registry at session start. A new `.claude/agents/*.md` that lands mid-session does not route to its declared `subagent_type` until the session is reloaded; calls return "Agent type not found". The fallback that works without a reload is to dispatch as `general-purpose` with the role's codename at the front of the description and the full brief in the prompt; the agent runs the same work, just without the automatic routing hint. New roles should be added at the start of a session, or the fallback used deliberately until the next reload.
+
 ## Naming
 
 Roles are the slots. Codenames are the people filling them today.
@@ -120,6 +124,23 @@ Worked example, a mid-cycle health check: **Trillian**, **Eddie**, **Zephyr**, a
 Spikes use the support team, not the resolver team. `researcher` gathers material. `devils-advocate` stages the failure modes. `supply-chain-scout` scores options where third-party tools are on the table. The organiser compiles a briefing. Josh decides. Only after that does the organiser draft a design stub and follow-up tickets, and it confirms before filing any of them.
 
 Worked example, picking a GDScript linter: **Zephyr** pulls docs for the three candidates; **Bill** writes the adversarial read on each; **Abe** checks provenance and SHA pinning on all three. Josh picks one. **Mabel** drafts the rollout design and the tickets, and asks before submitting.
+
+### Paired dispatch
+
+Some specialists have to ship together because the repo forces their outputs into one commit. The failing-first tests and the implementation that makes them green are the standing example: the pre-commit hook runs GUT, so red tests cannot land as a standalone commit. When a repo policy couples two outputs, the swarm couples the specialists.
+
+Two shapes work:
+
+1. **Single dual-role agent.** One prompt carries both roles: "write the failing tests, then the implementation, commit once when green." Simplest; loses the parallelism between the two roles but wins on coordination cost. Use when the roles share almost all of their context.
+2. **Shared worktree handoff.** Dispatch two agents with a pair id; the first writes its half to the worktree and posts `status: ready_to_pair` to an inbox; the organiser reads the signal and dispatches the second agent into the same worktree. They commit as one unit at the end. Preserves role specialisation at the cost of an extra dispatch hop.
+
+Known pair triggers today:
+
+- **Failing tests and implementation** — GUT runs in lefthook pre-commit; red tests block commits. `test-author` pairs with an implementer.
+- Any future "docs with code" gate would pair `docs-tender` with the implementer.
+- Integration-scenario-author may pair with an implementer on the same worktree when the scenario is as load-bearing as the unit tests for the same commit.
+
+Research outputs are not paired. `researcher`, `design-doc-reader`, `refactor-planner`, and `devils-advocate` inform the implementer but do not ship alongside it; they stay independent fan-outs that write to the scratchpad.
 
 ### Merge conflict
 

--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -136,7 +136,7 @@ Two shapes work:
 
 Known pair triggers today:
 
-- **Failing tests and implementation** — GUT runs in lefthook pre-commit; red tests block commits. `test-author` pairs with an implementer.
+- **Failing tests and implementation**: GUT runs in lefthook pre-commit; red tests block commits. `test-author` pairs with an implementer.
 - Any future "docs with code" gate would pair `docs-tender` with the implementer.
 - Integration-scenario-author may pair with an implementer on the same worktree when the scenario is as load-bearing as the unit tests for the same commit.
 

--- a/scripts/swarm/post-review.sh
+++ b/scripts/swarm/post-review.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Posts a swarm reviewer-agent verdict on a pull request.
+#
+# Usage:
+#   scripts/swarm/post-review.sh <pr-number> <verdict-json-file>
+#
+# Verdict JSON shape:
+#   {
+#     "verdict": "zaphod-approved" | "zaphod-blocked",
+#     "summary": "one-sentence overall finding",
+#     "items": [                           # required when blocked
+#       {"path": "<file>", "line": <N>, "body": "<concern and fix>"}
+#     ]
+#   }
+#
+# Behaviour:
+# - zaphod-approved: applies the label; posts nothing. Clean reviews do not
+#   clutter the PR.
+# - zaphod-blocked: posts a GitHub pull-request review with event=COMMENT
+#   (GitHub rejects REQUEST_CHANGES on self-authored PRs), summary as the
+#   review body, and each item as a line-anchored review comment on its
+#   path and line. Then applies zaphod-blocked.
+#
+# The script always pipes JSON via stdin to `gh api`, never builds the
+# payload by interpolating strings into a shell command, so reviewer
+# comment text cannot escape into the shell.
+
+set -euo pipefail
+
+die() {
+	printf 'post-review: %s\n' "$*" >&2
+	exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+	die "usage: $0 <pr-number> <verdict-json-file>"
+fi
+
+pr="$1"
+verdict_file="$2"
+
+[[ "$pr" =~ ^[0-9]+$ ]] || die "pr must be a number, got: $pr"
+[[ -r "$verdict_file" ]] || die "verdict file not readable: $verdict_file"
+
+command -v gh >/dev/null || die "gh CLI is required"
+command -v jq >/dev/null || die "jq is required"
+
+verdict=$(jq -r '.verdict // empty' "$verdict_file")
+summary=$(jq -r '.summary // ""' "$verdict_file")
+
+case "$verdict" in
+	zaphod-approved | zaphod-blocked) ;;
+	"") die "verdict field is required (zaphod-approved or zaphod-blocked)" ;;
+	*) die "invalid verdict: $verdict (expected zaphod-approved or zaphod-blocked)" ;;
+esac
+
+if [[ "$verdict" == "zaphod-blocked" ]]; then
+	[[ -n "$summary" ]] || die "summary is required when verdict is zaphod-blocked"
+
+	items_count=$(jq '(.items // []) | length' "$verdict_file")
+	[[ "$items_count" -gt 0 ]] || die "items is required and non-empty when verdict is zaphod-blocked"
+
+	missing=$(jq -r '[(.items // [])[] | select((.path // "") == "" or (.line // null) == null)] | length' "$verdict_file")
+	[[ "$missing" == "0" ]] || die "every item must carry path and line (got $missing malformed)"
+
+	repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+	payload=$(
+		jq -n \
+			--arg summary "$summary" \
+			--slurpfile verdict "$verdict_file" \
+			'{
+				event: "COMMENT",
+				body: $summary,
+				comments: ($verdict[0].items | map({path, line, side: "RIGHT", body}))
+			}'
+	)
+
+	printf '%s' "$payload" \
+		| gh api "repos/${repo}/pulls/${pr}/reviews" --method POST --input - \
+			--jq '"posted review: \(.html_url)"'
+fi
+
+gh pr edit "$pr" --add-label "$verdict" >/dev/null
+printf 'applied label: %s\n' "$verdict"


### PR DESCRIPTION
Documents three gaps surfaced on the SH-96 swarm run, ships the helper script for verdict posting, and codifies the dispatch-discipline lessons from this very PR.

- **Registry reload** (SH-156): Claude Code caches `.claude/agents/*.md` at session start; new role files do not route until reload. Added a subsection under the pools naming the caveat and the general-purpose fallback.
- **Paired dispatch** (SH-157): when repo policy forces two outputs into one commit (pre-commit GUT run blocks red tests), the swarm couples the specialists. Added a Paired dispatch recipe section with the two working shapes and current pair triggers.
- **post-review helper** (SH-158): `scripts/swarm/post-review.sh` wraps `gh api pulls/.../reviews` so reviewer verdicts post with structure validation, jq-built payloads, and JSON-on-stdin (no shell interpolation of comment text). Approved verdicts apply only the label; blocked verdicts post the review first.
- **Reviewer dispatch discipline** (bundled findings): added a subsection under PR verdicts and merge covering three rules that came out of this PR itself: reviewers see the PR diff not the on-disk file, organiser holds the branch between dispatch and return, verdicts are diff-scoped and invalidated by the reviewer-re-run workflow on every new commit.

Closes SH-156, SH-157, SH-158.