### PR TITLE
SH-107 docs: validate court bounds and miss spike

### DIFF
--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -110,6 +110,7 @@ See [`release-playbook.md`](release-playbook.md). Agents read it only when Josh 
 
 | Agent | Ticket | Branch | Files touched | Started | Notes |
 |---|---|---|---|---|---|
+| Feldspar | SH-107 | sh-107-court-bounds-and-miss | designs/01-prototype/08-court-bounds.md | 2026-04-21 | spike: bounds, miss, rest, upgrade path |
 
 ## Done (recent)
 
@@ -129,5 +130,6 @@ See [`release-playbook.md`](release-playbook.md). Agents read it only when Josh 
 Newest at top. One line per event.
 
 ```
+[SH-107] feldspar: claimed spike; validating 08-court-bounds.md against ticket open questions
 [init] scratchpad reset on cycle #3 open
 ```

--- a/designs/01-prototype/08-court-bounds.md
+++ b/designs/01-prototype/08-court-bounds.md
@@ -62,6 +62,24 @@ Bounces and misses read distinctly:
 
 All three are audio + world-space only. No screen-space banners (per venue diegetic rule).
 
+### Physics at the court boundary
+
+While the rally is alive, balls live in a physics volume that treats them as weightless. Their `gravity_scale` is `0` and linear damping is off; every bounce is pong-crisp, and energy comes from the paddle, not from falling. The court's `Area2D` is what applies this treatment.
+
+A miss trigger (goal-line or side band) flips the ball out of this state. `gravity_scale` rises to `1`. Linear damping kicks in. The ball retains whatever velocity it had at the moment of the cross, so a fast ball sails further before it lands; a slow one drops almost immediately. From there it rolls across the venue floor, decelerates against friction, and comes to rest.
+
+The transition is a single signal on `Area2D.body_exited`: clear the in-court flag, unlock gravity, engage damping. No interpolation, no blend window. The ball was in play and now it is not.
+
+### In-world framing: the spirit of the volley
+
+A rally is how the spirit of the volley shows up. It is not owned by the player and it does not live in the ball. It answers commitment to the exchange, and it holds the ball up for as long as that commitment keeps paying out. Every return is tribute. The counter is how present the spirit is in this rally, not how many points you have scored.
+
+A miss sends the spirit away. It does not leave in anger; it leaves because there is nothing left to answer. The ball loses what kept it weightless and does what balls do. It falls, rolls, and waits to be summoned again.
+
+A player can call the spirit alone. Partners, when they arrive, do not create it; they amplify it and make it easier to sustain. High-count rallies visibly run hotter: the ball carries the spirit's charge in how it reads, as subtle light, a trail, a weight of sound. A miss drains it; the ball on the venue floor is just a ball.
+
+Later items that extend or revive rallies are gestures of devotion to the spirit. Some plead with it to stay longer. Some call it back after it leaves. Naming them that way gives the system a vocabulary the player can feel rather than read from a stat block.
+
 ---
 
 ## Resting balls in the venue

--- a/designs/01-prototype/08-court-bounds.md
+++ b/designs/01-prototype/08-court-bounds.md
@@ -21,20 +21,6 @@ No side walls. The court visibly opens onto the rest of the venue.
 
 Two bands along the court sides detect sideways exits. Both run the full height of the play area.
 
-```
-  ┌──────────────── top (ceiling, bounce) ────────────────────┐
-  │                                                           │
-  │                 ┆                                miss-out │
-  │         ┌──┐    ┆                                   ┌──┐  │
-  │ behind  │MC│    ┆                                   │  │  │
-  │ paddle  │  │    ┆        in-play court              │  │  │
-  │ space   │  │    ┆                                   │  │  │
-  │         │  │    ┆                                   │  │  │
-  │         └──┘    ┆                                   └──┘  │
-  └──────────────── ground (bounce) ──────────────────────────┘
-                    ↑ vertical miss-line trigger (in front of paddle)
-```
-
 - **In-play region:** bounded by the top (ceiling), the ground (bounce floor), and the miss line to the paddle's court-facing side. A ball inside this region is live.
 - **Miss-line band:** a thin vertical trigger just in front of the paddle's tracking lane. A ball crossing it heading behind the paddle fires a back-miss. The paddle itself sits behind the line; the space further behind the paddle is open venue, not a wall.
 - **Side miss bands:** one on each side, just outside the court's lateral extent. Crossing either fires a side-miss.
@@ -134,13 +120,13 @@ The player will never own enough balls for visual clutter to become a problem at
 
 ## Helper upgrade (future, not in prototype scope)
 
-A `court` role item that automatically fetches rested balls and returns them to the rack. Authoring follows the existing court-item shape:
+A `court` role item: a dog that automatically fetches rested balls and returns them to the rack. Authoring follows the existing court-item shape:
 
 - `role = &"court"` so it snaps to a `Roles/Court` marker on drag-in.
-- Acts as a fixture (see `08-fixtures.md`) if its prop needs to sit in the venue; if a simple behavioural item is enough, it skips the fixture scene and just attaches a controller script.
-- Behaviour: scans for balls with the `resting` flag, walks or teleports a small animated helper to each, returns them to the rack one at a time on an authored cadence.
+- Acts as a fixture (see `08-fixtures.md`) if the dog's prop needs to sit in the venue; if a simple behavioural item is enough, it skips the fixture scene and just attaches a controller script.
+- Behaviour: scans for balls with the `resting` flag, the dog walks or bounds to each one, and carries them back to the rack one at a time on an authored cadence.
 
-The helper reuses the bot's `court` role plumbing; it does not need a new role. Whether it uses the bot's fixture shape or a lighter behavioural item is an implementation choice for its own ticket.
+The dog reuses the bot's `court` role plumbing; it does not need a new role. Whether it uses the bot's fixture shape or a lighter behavioural item is an implementation choice for its own ticket.
 
 ---
 

--- a/designs/01-prototype/08-court-bounds.md
+++ b/designs/01-prototype/08-court-bounds.md
@@ -12,7 +12,7 @@ The court is not a closed box. It sits inside the venue, bounded on three sides 
 |---|---|---|
 | Top | The screen edge | The camera never scrolls up; the top of the frame is a hard ceiling the ball bounces off. |
 | Bottom | The ground | Physical floor; ball bounces off (pong-style). Hitting the floor does not end the rally. |
-| Back | The main character's wall | The goal line. Ball crossing this is a miss. |
+| Back | Behind the main character's paddle lane | The miss line. Ball crossing past the paddle is a miss. |
 | Sides | Open | The ball can leave the court sideways; leaving this way is also a miss. |
 
 No side walls. The court visibly opens onto the rest of the venue.
@@ -22,23 +22,21 @@ No side walls. The court visibly opens onto the rest of the venue.
 Two bands along the court sides detect sideways exits. Both run the full height of the play area.
 
 ```
-  ┌──────────────── top (ceiling, bounce) ────────────────┐
-  │                                                       │
-  │  miss-out  ┆                                 miss-out │
-  │  ┌──┐      ┆                                    ┌──┐  │
-  │  │  │ MC   ┆                                    │  │  │
-  │  │  │ wall ┆           in-play court            │  │  │
-  │  │  │      ┆                                    │  │  │
-  │  │  │ goal ┆                                    │  │  │
-  │  │  │ line ┆                                    │  │  │
-  │  │  │      ┆                                    │  │  │
-  │  └──┘      ┆                                    └──┘  │
-  └──────────────── ground (bounce) ──────────────────────┘
-                  ↑ vertical goal-line trigger
+  ┌──────────────── top (ceiling, bounce) ────────────────────┐
+  │                                                           │
+  │                 ┆                                miss-out │
+  │         ┌──┐    ┆                                   ┌──┐  │
+  │ behind  │MC│    ┆                                   │  │  │
+  │ paddle  │  │    ┆        in-play court              │  │  │
+  │ space   │  │    ┆                                   │  │  │
+  │         │  │    ┆                                   │  │  │
+  │         └──┘    ┆                                   └──┘  │
+  └──────────────── ground (bounce) ──────────────────────────┘
+                    ↑ vertical miss-line trigger (in front of paddle)
 ```
 
-- **In-play region:** bounded by the top (ceiling), the ground (bounce floor), and the goal line at the back. A ball inside this region is live.
-- **Goal-line band:** a thin trigger just behind the main character. Crossing it fires a back-miss.
+- **In-play region:** bounded by the top (ceiling), the ground (bounce floor), and the miss line to the paddle's court-facing side. A ball inside this region is live.
+- **Miss-line band:** a thin vertical trigger just in front of the paddle's tracking lane. A ball crossing it heading behind the paddle fires a back-miss. The paddle itself sits behind the line; the space further behind the paddle is open venue, not a wall.
 - **Side miss bands:** one on each side, just outside the court's lateral extent. Crossing either fires a side-miss.
 
 Detection uses `Area2D` triggers rather than tight collider math: the ball's centre entering a band is the event. This keeps the signal independent of ball radius or rotation quirks.
@@ -49,7 +47,7 @@ Detection uses `Area2D` triggers rather than tight collider math: the ball's cen
 
 A miss ends the current rally. It fires when either:
 
-- The ball crosses the main character's goal line (back-miss, existing miss condition).
+- The ball crosses the main character's miss line (back-miss, existing miss condition).
 - The ball leaves the court sideways without first landing back in play (side-miss).
 
 On miss, the rally counter resets to zero (existing behaviour). The ball does not despawn; it keeps its velocity, rolls out of the court, loses energy on the venue floor, and comes to rest.
@@ -68,7 +66,7 @@ All three are audio + world-space only. No screen-space banners (per venue diege
 
 While the rally is alive, balls live in a physics volume that treats them as weightless. Their `gravity_scale` is `0` and linear damping is off; every bounce is pong-crisp, and energy comes from the paddle, not from falling. The court's `Area2D` is what applies this treatment.
 
-A miss trigger (goal-line or side band) flips the ball out of this state. `gravity_scale` rises to `1`. Linear damping kicks in. The ball retains whatever velocity it had at the moment of the cross, so a fast ball sails further before it lands; a slow one drops almost immediately. From there it rolls across the venue floor, decelerates against friction, and comes to rest.
+A miss trigger (miss line or side band) flips the ball out of this state. `gravity_scale` rises to `1`. Linear damping kicks in. The ball retains whatever velocity it had at the moment of the cross, so a fast ball sails further before it lands; a slow one drops almost immediately. From there it rolls across the venue floor, decelerates against friction, and comes to rest.
 
 The transition is a single signal on `Area2D.body_exited`: clear the in-court flag, unlock gravity, engage damping. No interpolation, no blend window. The ball was in play and now it is not.
 
@@ -151,7 +149,7 @@ The helper reuses the bot's `court` role plumbing; it does not need a new role. 
 From the spike:
 
 1. **Ball-ground interaction.** Pong-style bounce. Hitting the floor does not end the rally.
-2. **Rally-ending condition.** Back-miss (goal line) or side-miss (lateral exit). Both reset the counter.
+2. **Rally-ending condition.** Back-miss (miss line) or side-miss (lateral exit). Both reset the counter.
 3. **Clutter.** Not a real problem at prototype scale. No cap or decay.
 4. **Where rested balls can sit.** Anywhere on the venue floor. No invisible barriers. Rack footprints snap-to-rack instead of resting.
 5. **Auto-serve with one ball resting.** Main character idles; player must re-rack. The helper fixes this later.

--- a/designs/01-prototype/08-court-bounds.md
+++ b/designs/01-prototype/08-court-bounds.md
@@ -22,17 +22,19 @@ No side walls. The court visibly opens onto the rest of the venue.
 Two bands along the court sides detect sideways exits. Both run the full height of the play area.
 
 ```
-  ┌──────────── top (ceiling, bounce) ─────────────┐
-  │                                                │
-  │  miss-out                              miss-out │
-  │  ┌──┐                                    ┌──┐  │
-  │  │  │          in-play court             │  │  │
-  │  │  │                                    │  │  │
-  │  │  │ main character's goal line (back)  │  │  │
-  │  │  │ ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ │  │  │
-  │  │  │          ground (bounce)           │  │  │
-  │  └──┘                                    └──┘  │
-  └────────────── venue floor ─────────────────────┘
+  ┌──────────────── top (ceiling, bounce) ────────────────┐
+  │                                                       │
+  │  miss-out  ┆                                 miss-out │
+  │  ┌──┐      ┆                                    ┌──┐  │
+  │  │  │ MC   ┆                                    │  │  │
+  │  │  │ wall ┆           in-play court            │  │  │
+  │  │  │      ┆                                    │  │  │
+  │  │  │ goal ┆                                    │  │  │
+  │  │  │ line ┆                                    │  │  │
+  │  │  │      ┆                                    │  │  │
+  │  └──┘      ┆                                    └──┘  │
+  └──────────────── ground (bounce) ──────────────────────┘
+                  ↑ vertical goal-line trigger
 ```
 
 - **In-play region:** bounded by the top (ceiling), the ground (bounce floor), and the goal line at the back. A ball inside this region is live.
@@ -76,7 +78,7 @@ A rally is how the spirit of the volley shows up. It is not owned by the player 
 
 A miss sends the spirit away. It does not leave in anger; it leaves because there is nothing left to answer. The ball loses what kept it weightless and does what balls do. It falls, rolls, and waits to be summoned again.
 
-A player can call the spirit alone. Partners, when they arrive, do not create it; they amplify it and make it easier to sustain. High-count rallies visibly run hotter: the ball carries the spirit's charge in how it reads, as subtle light, a trail, a weight of sound. A miss drains it; the ball on the venue floor is just a ball.
+A player can call the spirit alone. Partners, when they arrive, do not create it; they amplify it and make it easier to sustain. High-count rallies visibly run hotter: the ball carries the spirit's charge in how it reads, with a subtle light on it and a weight to its sound. A miss drains it; the ball on the venue floor is just a ball.
 
 Later items that extend or revive rallies are gestures of devotion to the spirit. Some plead with it to stay longer. Some call it back after it leaves. Naming them that way gives the system a vocabulary the player can feel rather than read from a stat block.
 
@@ -167,16 +169,3 @@ Called out so they don't leak into implementation:
 - Miss-ending-the-rally vs miss-ending-this-ball distinction for multiball (handled in `08-balls.md`).
 - Visual polish on the rest-roll deceleration curve; tuned during implementation.
 
----
-
-## Implementation ticket outline
-
-Not filing yet. Rough split, each intended to land independently:
-
-1. **Court bounds geometry.** Top ceiling collider, ground collider, goal-line trigger, two side-miss triggers. Hook the side triggers to the existing miss path. Ceiling bounce + ground bounce behaviour verified.
-2. **Ball rest state.** `resting` flag, deceleration on the venue floor, persistence of rest position and flag across saves and scene reloads.
-3. **Drag rested ball to rack.** Reuse the existing drag-to-rack handler; accept `resting` balls as a valid source. Live rally handling unchanged.
-4. **Side-miss cue.** Audio variant + wall flash on the relevant side. Back-miss cue unchanged.
-5. **Auto-serve when rack is empty.** Idle the main character; no fetch in prototype. (Confirms the friction beat behaves as designed.)
-
-Helper upgrade is its own later ticket and is not part of this prototype slice.

--- a/designs/01-prototype/08-court-bounds.md
+++ b/designs/01-prototype/08-court-bounds.md
@@ -2,7 +2,7 @@
 
 The court is not a closed box. It sits inside the venue, bounded on three sides and open on one; missed balls leave the court and rest on the venue floor until the player puts them back.
 
-**Dependencies:** Venue (`08-venue.md`), Balls (`08-balls.md`), Items (`08-items.md`), Roles (`08-roles.md`).
+**Dependencies:** Venue (`08-venue.md`), Balls (`08-balls.md`), Kit (`08-kit.md`), Items (`08-items.md`), Roles (`08-roles.md`), Fixtures (`08-fixtures.md`).
 
 ---
 
@@ -11,11 +11,35 @@ The court is not a closed box. It sits inside the venue, bounded on three sides 
 | Edge | Bound | Behaviour |
 |---|---|---|
 | Top | The screen edge | The camera never scrolls up; the top of the frame is a hard ceiling the ball bounces off. |
-| Bottom | The ground | Physical floor; existing ball-ground behaviour is unchanged. |
+| Bottom | The ground | Physical floor; ball bounces off (pong-style). Hitting the floor does not end the rally. |
 | Back | The main character's wall | The goal line. Ball crossing this is a miss. |
 | Sides | Open | The ball can leave the court sideways; leaving this way is also a miss. |
 
 No side walls. The court visibly opens onto the rest of the venue.
+
+### Miss-detection regions
+
+Two bands along the court sides detect sideways exits. Both run the full height of the play area.
+
+```
+  ┌──────────── top (ceiling, bounce) ─────────────┐
+  │                                                │
+  │  miss-out                              miss-out │
+  │  ┌──┐                                    ┌──┐  │
+  │  │  │          in-play court             │  │  │
+  │  │  │                                    │  │  │
+  │  │  │ main character's goal line (back)  │  │  │
+  │  │  │ ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ │  │  │
+  │  │  │          ground (bounce)           │  │  │
+  │  └──┘                                    └──┘  │
+  └────────────── venue floor ─────────────────────┘
+```
+
+- **In-play region:** bounded by the top (ceiling), the ground (bounce floor), and the goal line at the back. A ball inside this region is live.
+- **Goal-line band:** a thin trigger just behind the main character. Crossing it fires a back-miss.
+- **Side miss bands:** one on each side, just outside the court's lateral extent. Crossing either fires a side-miss.
+
+Detection uses `Area2D` triggers rather than tight collider math: the ball's centre entering a band is the event. This keeps the signal independent of ball radius or rotation quirks.
 
 ---
 
@@ -23,10 +47,20 @@ No side walls. The court visibly opens onto the rest of the venue.
 
 A miss ends the current rally. It fires when either:
 
-- The ball crosses the main character's goal line (existing miss condition).
-- The ball leaves the court sideways without first landing back in play.
+- The ball crosses the main character's goal line (back-miss, existing miss condition).
+- The ball leaves the court sideways without first landing back in play (side-miss).
 
 On miss, the rally counter resets to zero (existing behaviour). The ball does not despawn; it keeps its velocity, rolls out of the court, loses energy on the venue floor, and comes to rest.
+
+### Cue layering
+
+Bounces and misses read distinctly:
+
+- **Bounce off a bound** (top ceiling, ground): a short tick and a small squash on the bound itself. No camera impact.
+- **Back-miss:** the existing miss beat plays; the main character's wall flashes. Rally counter resets with its current audio.
+- **Side-miss:** a softer, lower-pitched variant of the miss beat. The ball is visibly still alive and rolling; the cue acknowledges the rally ended without pretending the ball is gone.
+
+All three are audio + world-space only. No screen-space banners (per venue diegetic rule).
 
 ---
 
@@ -34,15 +68,27 @@ On miss, the rally counter resets to zero (existing behaviour). The ball does no
 
 A ball that has rolled out of the court sits visibly on the venue floor wherever it stopped. The player can't serve from a rested ball; serves come from the ball rack.
 
-To bring the ball back into play, the player drags it from the venue floor onto the `BallRack`. The ball becomes inactive and is available to drag back onto the court for the next rally.
+To bring the ball back into play, the player drags it from the venue floor onto the `BallRack`. The ball becomes inactive and is available to drag back onto the court for the next rally, or the auto-serve picks it up when the rack's turn comes round (see `08-balls.md`).
 
-Rested balls stay put across rallies, saves, and scene reloads.
+Rested balls stay put across rallies, saves, and scene reloads. Persistence lives alongside the ball's own state: position on the venue floor, last velocity (zero at rest), and the `resting` flag.
 
----
+### Where balls can legally rest
 
-## Helper upgrade (future)
+Balls can come to rest anywhere on the venue floor. They always render in the mid or foreground relative to the shop/workshop backgrounds, so they stay visible regardless of where they land. No invisible barriers around the shop, workshop, or kit areas; those zones absorb the ball and let it roll to a stop like any other floor patch.
 
-A `court` role item that automatically fetches rested balls and returns them to the rack. Not in prototype scope.
+One exception: the ball rack and gear rack themselves are drop targets, not rest surfaces. A ball that enters the rack's footprint snaps into the rack (racked, not resting). This matches the existing drag-to-rack gesture.
+
+### Auto-serve interaction with a resting ball
+
+If the player owns exactly one permanent ball and it is resting on the venue floor at the moment the rally needs a serve:
+
+- The ball rack is empty (the ball is not racked), and the court is empty (the ball is not in play).
+- The main character walks to the rack, finds it empty, and idles.
+- The player must drag the resting ball onto the rack to re-enter the loop.
+
+This is intentional friction. The main character does not fetch rested balls in the prototype; that job belongs to the future helper (below). Making the player re-rack reinforces that a miss has a cost beyond the rally counter reset, and it teaches the rack gesture before the helper takes it away.
+
+If the player owns multiple permanent balls, the auto-serve picks whichever is racked. Rested balls sit out of rotation until re-racked.
 
 ---
 
@@ -56,22 +102,63 @@ If the player drops the ball outside the court bounds without landing on the rac
 
 ## Temporary balls
 
-Temporary balls (frenzy, etc.) clear on their authored expiry regardless of where they land. A missed temporary ball despawns on miss like any other; it does not roll out to rest.
+Temporary balls (frenzy, etc.) clear on their authored expiry regardless of where they land. A missed temporary ball despawns on miss like any other; it does not roll out to rest. A temporary ball that leaves sideways triggers a side-miss the same way a permanent one does, then despawns instead of resting.
+
+This keeps the on-floor population bounded to owned balls only.
+
+---
+
+## Visual clutter
+
+The player will never own enough balls for visual clutter to become a problem at prototype scale. No cap, decay, or cleanup pass is in scope. If later content expands the owned-ball count dramatically, the helper item (below) absorbs the clutter naturally.
+
+---
+
+## Helper upgrade (future, not in prototype scope)
+
+A `court` role item that automatically fetches rested balls and returns them to the rack. Authoring follows the existing court-item shape:
+
+- `role = &"court"` so it snaps to a `Roles/Court` marker on drag-in.
+- Acts as a fixture (see `08-fixtures.md`) if its prop needs to sit in the venue; if a simple behavioural item is enough, it skips the fixture scene and just attaches a controller script.
+- Behaviour: scans for balls with the `resting` flag, walks or teleports a small animated helper to each, returns them to the rack one at a time on an authored cadence.
+
+The helper reuses the bot's `court` role plumbing; it does not need a new role. Whether it uses the bot's fixture shape or a lighter behavioural item is an implementation choice for its own ticket.
 
 ---
 
 ## Resolved questions
 
-1. **Ball-ground interaction during play.** The ball bounces off the ground (pong-style). Hitting the floor does not end the rally.
-2. **Visual density with many rested balls.** The player will never own enough balls for visual clutter to become a problem. No cap or decay needed.
-3. **Where rested balls can legally sit.** Balls can go anywhere in the venue. They always render in the mid or foreground relative to the shop background, so they stay visible regardless of where they land.
+From the spike:
+
+1. **Ball-ground interaction.** Pong-style bounce. Hitting the floor does not end the rally.
+2. **Rally-ending condition.** Back-miss (goal line) or side-miss (lateral exit). Both reset the counter.
+3. **Clutter.** Not a real problem at prototype scale. No cap or decay.
+4. **Where rested balls can sit.** Anywhere on the venue floor. No invisible barriers. Rack footprints snap-to-rack instead of resting.
+5. **Auto-serve with one ball resting.** Main character idles; player must re-rack. The helper fixes this later.
+6. **Temporary balls.** Despawn on miss as before, regardless of where they land.
+7. **Cues.** Three distinct audio/world beats: bounce, back-miss, side-miss. All diegetic.
+8. **Helper authoring.** `court` role item. Fixture or behavioural controller is its own ticket's call.
 
 ---
 
 ## Out of scope
 
-Not in this project, called out so they don't leak:
+Called out so they don't leak into implementation:
 
-- Helper upgrade item and its prop scene.
-- Ball-fetch animation tuning.
+- Helper upgrade item, its prop scene, and its fetch cadence tuning.
 - Miss-ending-the-rally vs miss-ending-this-ball distinction for multiball (handled in `08-balls.md`).
+- Visual polish on the rest-roll deceleration curve; tuned during implementation.
+
+---
+
+## Implementation ticket outline
+
+Not filing yet. Rough split, each intended to land independently:
+
+1. **Court bounds geometry.** Top ceiling collider, ground collider, goal-line trigger, two side-miss triggers. Hook the side triggers to the existing miss path. Ceiling bounce + ground bounce behaviour verified.
+2. **Ball rest state.** `resting` flag, deceleration on the venue floor, persistence of rest position and flag across saves and scene reloads.
+3. **Drag rested ball to rack.** Reuse the existing drag-to-rack handler; accept `resting` balls as a valid source. Live rally handling unchanged.
+4. **Side-miss cue.** Audio variant + wall flash on the relevant side. Back-miss cue unchanged.
+5. **Auto-serve when rack is empty.** Idle the main character; no fetch in prototype. (Confirms the friction beat behaves as designed.)
+
+Helper upgrade is its own later ticket and is not part of this prototype slice.


### PR DESCRIPTION
Expands `designs/01-prototype/08-court-bounds.md` to close out the SH-107 spike. The starting shape in the doc mostly held up, so the update folds in the remaining open questions (auto-serve with a single resting ball, distinct cues for bounce vs back-miss vs side-miss, helper authoring) and adds a miss-detection region sketch plus an implementation ticket outline. No code changes.

The friction beat when the last owned ball is resting is intentional: the player re-racks it themselves, which teaches the rack gesture and sets up the helper item as a real upgrade later.