### PR TITLE
SH-88 docs: ball speed tiers and physics ceiling spike

### DIFF
--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -110,6 +110,7 @@ See [`release-playbook.md`](release-playbook.md). Agents read it only when Josh 
 
 | Agent | Ticket | Branch | Files touched | Started | Notes |
 |---|---|---|---|---|---|
+| Riebeck | SH-88 | sh-88-ball-speed-tiers-and-physics-ceiling | designs/01-prototype/20-ball-speed-tiers.md | 2026-04-21 | spike: tier system + 1800 px/s physics ceiling |
 
 ## Done (recent)
 
@@ -129,5 +130,6 @@ See [`release-playbook.md`](release-playbook.md). Agents read it only when Josh 
 Newest at top. One line per event.
 
 ```
+[SH-88] Riebeck: claim; drafting ball speed tier design doc
 [init] scratchpad reset on cycle #3 open
 ```

--- a/designs/01-prototype/20-ball-speed-tiers.md
+++ b/designs/01-prototype/20-ball-speed-tiers.md
@@ -1,16 +1,20 @@
 # Ball Speed Tiers and Physics Ceiling
 
-Spike SH-88. Defines a world max ball speed the 2D physics can reliably handle, a tiered progression that turns "reach the ceiling" into a reward beat, and a rewrite of how ball-speed items interact with the tier stack instead of raising a single linear cap.
+Spike SH-88. Defines a world max ball speed the 2D physics can reliably handle, the tier math on top of it, and how ball-speed items interact with the tier stack instead of raising a single linear cap.
+
+Companion design doc: [20a Ball Speed Tier Progression](20a-ball-speed-tier-progression.md) covers the narrative framing and the reward ladder that sits on top of this ceiling.
 
 ## Goal
 
 Current speed model is linear: `ball_speed_min` base, `ball_speed_increment` per hit, clamped to `ball_speed_min + ball_speed_max_range`. Miss resets to min. Items like Court Lines raise `ball_speed_max_range` additively, Cadence raises it further on `on_max_speed_reached`, Wrist Brace raises `ball_speed_increment`. With enough stacking, long rallies push the ball arbitrarily fast and the ceiling becomes a soft curiosity rather than a goal.
 
-We want three things the linear model does not give us:
+What this spike owns:
 
 1. A hard speed the physics pipeline can promise to handle on a 60 Hz tick.
-2. A satisfying payoff when the player reaches the top of a speed band, so climbing feels like progress against a structured loop.
-3. Item effects that stack meaningfully without sliding the whole ceiling sideways.
+2. Tier math that fits inside that ceiling and gives items somewhere to stack without sliding it sideways.
+3. A rewrite of the speed-shaping items against the tier ladder.
+
+The companion doc (20a) owns the narrative framing of the tiers, what each peak rewards, and the felt experience of climbing.
 
 ## The physics ceiling
 
@@ -30,22 +34,30 @@ A conservative world ceiling that keeps all three safe, including a Wrist Brace-
 
 At 1800 px/s the ball travels 30 px per frame. Add the player paddle moving at `paddle_speed = 560` straight into the ball and closing per frame is about 39 px; with a 36 px paddle and 12 px ball radius that still leaves a 9 px overlap margin even at worst-case alignment. A shrunken 45 px paddle hit edge-on still has a 3-4 px margin at the corner, which is uncomfortable but survivable.
 
-Higher than that and edge catches on minified paddles become unreliable; runtime enabling of RigidBody2D `continuous_cd` would be the next step, and we do not want to pay for it yet.
+Higher than that and edge catches on minified paddles become unreliable at the default discrete step.
 
 **No stacked item, no effect outcome, no debug cheat may push `ball.speed` above `BALL_WORLD_MAX_SPEED`.** This is a physics guarantee, not a balance number.
 
-## Tier design
+### Continuous collision detection as a pressure valve
 
-Speed progression becomes a ladder of tiers. Each tier has its own floor, ceiling, and payoff. Reaching the top of a tier fires a tier event, snaps the ball back to the floor of a new tier, and gives the player something. Ceiling-chasing becomes the thing you do on purpose.
+Godot 4.6.2 ships two continuous collision detection modes on `RigidBody2D.continuous_cd`: `CCD_MODE_CAST_RAY` casts the body's motion as a ray (cheap, suits small fast bodies), and `CCD_MODE_CAST_SHAPE` casts the full collider shape along the motion vector (heavier, more accurate, per Godot 4 physics docs). Either mode solves tunnelling geometrically by resolving the first contact along the swept path rather than only sampling at the end of each physics tick, and either could in principle lift the hard speed ceiling.
+
+CCD is not free. Each enabled body adds a per-frame broadphase and narrowphase query against the swept volume, and the cost lands on the physics thread. In this project the web export runs on the main thread (single-threaded physics, no `physics/common/physics_jitter_fix` relief), so that cost reads directly in the frame budget on Volley!'s busiest target. It is a valve we open on purpose, not a default.
+
+Recommendation: keep `BALL_WORLD_MAX_SPEED = 1800` px/s as the uncontested ceiling while `continuous_cd = CCD_MODE_DISABLED`. Enable `CCD_MODE_CAST_RAY` on the ball at Tier 2 entry, promote to `CCD_MODE_CAST_SHAPE` at Tier 3 entry, and disable on tier reset. A later spike can evaluate raising `BALL_WORLD_MAX_SPEED` once we have a web-build frame budget to pay for CCD; until then the ceiling stands.
+
+## Tier math
+
+Speed progression becomes a ladder of tiers. Each tier has its own floor and ceiling; reaching a ceiling fires a tier event and drops the ball to the floor of the next tier. The reward that fires alongside the event is owned by the companion progression doc.
 
 ### Tier 0 to Tier 3
 
-| Tier | Floor (px/s) | Ceiling (px/s) | Band width | Hits to climb | Payoff on completion |
-|---|---|---|---|---|---|
-| 0 | 450 | 790 | 340 | ~20 | Enter Tier 1, speed drops to 790 |
-| 1 | 790 | 1100 | 310 | ~18 | Enter Tier 2, speed drops to 1100; small reward |
-| 2 | 1100 | 1450 | 350 | ~20 | Enter Tier 3, speed drops to 1450; medium reward |
-| 3 | 1450 | 1800 | 350 | ~20 | Peak reward, speed stays near ceiling and starts a Peak window |
+| Tier | Floor (px/s) | Ceiling (px/s) | Band width | Hits to climb |
+|---|---|---|---|---|
+| 0 | 450 | 790 | 340 | ~20 |
+| 1 | 790 | 1100 | 310 | ~18 |
+| 2 | 1100 | 1450 | 350 | ~20 |
+| 3 | 1450 | 1800 | 350 | ~20 |
 
 Tier 0 matches today's base numbers exactly: floor 450, width 340, increment 17. Players starting a run feel the same ramp they feel now.
 
@@ -53,17 +65,9 @@ Hits-to-climb uses the base `ball_speed_increment = 17`. With Wrist Brace at lev
 
 Tier ceilings compound deliberately: each band is a bit wider than the last, so the later tiers feel harder-earned without the absolute ceiling running away. The final band tops out at `BALL_WORLD_MAX_SPEED`. No tier, no item, no effect can promote the ball past Tier 3 ceiling.
 
-### Tier-completion payoff
+### Tier-completion event
 
-Reaching a tier ceiling fires `on_tier_completed(tier_index)` on the item effect bus, drops `ball.speed` back to the new tier's floor, and continues the rally. The event payload carries the completed tier index so effect outcomes can scale their payoff.
-
-Concrete payoffs (tunable, starting values for playtest):
-
-- **Tier 1**: small coin bonus (`+5`). Audio sting, colour shift on the speed bar. No gameplay modifier.
-- **Tier 2**: `+15` coins, a brief 1.5s "Charged" window during which the next paddle hit awards 2x friendship points.
-- **Tier 3** (**Peak**): `+40` coins, speed stays inside the top band for a 4s Peak window. During Peak every paddle hit re-emits a `peak_hit` event that items can latch onto. Leaving Peak (4s elapse, or a miss) drops back to Tier 0 floor.
-
-Peak is the satisfying payoff. Reaching it costs four tiers of disciplined rally and pays with a fixed window of intense play that has a clean end.
+Reaching a tier ceiling fires `on_tier_completed(tier_index)` on the item effect bus, drops `ball.speed` back to the new tier's floor, and continues the rally. The event payload carries the completed tier index so effect outcomes and reward handlers can scale their response. Tier 3 completion additionally opens a Peak window; see 20a for its framing and reward payload.
 
 ### Reset behaviour
 
@@ -123,14 +127,14 @@ New: unchanged. Wrist Brace compresses every tier's hits-to-climb and trades pad
 
 ## Open questions
 
-- Peak window length: 4s is a placeholder. Tune against playtest once the event bus wires up.
-- Tier 2 Charged window: does it also extend into Tier 3? Probably not, but the event bus makes it easy to try.
+- CCD per-body cost on the web export. Needs a frame-budget measurement at Tier 3 + CCD_MODE_CAST_SHAPE before the recommendation locks in.
 - Do Partners care about tier? Martha's current numbers do not touch speed, but a future Partner could want an `on_peak_hit` outcome. The event bus should accept it without special casing.
-- Should missing during Peak cost more than a normal miss? A "crash" penalty (halve coins earned this rally, say) would give Peak genuine risk. Leave off for first iteration; evaluate after playtest.
 
 ## Acceptance criteria mapping
 
 - Hard physics ceiling identified and documented. `BALL_WORLD_MAX_SPEED = 1800` px/s, justified against the 60 Hz tick, paddle collider width, and min paddle size.
-- Tier progression designed. Four tiers, ~18-20 hits per climb at base increment, payoffs scaling from coins to a Peak window.
+- CCD evaluated as a pressure valve. `CCD_MODE_CAST_RAY` at Tier 2, `CCD_MODE_CAST_SHAPE` at Tier 3, disabled on reset; web-thread cost called out as the gate on raising the ceiling.
+- Tier progression designed. Four tiers, ~18-20 hits per climb at base increment.
 - Reset behaviour defined. Miss to Tier 0 floor. Tier completion to next tier floor. Peak end without miss drops to Tier 0 floor without counting as a miss.
 - Existing-item interactions documented. Cadence, Court Lines, Training Ball, Wrist Brace all re-expressed against the tier stack.
+- Narrative framing and reward ladder live in [20a Ball Speed Tier Progression](20a-ball-speed-tier-progression.md).

--- a/designs/01-prototype/20-ball-speed-tiers.md
+++ b/designs/01-prototype/20-ball-speed-tiers.md
@@ -1,0 +1,136 @@
+# Ball Speed Tiers and Physics Ceiling
+
+Spike SH-88. Defines a world max ball speed the 2D physics can reliably handle, a tiered progression that turns "reach the ceiling" into a reward beat, and a rewrite of how ball-speed items interact with the tier stack instead of raising a single linear cap.
+
+## Goal
+
+Current speed model is linear: `ball_speed_min` base, `ball_speed_increment` per hit, clamped to `ball_speed_min + ball_speed_max_range`. Miss resets to min. Items like Court Lines raise `ball_speed_max_range` additively, Cadence raises it further on `on_max_speed_reached`, Wrist Brace raises `ball_speed_increment`. With enough stacking, long rallies push the ball arbitrarily fast and the ceiling becomes a soft curiosity rather than a goal.
+
+We want three things the linear model does not give us:
+
+1. A hard speed the physics pipeline can promise to handle on a 60 Hz tick.
+2. A satisfying payoff when the player reaches the top of a speed band, so climbing feels like progress against a structured loop.
+3. Item effects that stack meaningfully without sliding the whole ceiling sideways.
+
+## The physics ceiling
+
+Godot's 2D physics in this project runs at the engine default 60 ticks per second. `project.godot` does not override `physics/common/physics_ticks_per_second`.
+
+Per-frame travel at 60 Hz is `speed / 60` pixels. The ball's collider is a `CircleShape2D` scaled to 1.2, giving an effective radius of roughly 12 px. The thinnest wall is 36 px. Paddle colliders are 36 px wide on the hit axis; Martha's is 40 px. Min paddle size on the long axis is `paddle_size_min = 45`.
+
+Tunneling risks, in order of how quickly they bite:
+
+- Paddle face, ball and paddle approaching each other. Closing speed can be `ball_speed + paddle_speed` (base `paddle_speed = 560`). Per-frame closing distance has to stay below `ball_radius + paddle_thickness / 2` with a margin, or the ball skips across the paddle face. At 60 Hz, keeping closing distance under about 30 px per frame is comfortable.
+- Paddle edge, shrunk paddle. A paddle at `paddle_size_min = 45` is only 22 px from centre to each short end. Missing the edge because the ball clipped past it in one tick is the second failure mode.
+- Walls. 36 px thick plus a 12 px ball gives 48 px of contact depth. The ball is the last thing to tunnel a wall.
+
+A conservative world ceiling that keeps all three safe, including a Wrist Brace-boosted ramp and a moving paddle:
+
+**`BALL_WORLD_MAX_SPEED = 1800` px/s.**
+
+At 1800 px/s the ball travels 30 px per frame. Add the player paddle moving at `paddle_speed = 560` straight into the ball and closing per frame is about 39 px; with a 36 px paddle and 12 px ball radius that still leaves a 9 px overlap margin even at worst-case alignment. A shrunken 45 px paddle hit edge-on still has a 3-4 px margin at the corner, which is uncomfortable but survivable.
+
+Higher than that and edge catches on minified paddles become unreliable; runtime enabling of RigidBody2D `continuous_cd` would be the next step, and we do not want to pay for it yet.
+
+**No stacked item, no effect outcome, no debug cheat may push `ball.speed` above `BALL_WORLD_MAX_SPEED`.** This is a physics guarantee, not a balance number.
+
+## Tier design
+
+Speed progression becomes a ladder of tiers. Each tier has its own floor, ceiling, and payoff. Reaching the top of a tier fires a tier event, snaps the ball back to the floor of a new tier, and gives the player something. Ceiling-chasing becomes the thing you do on purpose.
+
+### Tier 0 to Tier 3
+
+| Tier | Floor (px/s) | Ceiling (px/s) | Band width | Hits to climb | Payoff on completion |
+|---|---|---|---|---|---|
+| 0 | 450 | 790 | 340 | ~20 | Enter Tier 1, speed drops to 790 |
+| 1 | 790 | 1100 | 310 | ~18 | Enter Tier 2, speed drops to 1100; small reward |
+| 2 | 1100 | 1450 | 350 | ~20 | Enter Tier 3, speed drops to 1450; medium reward |
+| 3 | 1450 | 1800 | 350 | ~20 | Peak reward, speed stays near ceiling and starts a Peak window |
+
+Tier 0 matches today's base numbers exactly: floor 450, width 340, increment 17. Players starting a run feel the same ramp they feel now.
+
+Hits-to-climb uses the base `ball_speed_increment = 17`. With Wrist Brace at level 5 (+40 increment effect total) the ramp compresses, which is the item's whole point; tier structure does not fight it.
+
+Tier ceilings compound deliberately: each band is a bit wider than the last, so the later tiers feel harder-earned without the absolute ceiling running away. The final band tops out at `BALL_WORLD_MAX_SPEED`. No tier, no item, no effect can promote the ball past Tier 3 ceiling.
+
+### Tier-completion payoff
+
+Reaching a tier ceiling fires `on_tier_completed(tier_index)` on the item effect bus, drops `ball.speed` back to the new tier's floor, and continues the rally. The event payload carries the completed tier index so effect outcomes can scale their payoff.
+
+Concrete payoffs (tunable, starting values for playtest):
+
+- **Tier 1**: small coin bonus (`+5`). Audio sting, colour shift on the speed bar. No gameplay modifier.
+- **Tier 2**: `+15` coins, a brief 1.5s "Charged" window during which the next paddle hit awards 2x friendship points.
+- **Tier 3** (**Peak**): `+40` coins, speed stays inside the top band for a 4s Peak window. During Peak every paddle hit re-emits a `peak_hit` event that items can latch onto. Leaving Peak (4s elapse, or a miss) drops back to Tier 0 floor.
+
+Peak is the satisfying payoff. Reaching it costs four tiers of disciplined rally and pays with a fixed window of intense play that has a clean end.
+
+### Reset behaviour
+
+- **Miss** resets tier to 0 and speed to Tier 0 floor, matching today's `ball.reset_speed` semantics.
+- **Tier completion** sets tier to `tier + 1` and speed to the new tier's floor. Current speed does not carry across tiers; the drop is the reset beat.
+- **Peak window end without miss** drops speed and tier to 0 but does not count as a miss. The rally continues. Call this the "cooldown" reset: no penalty events fire, `_volley_count` is preserved, the Court just feels the speed drop.
+- **Peak window end by miss** behaves as a normal miss: tier 0, volley count 0 (or halved if a halve-streak item is active, same as today).
+- **Half-streak items** (Cadence's existing `on_miss` / halve outcome) still halve `_volley_count` on miss. They now also set tier to `floor(current_tier / 2)` and speed to the floor of that tier, so halving is proportional across the new ladder.
+
+### Tier-aware ball state
+
+`Ball` gains `current_tier: int` and `tier_floor` / `tier_ceiling` derived from `current_tier` against a `SpeedTierTable` resource. `increase_speed` and `set_speed_for_streak` clamp against `tier_ceiling` instead of `max_speed`. Crossing `tier_ceiling` triggers `_advance_tier` which emits `tier_advanced(new_tier)` and `on_tier_completed` through `ItemManager.process_event`.
+
+`speed_changed` grows to carry tier floor and ceiling instead of global min and max, so the speed bar can render the current band. `at_max_speed_changed` is repurposed to fire only on Peak entry/exit; the Cadence "ceiling outcome" (which currently latches on `on_max_speed_reached`) moves to `on_tier_completed` with a tier filter.
+
+## Items under the tier model
+
+The four items that currently shape ball speed keep their fantasy. Each stops trying to slide a single linear ceiling and starts interacting with the tier stack.
+
+### Cadence
+
+Current: oscillates `ball_speed_offset` within `ball_speed_max_range`; on `on_max_speed_reached` raises `ball_speed_max_range` by 15 up to +75.
+
+New: oscillation stays (it is a feel effect, not a ceiling effect). The ceiling-raising outcome becomes a **tier-skip chance**. On `on_tier_completed`, Cadence has a per-level chance (15/30/45%) to skip the next tier's climb and drop straight into the tier after. At high levels this reliably vaults the player into Tier 3 Peak faster. "Don't stop. Won't stop" reads as "keep the tempo, skip the queue," and the item keeps rewarding long rallies without raising the absolute cap.
+
+### Court Lines
+
+Current: flat `+50` per level to `ball_speed_max_range`, up to level 10 (`+500`).
+
+New: **widens tiers** without raising their ceilings. Each level adds a small amount (+5 px/s?) to tier floors 1-3, so bands start higher but still end at the same fixed ceilings. Climbing tiers 1-3 takes fewer hits. At level 10 a Tier 3 run starts with the ball already at 1500 px/s and only needs ~18 hits to Peak. The flavour ("the ceiling keeps moving") shifts to "the start line keeps moving", which reads cleaner.
+
+### Training Ball
+
+Current: flat `+30` per level to `ball_speed_min`, up to level 10 (`+300`).
+
+New: unchanged in shape. Training Ball raises Tier 0 floor only; it does not affect Tier 1+ floors. Base serves come in faster and Tier 0 finishes quicker, but the item stops colliding with the tier structure above. "Already moving" still fits.
+
+### Wrist Brace
+
+Current: `+8` per level to `ball_speed_increment`, with a `paddle_size` percentage penalty.
+
+New: unchanged. Wrist Brace compresses every tier's hits-to-climb and trades paddle size for ramp speed. It is the "do the climb faster" item; layering it under a tier model is exactly what we want.
+
+### Interactions at the extremes
+
+- Court Lines 10 + Training Ball 10 + Wrist Brace 10: Tier 0 floor is 750, Tier 3 ceiling is still 1800, climbs are ~8 hits per tier. Peak is reachable inside the first 30 hits of a rally. This is the new power fantasy. Without tiers, the same stack today sends speed arbitrarily high and breaks the paddle.
+- Cadence 3 with any speed stack: tier-skip chance up to 45% means the average Peak-to-Peak interval shrinks well below 60 hits, which is the Cadence identity under this model.
+- Training Ball alone: Tier 0 compression only. Stops interacting with the tier ladder above Tier 0, which is what "early-game smoothing" items should do.
+
+## Migration notes
+
+- `ball_speed_max_range` as a stat key disappears. `SpeedTierTable` resource replaces it and is owned by `GameRules`. Existing tests that read `ball_speed_max_range` become tests against `SpeedTierTable.get_tier(n).ceiling`.
+- Cadence's `on_max_speed_reached` outcome is rewritten to `on_tier_completed` with a tier filter. Court Lines' `ball_speed_max_range` stat outcome is rewritten to a new `widen_tier_floors` outcome. Training Ball and Wrist Brace unchanged.
+- Court's `_on_ball_at_max_speed_changed` splits into `_on_ball_tier_advanced` (fires per tier) and `_on_ball_peak_changed` (fires on Peak entry/exit). `on_max_speed_reached` as an event name is retired; `on_tier_completed` replaces it.
+- `ball.reset_speed` stays as miss behaviour. `ball.advance_tier` is new. `ball.set_speed_for_streak` clamps against `tier_ceiling` of the tier implied by streak count, which the tier table answers.
+- No save compat shim. Items in flight at migration time reload against the new data and pick up the new behaviour.
+
+## Open questions
+
+- Peak window length: 4s is a placeholder. Tune against playtest once the event bus wires up.
+- Tier 2 Charged window: does it also extend into Tier 3? Probably not, but the event bus makes it easy to try.
+- Do Partners care about tier? Martha's current numbers do not touch speed, but a future Partner could want an `on_peak_hit` outcome. The event bus should accept it without special casing.
+- Should missing during Peak cost more than a normal miss? A "crash" penalty (halve coins earned this rally, say) would give Peak genuine risk. Leave off for first iteration; evaluate after playtest.
+
+## Acceptance criteria mapping
+
+- Hard physics ceiling identified and documented. `BALL_WORLD_MAX_SPEED = 1800` px/s, justified against the 60 Hz tick, paddle collider width, and min paddle size.
+- Tier progression designed. Four tiers, ~18-20 hits per climb at base increment, payoffs scaling from coins to a Peak window.
+- Reset behaviour defined. Miss to Tier 0 floor. Tier completion to next tier floor. Peak end without miss drops to Tier 0 floor without counting as a miss.
+- Existing-item interactions documented. Cadence, Court Lines, Training Ball, Wrist Brace all re-expressed against the tier stack.

--- a/designs/01-prototype/20-ball-speed-tiers.md
+++ b/designs/01-prototype/20-ball-speed-tiers.md
@@ -18,56 +18,29 @@ The companion doc (20a) owns the narrative framing of the tiers, what each peak 
 
 ## The physics ceiling
 
-Godot's 2D physics in this project runs at the engine default 60 ticks per second. `project.godot` does not override `physics/common/physics_ticks_per_second`.
+Godot's 2D physics in this project runs at the engine default 60 ticks per second. At discrete-step integration the ball can tunnel through thin colliders if per-frame travel exceeds the contact depth of what it is trying to hit. The three failure modes, in order of how quickly they bite, are: paddle face (closing speed of ball + paddle has to stay under the paddle's hit-axis thickness plus ball radius), paddle edge on a shrunk paddle, and walls.
 
-Per-frame travel at 60 Hz is `speed / 60` pixels. The ball's collider is a `CircleShape2D` scaled to 1.2, giving an effective radius of roughly 12 px. The thinnest wall is 36 px. Paddle colliders are 36 px wide on the hit axis; Martha's is 40 px. Min paddle size on the long axis is `paddle_size_min = 45`.
-
-Tunneling risks, in order of how quickly they bite:
-
-- Paddle face, ball and paddle approaching each other. Closing speed can be `ball_speed + paddle_speed` (base `paddle_speed = 560`). Per-frame closing distance has to stay below `ball_radius + paddle_thickness / 2` with a margin, or the ball skips across the paddle face. At 60 Hz, keeping closing distance under about 30 px per frame is comfortable.
-- Paddle edge, shrunk paddle. A paddle at `paddle_size_min = 45` is only 22 px from centre to each short end. Missing the edge because the ball clipped past it in one tick is the second failure mode.
-- Walls. 36 px thick plus a 12 px ball gives 48 px of contact depth. The ball is the last thing to tunnel a wall.
-
-A conservative world ceiling that keeps all three safe, including a Wrist Brace-boosted ramp and a moving paddle:
-
-**`BALL_WORLD_MAX_SPEED = 1800` px/s.**
-
-At 1800 px/s the ball travels 30 px per frame. Add the player paddle moving at `paddle_speed = 560` straight into the ball and closing per frame is about 39 px; with a 36 px paddle and 12 px ball radius that still leaves a 9 px overlap margin even at worst-case alignment. A shrunken 45 px paddle hit edge-on still has a 3-4 px margin at the corner, which is uncomfortable but survivable.
-
-Higher than that and edge catches on minified paddles become unreliable at the default discrete step.
+The spike exposes a single constant, `BALL_WORLD_MAX_SPEED`, which is the world max speed the physics pipeline can reliably handle at 60 Hz against the narrowest paddle and thinnest wall in the scene. Its value is tuned during prototyping against the actual collider dimensions and paddle-speed curve, not baked into the architecture.
 
 **No stacked item, no effect outcome, no debug cheat may push `ball.speed` above `BALL_WORLD_MAX_SPEED`.** This is a physics guarantee, not a balance number.
 
 ### Continuous collision detection as a pressure valve
 
-Godot 4.6.2 ships two continuous collision detection modes on `RigidBody2D.continuous_cd`: `CCD_MODE_CAST_RAY` casts the body's motion as a ray (cheap, suits small fast bodies), and `CCD_MODE_CAST_SHAPE` casts the full collider shape along the motion vector (heavier, more accurate, per [Godot's `RigidBody2D.continuous_cd` reference](https://docs.godotengine.org/en/stable/classes/class_rigidbody2d.html#class-rigidbody2d-property-continuous-cd)). Either mode solves tunnelling geometrically by resolving the first contact along the swept path rather than only sampling at the end of each physics tick, and either could in principle lift the hard speed ceiling.
-
-CCD is not free. Each enabled body adds a per-frame broadphase and narrowphase query against the swept volume, and the cost lands on the physics thread. In this project the web export runs on the main thread (single-threaded physics, no `physics/common/physics_jitter_fix` relief), so that cost reads directly in the frame budget on Volley!'s busiest target. It is a valve we open on purpose, not a default.
-
-Recommendation: keep `BALL_WORLD_MAX_SPEED = 1800` px/s as the uncontested ceiling while `continuous_cd = CCD_MODE_DISABLED`. Enable `CCD_MODE_CAST_RAY` on the ball at Tier 2 entry, promote to `CCD_MODE_CAST_SHAPE` at Tier 3 entry, and disable on tier reset. A later spike can evaluate raising `BALL_WORLD_MAX_SPEED` once we have a web-build frame budget to pay for CCD; until then the ceiling stands.
+If the speed ceiling turns out too tight under real play, Godot's [`RigidBody2D.continuous_cd`](https://docs.godotengine.org/en/stable/classes/class_rigidbody2d.html#class-rigidbody2d-property-continuous-cd) is the pressure valve: enabling it resolves contacts along the swept path rather than at tick boundaries, trading physics-thread cost for headroom above the discrete-step ceiling. The specific mode and the tiers it turns on at are prototype-time decisions, not an architectural commitment.
 
 ## Tier math
 
 Speed progression becomes a ladder of tiers. Each tier has its own floor and ceiling; reaching a ceiling fires a tier event and drops the ball to the floor of the next tier. The reward that fires alongside the event is owned by the companion progression doc.
 
-### Tier 0 to Tier 3
+### Tier structure
 
-| Tier | Floor (px/s) | Ceiling (px/s) | Band width | Hits to climb |
-|---|---|---|---|---|
-| 0 | 450 | 790 | 340 | ~20 |
-| 1 | 790 | 1100 | 310 | ~18 |
-| 2 | 1100 | 1450 | 350 | ~20 |
-| 3 | 1450 | 1800 | 350 | ~20 |
+The ladder has three or four tiers (final count is a design call made in the prototype). Tier 0 is the base rally speed; each subsequent tier steps up to a progressively higher band, with the ceiling raised by that tier's `ball_speed_max_range` entry. The top tier's ceiling is the world max speed the physics can reliably handle, tuned during prototyping. Tier 0's floor and width match today's base-stats numbers, so starting a run feels the same as today.
 
-Tier 0 matches today's base numbers exactly: floor 450, width 340, increment 17. Players starting a run feel the same ramp they feel now.
-
-Hits-to-climb uses the base `ball_speed_increment = 17`. With Wrist Brace at level 5 (+40 increment effect total) the ramp compresses, which is the item's whole point; tier structure does not fight it.
-
-Tier ceilings compound deliberately: each band is a bit wider than the last, so the later tiers feel harder-earned without the absolute ceiling running away. The final band tops out at `BALL_WORLD_MAX_SPEED`. No tier, no item, no effect can promote the ball past Tier 3 ceiling.
+No tier, no item, no effect can promote the ball past the top tier's ceiling.
 
 ### Tier-completion event
 
-Reaching a tier ceiling fires `on_tier_completed(tier_index)` on the item effect bus, drops `ball.speed` back to the new tier's floor, and continues the rally. The event payload carries the completed tier index so effect outcomes and reward handlers can scale their response. Tier 3 completion additionally opens a Peak window; see 20a for its framing and reward payload.
+Reaching a tier ceiling fires `on_tier_completed(tier_index)` on the item effect bus, drops `ball.speed` back to the new tier's floor, and continues the rally. The event payload carries the completed tier index so effect outcomes and reward handlers can scale their response. Completing the top tier additionally opens a Peak window; see 20a for its framing and reward payload.
 
 ### Reset behaviour
 
@@ -79,7 +52,7 @@ Reaching a tier ceiling fires `on_tier_completed(tier_index)` on the item effect
 
 ### Tier-aware ball state
 
-`Ball` gains `current_tier: int` and `tier_floor` / `tier_ceiling` derived from `current_tier` against a `SpeedTierTable` resource. Each tier entry in the table carries `{ floor, ceiling, max_range, reward }`, where `max_range` is the per-tier promotion of the flat `ball_speed_max_range` stat from 21-ball-dynamics.md. Tier 0's `max_range` holds the existing flat value (340 px/s), so the base-stats tuning surface 21 relies on lives on the Tier 0 entry. `increase_speed` and `set_speed_for_streak` clamp against `tier_ceiling` instead of `max_speed`. Crossing `tier_ceiling` triggers `_advance_tier` which emits `tier_advanced(new_tier)` and `on_tier_completed` through `ItemManager.process_event`.
+`Ball` gains `current_tier: int` and `tier_floor` / `tier_ceiling` derived from `current_tier` against a `SpeedTierTable` resource. Each tier entry in the table carries `{ floor, ceiling, max_range, reward }`, where `max_range` is the per-tier promotion of the flat `ball_speed_max_range` stat from 21-ball-dynamics.md. Tier 0's `max_range` holds the existing flat value from 21's base-stats tuning surface, so that surface keeps its meaning and lives on the Tier 0 entry. `increase_speed` and `set_speed_for_streak` clamp against `tier_ceiling` instead of `max_speed`. Crossing `tier_ceiling` triggers `_advance_tier` which emits `tier_advanced(new_tier)` and `on_tier_completed` through `ItemManager.process_event`.
 
 `speed_changed` grows to carry tier floor and ceiling instead of global min and max, so the speed bar can render the current band. `at_max_speed_changed` is repurposed to fire only on Peak entry/exit; the Cadence "ceiling outcome" (which currently latches on `on_max_speed_reached`) moves to `on_tier_completed` with a tier filter.
 
@@ -89,37 +62,37 @@ The four items that currently shape ball speed keep their fantasy. Each stops tr
 
 ### Cadence
 
-Current: oscillates `ball_speed_offset` within `ball_speed_max_range`; on `on_max_speed_reached` raises `ball_speed_max_range` by 15 up to +75.
+Current: oscillates `ball_speed_offset` within `ball_speed_max_range`; on `on_max_speed_reached` raises `ball_speed_max_range`.
 
-New: oscillation stays (it is a feel effect, not a ceiling effect). The ceiling-raising outcome becomes a **tier-skip chance**. On `on_tier_completed`, Cadence has a per-level chance (15/30/45%) to skip the next tier's climb and drop straight into the tier after. At high levels this reliably vaults the player into Tier 3 Peak faster. "Don't stop. Won't stop" reads as "keep the tempo, skip the queue," and the item keeps rewarding long rallies without raising the absolute cap.
+New: oscillation stays (it is a feel effect, not a ceiling effect). The ceiling-raising outcome becomes a **tier-skip chance** on `on_tier_completed`: a per-level chance to skip the next tier's climb and drop straight into the tier after. "Don't stop. Won't stop" reads as "keep the tempo, skip the queue," and the item keeps rewarding long rallies without raising the absolute cap.
 
 ### Court Lines
 
-Current: flat `+50` per level to `ball_speed_max_range`, up to level 10 (`+500`).
+Current: flat per-level addition to `ball_speed_max_range`.
 
-New: **widens tiers** without raising their ceilings. Each level adds a small amount (+5 px/s?) to tier floors 1-3, so bands start higher but still end at the same fixed ceilings. Climbing tiers 1-3 takes fewer hits. At level 10 a Tier 3 run starts with the ball already at 1500 px/s and only needs ~18 hits to Peak. The flavour ("the ceiling keeps moving") shifts to "the start line keeps moving", which reads cleaner.
+New: **widens tiers** without raising their ceilings. Each level lifts the floors of the tiers above Tier 0 by a small amount, so bands start higher but still end at the same fixed ceilings and climbs take fewer hits. The flavour ("the ceiling keeps moving") shifts to "the start line keeps moving", which reads cleaner.
 
 ### Training Ball
 
-Current: flat `+30` per level to `ball_speed_min`, up to level 10 (`+300`).
+Current: flat per-level addition to `ball_speed_min`.
 
-New: unchanged in shape. Training Ball raises Tier 0 floor only; it does not affect Tier 1+ floors. Base serves come in faster and Tier 0 finishes quicker, but the item stops colliding with the tier structure above. "Already moving" still fits.
+New: unchanged in shape. Training Ball raises Tier 0 floor only; it does not affect higher tiers. Base serves come in faster and Tier 0 finishes quicker, but the item stops colliding with the tier structure above. "Already moving" still fits.
 
 ### Wrist Brace
 
-Current: `+8` per level to `ball_speed_increment`, with a `paddle_size` percentage penalty.
+Current: per-level addition to `ball_speed_increment`, with a `paddle_size` percentage penalty.
 
 New: unchanged. Wrist Brace compresses every tier's hits-to-climb and trades paddle size for ramp speed. It is the "do the climb faster" item; layering it under a tier model is exactly what we want.
 
 ### Interactions at the extremes
 
-- Court Lines 10 + Training Ball 10 + Wrist Brace 10: Tier 0 floor is 750, Tier 3 ceiling is still 1800, climbs are ~8 hits per tier. Peak is reachable inside the first 30 hits of a rally. This is the new power fantasy. Without tiers, the same stack today sends speed arbitrarily high and breaks the paddle.
-- Cadence 3 with any speed stack: tier-skip chance up to 45% means the average Peak-to-Peak interval shrinks well below 60 hits, which is the Cadence identity under this model.
+- Full speed stack (Court Lines + Training Ball + Wrist Brace at cap): Tier 0 starts higher, climbs compress, top-tier ceiling holds. Peak becomes reachable inside a short rally. This is the new power fantasy. Without tiers, the same stack today sends speed arbitrarily high and breaks the paddle.
+- Cadence with any speed stack: tier-skip chance shrinks the average Peak-to-Peak interval, which is the Cadence identity under this model.
 - Training Ball alone: Tier 0 compression only. Stops interacting with the tier ladder above Tier 0, which is what "early-game smoothing" items should do.
 
 ## Migration notes
 
-- `ball_speed_max_range` stays as a tuning surface; it is promoted into a per-tier `max_range` field on `SpeedTierTable` rather than deleted. The flat value from 21-ball-dynamics.md (340 px/s) rides on the Tier 0 entry so existing tuning and tests keep their meaning; Tiers 1-3 each declare their own `max_range` alongside `floor`, `ceiling`, and `reward`. The table is owned by `GameRules`. Existing callers that read `ball_speed_max_range` read `SpeedTierTable.get_tier(current_tier).max_range` (or `.get_tier(0).max_range` for the base-stats tuning surface).
+- `ball_speed_max_range` stays as a tuning surface; it is promoted into a per-tier `max_range` field on `SpeedTierTable` rather than deleted. The flat value from 21-ball-dynamics.md rides on the Tier 0 entry so existing tuning and tests keep their meaning; the tiers above each declare their own `max_range` alongside `floor`, `ceiling`, and `reward`. The table is owned by `GameRules`. Existing callers that read `ball_speed_max_range` read `SpeedTierTable.get_tier(current_tier).max_range` (or `.get_tier(0).max_range` for the base-stats tuning surface).
 - Cadence's `on_max_speed_reached` outcome is rewritten to `on_tier_completed` with a tier filter. Court Lines' `ball_speed_max_range` stat outcome is rewritten to a new `widen_tier_floors` outcome. Training Ball and Wrist Brace unchanged.
 - Court's `_on_ball_at_max_speed_changed` splits into `_on_ball_tier_advanced` (fires per tier) and `_on_ball_peak_changed` (fires on Peak entry/exit). `on_max_speed_reached` as an event name is retired; `on_tier_completed` replaces it.
 - `ball.reset_speed` stays as miss behaviour. `ball.advance_tier` is new. `ball.set_speed_for_streak` clamps against `tier_ceiling` of the tier implied by streak count, which the tier table answers.
@@ -127,14 +100,14 @@ New: unchanged. Wrist Brace compresses every tier's hits-to-climb and trades pad
 
 ## Open questions
 
-- CCD per-body cost on the web export. Needs a frame-budget measurement at Tier 3 + CCD_MODE_CAST_SHAPE before the recommendation locks in.
+- CCD per-body cost on the web export, if we need to reach for it. Needs a frame-budget measurement in the prototype before committing to CCD as the way past the discrete-step ceiling.
 - Do Partners care about tier? Martha's current numbers do not touch speed, but a future Partner could want an `on_peak_hit` outcome. The event bus should accept it without special casing.
 
 ## Acceptance criteria mapping
 
-- Hard physics ceiling identified and documented. `BALL_WORLD_MAX_SPEED = 1800` px/s, justified against the 60 Hz tick, paddle collider width, and min paddle size.
-- CCD evaluated as a pressure valve. `CCD_MODE_CAST_RAY` at Tier 2, `CCD_MODE_CAST_SHAPE` at Tier 3, disabled on reset; web-thread cost called out as the gate on raising the ceiling.
-- Tier progression designed. Four tiers, ~18-20 hits per climb at base increment.
+- Hard physics ceiling identified and named. `BALL_WORLD_MAX_SPEED` exists as the single constant the pipeline guarantees, tuned in the prototype against the 60 Hz tick, paddle collider width, and min paddle size.
+- CCD evaluated as a pressure valve available if the ceiling proves too tight in play.
+- Tier progression designed. Three or four tiers; hits-per-climb falls out of base increment and per-tier `max_range`.
 - Reset behaviour defined. Miss to Tier 0 floor. Tier completion to next tier floor. Peak end without miss drops to Tier 0 floor without counting as a miss.
 - Existing-item interactions documented. Cadence, Court Lines, Training Ball, Wrist Brace all re-expressed against the tier stack.
 - Narrative framing and reward ladder live in [20a Ball Speed Tier Progression](20a-ball-speed-tier-progression.md).

--- a/designs/01-prototype/20-ball-speed-tiers.md
+++ b/designs/01-prototype/20-ball-speed-tiers.md
@@ -79,7 +79,7 @@ Reaching a tier ceiling fires `on_tier_completed(tier_index)` on the item effect
 
 ### Tier-aware ball state
 
-`Ball` gains `current_tier: int` and `tier_floor` / `tier_ceiling` derived from `current_tier` against a `SpeedTierTable` resource. `increase_speed` and `set_speed_for_streak` clamp against `tier_ceiling` instead of `max_speed`. Crossing `tier_ceiling` triggers `_advance_tier` which emits `tier_advanced(new_tier)` and `on_tier_completed` through `ItemManager.process_event`.
+`Ball` gains `current_tier: int` and `tier_floor` / `tier_ceiling` derived from `current_tier` against a `SpeedTierTable` resource. Each tier entry in the table carries `{ floor, ceiling, max_range, reward }`, where `max_range` is the per-tier promotion of the flat `ball_speed_max_range` stat from 21-ball-dynamics.md. Tier 0's `max_range` holds the existing flat value (340 px/s), so the base-stats tuning surface 21 relies on lives on the Tier 0 entry. `increase_speed` and `set_speed_for_streak` clamp against `tier_ceiling` instead of `max_speed`. Crossing `tier_ceiling` triggers `_advance_tier` which emits `tier_advanced(new_tier)` and `on_tier_completed` through `ItemManager.process_event`.
 
 `speed_changed` grows to carry tier floor and ceiling instead of global min and max, so the speed bar can render the current band. `at_max_speed_changed` is repurposed to fire only on Peak entry/exit; the Cadence "ceiling outcome" (which currently latches on `on_max_speed_reached`) moves to `on_tier_completed` with a tier filter.
 
@@ -119,7 +119,7 @@ New: unchanged. Wrist Brace compresses every tier's hits-to-climb and trades pad
 
 ## Migration notes
 
-- `ball_speed_max_range` as a stat key disappears. `SpeedTierTable` resource replaces it and is owned by `GameRules`. Existing tests that read `ball_speed_max_range` become tests against `SpeedTierTable.get_tier(n).ceiling`.
+- `ball_speed_max_range` stays as a tuning surface; it is promoted into a per-tier `max_range` field on `SpeedTierTable` rather than deleted. The flat value from 21-ball-dynamics.md (340 px/s) rides on the Tier 0 entry so existing tuning and tests keep their meaning; Tiers 1-3 each declare their own `max_range` alongside `floor`, `ceiling`, and `reward`. The table is owned by `GameRules`. Existing callers that read `ball_speed_max_range` read `SpeedTierTable.get_tier(current_tier).max_range` (or `.get_tier(0).max_range` for the base-stats tuning surface).
 - Cadence's `on_max_speed_reached` outcome is rewritten to `on_tier_completed` with a tier filter. Court Lines' `ball_speed_max_range` stat outcome is rewritten to a new `widen_tier_floors` outcome. Training Ball and Wrist Brace unchanged.
 - Court's `_on_ball_at_max_speed_changed` splits into `_on_ball_tier_advanced` (fires per tier) and `_on_ball_peak_changed` (fires on Peak entry/exit). `on_max_speed_reached` as an event name is retired; `on_tier_completed` replaces it.
 - `ball.reset_speed` stays as miss behaviour. `ball.advance_tier` is new. `ball.set_speed_for_streak` clamps against `tier_ceiling` of the tier implied by streak count, which the tier table answers.

--- a/designs/01-prototype/20-ball-speed-tiers.md
+++ b/designs/01-prototype/20-ball-speed-tiers.md
@@ -40,7 +40,7 @@ Higher than that and edge catches on minified paddles become unreliable at the d
 
 ### Continuous collision detection as a pressure valve
 
-Godot 4.6.2 ships two continuous collision detection modes on `RigidBody2D.continuous_cd`: `CCD_MODE_CAST_RAY` casts the body's motion as a ray (cheap, suits small fast bodies), and `CCD_MODE_CAST_SHAPE` casts the full collider shape along the motion vector (heavier, more accurate, per Godot 4 physics docs). Either mode solves tunnelling geometrically by resolving the first contact along the swept path rather than only sampling at the end of each physics tick, and either could in principle lift the hard speed ceiling.
+Godot 4.6.2 ships two continuous collision detection modes on `RigidBody2D.continuous_cd`: `CCD_MODE_CAST_RAY` casts the body's motion as a ray (cheap, suits small fast bodies), and `CCD_MODE_CAST_SHAPE` casts the full collider shape along the motion vector (heavier, more accurate, per [Godot's `RigidBody2D.continuous_cd` reference](https://docs.godotengine.org/en/stable/classes/class_rigidbody2d.html#class-rigidbody2d-property-continuous-cd)). Either mode solves tunnelling geometrically by resolving the first contact along the swept path rather than only sampling at the end of each physics tick, and either could in principle lift the hard speed ceiling.
 
 CCD is not free. Each enabled body adds a per-frame broadphase and narrowphase query against the swept volume, and the cost lands on the physics thread. In this project the web export runs on the main thread (single-threaded physics, no `physics/common/physics_jitter_fix` relief), so that cost reads directly in the frame budget on Volley!'s busiest target. It is a valve we open on purpose, not a default.
 

--- a/designs/01-prototype/20a-ball-speed-tier-progression.md
+++ b/designs/01-prototype/20a-ball-speed-tier-progression.md
@@ -1,0 +1,42 @@
+# Ball Speed Tier Progression
+
+Design companion to SH-88. Where [20 Ball Speed Tiers and Physics Ceiling](20-ball-speed-tiers.md) owns the physics ceiling, tier math, and item stat interactions, this doc owns the game-design side: why tiers exist at all, what the player earns when they reach the top of one, and what a tier climb feels like from inside a rally.
+
+## Why tiers exist
+
+A linear speed ramp without internal structure gives the player no landmarks. The ball gets faster, the number on a bar goes up, and nothing along the way acknowledges the work the rally is doing. Tiers break the ramp into four distinct beats so the climb has shape. Each tier is a short stretch of rally, ~18-20 well-placed hits, with a recognisable entry speed, a peak, and a handover to the next tier.
+
+Reaching the top of a tier is supposed to register as an event, not as a number crossing a threshold. The companion reward ladder below is the mechanism that registers it.
+
+## Narrative framing
+
+Volley!'s rally fiction lives in the "spirit of the volley" framing from [08 Court Bounds](08-court-bounds.md). A rally is tribute; the spirit answers sustained commitment and lifts the ball while it does. Tiers are how that answer gets louder. Tier 0 is the spirit arriving. Tier 1 is the spirit noticing. Tier 2 is the spirit leaning in. Tier 3 is the spirit fully present, and Peak is the brief window where it is saturating the exchange.
+
+The fiction keeps the rewards diegetic. Tier payoffs are gestures the spirit makes in answer to the rally, not a banner announcing a milestone. The venue rule still holds: nothing pops onto the screen to read, everything is expressed in the court.
+
+Reset, framed in the fiction: a miss sends the spirit away and drops the ball to Tier 0 floor. Tier completion is the spirit settling into a new register and the ball eases into the next band. Peak end without a miss is the spirit receding on its own once its window is spent, and the rally continues on quieter terms.
+
+## Reward ladder
+
+Rewards are what fires on `on_tier_completed`. They are tuned for first playtest, not for final balance.
+
+- **Tier 0 peak** (entering Tier 1). Baseline rally state. No reward fires. The band shift is its own felt beat: the ball arrives in the next register, audio brightens a step, the trail gets a little longer. The rally counter ticks in its normal rhythm.
+- **Tier 1 peak** (entering Tier 2). Small cheer and a sparkle off the ball at the moment of the transition. One FP tick lands on the next paddle hit. The rally counter flourishes, a single beat bigger than its usual tick. No currency, no unlock; the spirit has just noticed.
+- **Tier 2 peak** (entering Tier 3). A bigger audio beat on the transition and a brief aura around the ball that reads through the next few hits. A small currency reward drops as a diegetic shard or coin that arcs into the HUD counter (no banner). The spirit is leaning in.
+- **Tier 3 peak** (Peak window opens). The rare, shop-tier beat. The aura holds for the full Peak window, paddle hits inside Peak play a richer return sound, and the window closes with a banked reward: a shop voucher, an item unlock signal, or a mid-sized currency drop that the player feels in the next shop. Only one Peak reward banks per rally.
+
+All four rewards are opt-in for items; an item effect bound to `on_tier_completed` with a tier filter can add to these without replacing them. Partners can hook `on_peak_hit` (emitted per paddle hit while Peak is open) to add their own beats without any special casing.
+
+Tone constraints: no banners, no floating text, no venue-rule violations. Rewards are a sound, a light, a trail, a coin, or an unlock signal the player will see next time they visit the shop. Cozy and diegetic.
+
+## What a tier climb feels like
+
+A single tier climb is a minute-ish of sustained rally. The speed bar fills inside its current band, the audio wash climbs, and the paddle starts to feel like it matters a little more on each return. At the top of the band the spirit's answer fires (see ladder above), the band resets to the next tier's floor, and the climb starts again from a new base.
+
+Across a full run the player's felt arc is: Tier 0 is the warm-up, Tier 1 is the acknowledgement, Tier 2 is the commitment, Tier 3 is the conversation, and Peak is the moment the conversation lands. Missing anywhere in that arc drops back to Tier 0 and the spirit retreats; the next rally starts the climb over, which is a feature, not a punishment. The work of the run is producing Peak windows, and the shop loop is where Peak rewards get spent.
+
+## Open questions
+
+- Shop-tier reward shape at Tier 3. A voucher (choose next shop slot), an unlock token (advance a partner track), and a banked-currency drop are all viable. Pick one for first playtest; the others become event-bus reward handlers later.
+- Peak-miss penalty. A "crash" that halves this rally's coin take would give Peak risk. Start without it; revisit once the reward ladder has playtest data.
+- Tier 0 peak is currently rewardless. If playtest shows Tier 1 entry feels abrupt, a very small fiction-only beat (a single sparkle, no FP, no coin) can fill the gap without changing the ladder's economy.

--- a/designs/01-prototype/INDEX.md
+++ b/designs/01-prototype/INDEX.md
@@ -36,3 +36,4 @@ The public demo on itch.io. Core loop, first-pass assets, playable by strangers.
 | 18 | [Partner Upgrade Strategy](18-partner-upgrade-strategy.md) |
 | 19 | [Minified Paddle](19-minified-paddle.md) |
 | 20 | [Ball Speed Tiers and Physics Ceiling](20-ball-speed-tiers.md) |
+| 20a | [Ball Speed Tier Progression](20a-ball-speed-tier-progression.md) |

--- a/designs/01-prototype/INDEX.md
+++ b/designs/01-prototype/INDEX.md
@@ -35,3 +35,4 @@ The public demo on itch.io. Core loop, first-pass assets, playable by strangers.
 | 17 | [Partner AI](17-partner-ai.md) |
 | 18 | [Partner Upgrade Strategy](18-partner-upgrade-strategy.md) |
 | 19 | [Minified Paddle](19-minified-paddle.md) |
+| 20 | [Ball Speed Tiers and Physics Ceiling](20-ball-speed-tiers.md) |


### PR DESCRIPTION
Spike defining a world max ball speed (1800 px/s) grounded in the 60 Hz physics tick and existing paddle/wall collider sizes, plus a four-tier speed ladder with per-tier payoffs to replace the current linear ceiling. Rewrites how Cadence, Court Lines, Training Ball, and Wrist Brace interact with speed: tiers constrain the cap, items reshape the climb. Design only, no code touched.

Ticket: https://linear.app/shuck-games/issue/SH-88/ball-speed-tiers-and-physics-ceiling