### PR TITLE
SH-169 prefix PR comments with commenter name

### DIFF
--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -26,9 +26,12 @@ Live scratchpad for parallel agent work. One agent per Linear ticket. Log progre
 
    ```
    gh api -X POST repos/shuck-dev/volley/pulls/<N>/comments \
-     -f body="..." -f commit_id="<sha>" -f path="<file>" \
+     -f body=$'**<commenter>**\n\n<type>: <body>' \
+     -f commit_id="<sha>" -f path="<file>" \
      -F line=<line> -f side=RIGHT
    ```
+
+   ANSI-C quoting (`$'...'`) expands `\n\n` into real newlines, so the bold name sits on its own line above the Conventional Comment. `<commenter>` is a rotating codename for implementation agents (`trillian`, `abe`, `manny`), the role name for review specialists (`ci-and-workflows`, `docs-and-writing`, `code-quality`, etc.), or `josh` for Josh. Replies to existing comments use the same prefix so threaded context stays legible.
 6. **Hand off.** Re-sync against main, then report the PR to Josh. Don't flag comments in chat; the PR is the source of truth.
 7. **Block or spin.** Loop on the same issue twice → escalate (see below). Do not try a third variant silently.
 
@@ -110,6 +113,7 @@ See [`release-playbook.md`](release-playbook.md). Agents read it only when Josh 
 
 | Agent | Ticket | Branch | Files touched | Started | Notes |
 |---|---|---|---|---|---|
+| Ford | SH-169 | sh-169-prefix-pr-comments-with-commenter-name | ai/PARALLEL.md, ai/swarm/README.md, scripts/swarm/post-review.sh | 2026-04-21 | commenter-name prefix on PR comments |
 
 ## Done (recent)
 
@@ -129,5 +133,6 @@ See [`release-playbook.md`](release-playbook.md). Agents read it only when Josh 
 Newest at top. One line per event.
 
 ```
+[SH-169] Ford: claimed; name-prefix rule landed in PARALLEL.md §5, swarm README, post-review.sh
 [init] scratchpad reset on cycle #3 open
 ```

--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -175,7 +175,38 @@ When the verdict is `zaphod-approved`, the organiser applies the label with `gh 
 
 When the verdict is `zaphod-blocked`, the organiser posts a GitHub pull request review with the summary as the review body and each `item` as an inline review comment on its line, via `gh api repos/:owner/:repo/pulls/:pr/reviews` with `event: COMMENT`. Inline review comments are resolvable in the PR UI, so fixes close threads naturally. The organiser then applies `zaphod-blocked`.
 
-`scripts/swarm/post-review.sh` wraps that posting surface: pass a PR number and a verdict JSON file in the shape above, and the script handles structure validation, payload construction with `jq`, the `gh api` post, and the label. It pipes JSON via stdin rather than shell-interpolating comment text, so reviewer prose can carry any punctuation without escaping back into the shell. Approved verdicts apply the label only; blocked verdicts post the review first.
+`scripts/swarm/post-review.sh` wraps that posting surface: pass a PR number and a verdict JSON file in the shape above, and the script handles structure validation, payload construction with `jq`, the `gh api` post, and the label. It pipes JSON via stdin rather than shell-interpolating comment text, so reviewer prose can carry any punctuation without escaping back into the shell. Every `item` also carries a `commenter` field (the role name for reviewers, the rotating codename for implementers, `josh` for Josh); the script prepends `**<commenter>**\n\n` to each body automatically, so agents pass only their identity and the raw Conventional Comment. Approved verdicts apply the label only; blocked verdicts post the review first.
+
+Agents that post comments directly with `gh api` (one-off replies, manual comments outside the reviewer fan-out) follow the template from `ai/PARALLEL.md` §5 and prefix the body by hand. One example per commenter type:
+
+- **Implementation agent (rotating codename).** `trillian` leaves a `note:` on a workflow pin after auto-fixing it:
+
+  ```
+  gh api -X POST repos/shuck-dev/volley/pulls/291/comments \
+    -f body=$'**trillian**\n\nnote: pinned to the tagged SHA; dependabot will bump this alongside the tag.' \
+    -f commit_id="$SHA" -f path=".github/workflows/ci.yml" \
+    -F line=42 -f side=RIGHT
+  ```
+
+- **Review specialist (role name).** `ci-and-workflows` flags a missing permissions block:
+
+  ```
+  gh api -X POST repos/shuck-dev/volley/pulls/291/comments \
+    -f body=$'**ci-and-workflows**\n\nissue: job is missing an explicit `permissions:` block; default is read-all which is broader than needed.' \
+    -f commit_id="$SHA" -f path=".github/workflows/release.yml" \
+    -F line=17 -f side=RIGHT
+  ```
+
+- **Josh.** When Josh comments inline himself the same prefix applies so threaded replies stay consistent:
+
+  ```
+  gh api -X POST repos/shuck-dev/volley/pulls/291/comments \
+    -f body=$'**josh**\n\nquestion: why RIGHT side here rather than the base commit?' \
+    -f commit_id="$SHA" -f path="ai/PARALLEL.md" \
+    -F line=30 -f side=RIGHT
+  ```
+
+Replies to existing comments (`…/comments/{id}/replies`) use the same `**<commenter>**\n\n<type>: <body>` shape, so reply bodies read the same as top-level ones on mobile.
 
 Reviewers never post standalone issue comments on PRs; all actionable feedback lives as line-anchored review comments so Josh can resolve them as they are addressed.
 

--- a/scripts/swarm/post-review.sh
+++ b/scripts/swarm/post-review.sh
@@ -8,8 +8,16 @@
 #   {
 #     "verdict": "zaphod-approved" | "zaphod-blocked",
 #     "summary": "one-sentence overall finding",
+#     "commenter": "<role-or-codename>",  # default commenter for items that
+#                                          # omit their own (reviewer role name,
+#                                          # implementer codename, or "josh")
 #     "items": [                           # required when blocked
-#       {"path": "<file>", "line": <N>, "body": "<concern and fix>"}
+#       {
+#         "path": "<file>",
+#         "line": <N>,
+#         "body": "<type>: <concern and fix>",
+#         "commenter": "<override>"        # optional, overrides top-level
+#       }
 #     ]
 #   }
 #
@@ -19,7 +27,9 @@
 # - zaphod-blocked: posts a GitHub pull-request review with event=COMMENT
 #   (GitHub rejects REQUEST_CHANGES on self-authored PRs), summary as the
 #   review body, and each item as a line-anchored review comment on its
-#   path and line. Then applies zaphod-blocked.
+#   path and line. Each item body is emitted as "**<commenter>**\n\n<body>"
+#   so the author is legible at a glance in the review thread. Then applies
+#   zaphod-blocked.
 #
 # The script always pipes JSON via stdin to `gh api`, never builds the
 # payload by interpolating strings into a shell command, so reviewer
@@ -63,15 +73,32 @@ if [[ "$verdict" == "zaphod-blocked" ]]; then
 	missing=$(jq -r '[(.items // [])[] | select((.path // "") == "" or (.line // null) == null)] | length' "$verdict_file")
 	[[ "$missing" == "0" ]] || die "every item must carry path and line (got $missing malformed)"
 
+	default_commenter=$(jq -r '.commenter // ""' "$verdict_file")
+	missing_commenter=$(
+		jq -r --arg default "$default_commenter" \
+			'[(.items // [])[] | select(((.commenter // $default) | length) == 0)] | length' \
+			"$verdict_file"
+	)
+	[[ "$missing_commenter" == "0" ]] \
+		|| die "every item needs a commenter (set top-level .commenter or .items[].commenter; got $missing_commenter missing)"
+
 	repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 	payload=$(
 		jq -n \
 			--arg summary "$summary" \
+			--arg default_commenter "$default_commenter" \
 			--slurpfile verdict "$verdict_file" \
 			'{
 				event: "COMMENT",
 				body: $summary,
-				comments: ($verdict[0].items | map({path, line, side: "RIGHT", body}))
+				comments: (
+					$verdict[0].items | map({
+						path,
+						line,
+						side: "RIGHT",
+						body: ("**" + (.commenter // $default_commenter) + "**\n\n" + .body)
+					})
+				)
 			}'
 	)
 


### PR DESCRIPTION
Every agent-authored PR comment now leads with a bold commenter line, so the author is legible at a glance without cross-referencing the Active table or a bot avatar. The PARALLEL.md §5 template switches to ANSI-C quoting so the newline between name and Conventional Comment is expanded by the shell, and the swarm README carries one worked example per commenter type (rotating codename, reviewer role, Josh).

`scripts/swarm/post-review.sh` now takes a `commenter` field on each verdict item (or a top-level default) and prepends `**<commenter>**\n\n` to every review comment body automatically, so reviewer agents only pass identity and the raw body.