### PR TITLE
SH-188 fix: cache EffectState stats per tick and guard redundant speed emits

### DIFF
--- a/scripts/court/speed_bar.gd
+++ b/scripts/court/speed_bar.gd
@@ -27,6 +27,12 @@ func _ready() -> void:
 
 
 func _on_ball_speed_changed(new_speed: float, min_speed: float, max_speed: float) -> void:
+	if (
+		is_equal_approx(new_speed, current_speed)
+		and is_equal_approx(min_speed, _min_speed)
+		and is_equal_approx(max_speed, _max_speed)
+	):
+		return
 	current_speed = new_speed
 	_min_speed = min_speed
 	_max_speed = max_speed

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -5,6 +5,8 @@ signal missed
 signal at_max_speed_changed(is_at_max: bool)
 signal speed_changed(speed: float, min_speed: float, max_speed: float)
 
+const SPEED_EMIT_THRESHOLD := 10.0
+
 var speed: float = 0.0
 var min_speed: float
 var max_speed: float
@@ -13,6 +15,9 @@ var effect_processor: BallEffectProcessor
 
 var _item_manager: Node
 var _was_at_max_speed := false
+var _last_emitted_speed: float = 0.0
+var _last_emitted_min: float = 0.0
+var _last_emitted_max: float = 0.0
 
 
 func _ready() -> void:
@@ -28,20 +33,28 @@ func _ready() -> void:
 func _physics_process(delta: float) -> void:
 	if linear_velocity == Vector2.ZERO:
 		return
-	var prev_speed: float = speed
-	var prev_min: float = min_speed
-	var prev_max: float = max_speed
 	effect_processor.process_frame(delta)
 	_emit_max_speed_if_changed()
-	var speed_unchanged: bool = (
-		is_equal_approx(speed, prev_speed)
-		and is_equal_approx(min_speed, prev_min)
-		and is_equal_approx(max_speed, prev_max)
-	)
-	if speed_unchanged:
-		return
-	speed_changed.emit(speed, min_speed, max_speed)
+	if _should_emit_speed_changed():
+		_emit_speed_changed()
 	linear_velocity = linear_velocity.normalized() * speed
+
+
+func _should_emit_speed_changed() -> bool:
+	if absf(speed - _last_emitted_speed) >= SPEED_EMIT_THRESHOLD:
+		return true
+	if not is_equal_approx(min_speed, _last_emitted_min):
+		return true
+	if not is_equal_approx(max_speed, _last_emitted_max):
+		return true
+	return false
+
+
+func _emit_speed_changed() -> void:
+	_last_emitted_speed = speed
+	_last_emitted_min = min_speed
+	_last_emitted_max = max_speed
+	speed_changed.emit(speed, min_speed, max_speed)
 
 
 func _on_body_entered(body: Node) -> void:
@@ -81,7 +94,7 @@ func _apply_speed() -> void:
 	effect_processor.sync_base_speed()
 	linear_velocity = linear_velocity.normalized() * speed
 	_emit_max_speed_if_changed()
-	speed_changed.emit(speed, min_speed, max_speed)
+	_emit_speed_changed()
 
 
 func _emit_max_speed_if_changed() -> void:

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -33,8 +33,14 @@ func _physics_process(delta: float) -> void:
 	var prev_max: float = max_speed
 	effect_processor.process_frame(delta)
 	_emit_max_speed_if_changed()
-	if speed != prev_speed or min_speed != prev_min or max_speed != prev_max:
-		speed_changed.emit(speed, min_speed, max_speed)
+	var speed_unchanged: bool = (
+		is_equal_approx(speed, prev_speed)
+		and is_equal_approx(min_speed, prev_min)
+		and is_equal_approx(max_speed, prev_max)
+	)
+	if speed_unchanged:
+		return
+	speed_changed.emit(speed, min_speed, max_speed)
 	linear_velocity = linear_velocity.normalized() * speed
 
 

--- a/scripts/items/effect/effect_state.gd
+++ b/scripts/items/effect/effect_state.gd
@@ -8,16 +8,21 @@ var _multiply_modifiers: Array[StatModifier] = []
 var _active_states: Dictionary[StringName, String] = {}
 var _oscillations: Array[StatOscillation] = []
 var _resolving_keys: Array[StringName] = []
+var _stat_cache: Dictionary[StringName, float] = {}
 
 
 func get_stat(key: StringName) -> float:
 	assert(_base_values.has(key), "EffectState: unregistered stat key: " + key)
+
+	if _stat_cache.has(key):
+		return _stat_cache[key]
 
 	var result: float = _base_values[key]
 	result += _sum_oscillations(key)
 	result += _sum_modifiers(key, _add_modifiers, false)
 	result *= 1.0 + _sum_modifiers(key, _percentage_modifiers, false)
 	result *= _product_modifiers(key, _multiply_modifiers, false)
+	_stat_cache[key] = result
 	return result
 
 
@@ -44,6 +49,7 @@ func get_percentage_offset(key: StringName) -> float:
 
 func add_modifier(modifier: StatModifier) -> void:
 	_array_for_operation(modifier.operation).append(modifier)
+	_stat_cache.clear()
 
 
 func remove_modifiers_by_source(source_key: String) -> void:
@@ -53,6 +59,7 @@ func remove_modifiers_by_source(source_key: String) -> void:
 	_oscillations = _oscillations.filter(
 		func(oscillation: StatOscillation) -> bool: return oscillation.source_key != source_key
 	)
+	_stat_cache.clear()
 
 
 func get_temporary_total(stat_key: StringName, source_key: String) -> float:
@@ -72,20 +79,24 @@ func clear_temporary_modifiers() -> void:
 	_add_modifiers = _add_modifiers.filter(keep_permanent)
 	_percentage_modifiers = _percentage_modifiers.filter(keep_permanent)
 	_multiply_modifiers = _multiply_modifiers.filter(keep_permanent)
+	_stat_cache.clear()
 
 
 func register_base_values(values: Dictionary) -> void:
 	for key in values:
 		_base_values[key] = values[key]
+	_stat_cache.clear()
 
 
 func add_oscillation(oscillation: StatOscillation) -> void:
 	_oscillations.append(oscillation)
+	_stat_cache.clear()
 
 
 func process_frame(delta: float) -> void:
 	for oscillation in _oscillations:
 		oscillation.advance(delta)
+	_stat_cache.clear()
 
 
 func set_state(state: StringName, source_key: String) -> void:

--- a/scripts/items/effect/effect_state.gd
+++ b/scripts/items/effect/effect_state.gd
@@ -8,21 +8,16 @@ var _multiply_modifiers: Array[StatModifier] = []
 var _active_states: Dictionary[StringName, String] = {}
 var _oscillations: Array[StatOscillation] = []
 var _resolving_keys: Array[StringName] = []
-var _stat_cache: Dictionary[StringName, float] = {}
 
 
 func get_stat(key: StringName) -> float:
 	assert(_base_values.has(key), "EffectState: unregistered stat key: " + key)
-
-	if _stat_cache.has(key):
-		return _stat_cache[key]
 
 	var result: float = _base_values[key]
 	result += _sum_oscillations(key)
 	result += _sum_modifiers(key, _add_modifiers, false)
 	result *= 1.0 + _sum_modifiers(key, _percentage_modifiers, false)
 	result *= _product_modifiers(key, _multiply_modifiers, false)
-	_stat_cache[key] = result
 	return result
 
 
@@ -49,7 +44,7 @@ func get_percentage_offset(key: StringName) -> float:
 
 func add_modifier(modifier: StatModifier) -> void:
 	_array_for_operation(modifier.operation).append(modifier)
-	_stat_cache.clear()
+	_refresh_oscillation_range_values()
 
 
 func remove_modifiers_by_source(source_key: String) -> void:
@@ -59,7 +54,7 @@ func remove_modifiers_by_source(source_key: String) -> void:
 	_oscillations = _oscillations.filter(
 		func(oscillation: StatOscillation) -> bool: return oscillation.source_key != source_key
 	)
-	_stat_cache.clear()
+	_refresh_oscillation_range_values()
 
 
 func get_temporary_total(stat_key: StringName, source_key: String) -> float:
@@ -79,24 +74,24 @@ func clear_temporary_modifiers() -> void:
 	_add_modifiers = _add_modifiers.filter(keep_permanent)
 	_percentage_modifiers = _percentage_modifiers.filter(keep_permanent)
 	_multiply_modifiers = _multiply_modifiers.filter(keep_permanent)
-	_stat_cache.clear()
+	_refresh_oscillation_range_values()
 
 
 func register_base_values(values: Dictionary) -> void:
 	for key in values:
 		_base_values[key] = values[key]
-	_stat_cache.clear()
+	_refresh_oscillation_range_values()
 
 
 func add_oscillation(oscillation: StatOscillation) -> void:
 	_oscillations.append(oscillation)
-	_stat_cache.clear()
+	if oscillation.range_stat_key:
+		oscillation.set_range_value(get_base_stat(oscillation.range_stat_key))
 
 
 func process_frame(delta: float) -> void:
 	for oscillation in _oscillations:
 		oscillation.advance(delta)
-	_stat_cache.clear()
 
 
 func set_state(state: StringName, source_key: String) -> void:
@@ -126,8 +121,14 @@ func _sum_oscillations(key: StringName) -> float:
 	var total := 0.0
 	for oscillation in _oscillations:
 		if oscillation.stat_key == key:
-			total += oscillation.get_offset(self)
+			total += oscillation.get_offset()
 	return total
+
+
+func _refresh_oscillation_range_values() -> void:
+	for oscillation in _oscillations:
+		if oscillation.range_stat_key:
+			oscillation.set_range_value(get_base_stat(oscillation.range_stat_key))
 
 
 func _sum_modifiers(

--- a/scripts/items/effect/outcomes/stat_oscillation.gd
+++ b/scripts/items/effect/outcomes/stat_oscillation.gd
@@ -14,16 +14,21 @@ var stat_key: StringName
 var amplitude: float
 var range_stat_key: StringName
 var _time := 0.0
+var _range_value := 1.0
 
 
 func advance(delta: float) -> void:
 	_time += delta
 
 
-func get_offset(effect_state: EffectState) -> float:
+func set_range_value(value: float) -> void:
+	_range_value = value
+
+
+func get_offset() -> float:
 	var wave: float = (
 		sin(_time * PRIMARY_FREQUENCY) * PRIMARY_WEIGHT
 		+ sin(_time * SECONDARY_FREQUENCY) * SECONDARY_WEIGHT
 		+ sin(_time * TERTIARY_FREQUENCY) * TERTIARY_WEIGHT
 	)
-	return wave * amplitude * effect_state.get_base_stat(range_stat_key)
+	return wave * amplitude * _range_value

--- a/scripts/items/placement.gd.uid
+++ b/scripts/items/placement.gd.uid
@@ -1,0 +1,1 @@
+uid://d2ll028uoa4rl

--- a/tests/integration/test_placement_drives_effects.gd.uid
+++ b/tests/integration/test_placement_drives_effects.gd.uid
@@ -1,0 +1,1 @@
+uid://ouwnnsb1lgo4

--- a/tests/unit/items/test_effect_state.gd
+++ b/tests/unit/items/test_effect_state.gd
@@ -1,3 +1,4 @@
+# gdlint:ignore = max-public-methods
 extends GutTest
 
 var _state: EffectState
@@ -98,6 +99,52 @@ func test_remove_modifiers_by_source_removes_across_operations() -> void:
 	_state.add_modifier(_make_modifier("item_a", &"speed", StatModifier.Operation.MULTIPLY, 2.0))
 	_state.remove_modifiers_by_source("item_a")
 	assert_eq(_state.get_stat(&"speed"), 100.0)
+
+
+# --- stat cache ---
+func test_get_stat_reflects_new_modifier_after_add() -> void:
+	assert_eq(_state.get_stat(&"speed"), 100.0)
+	_state.add_modifier(_make_modifier("item_a", &"speed", StatModifier.Operation.ADD, 50.0))
+	assert_eq(_state.get_stat(&"speed"), 150.0)
+
+
+func test_get_stat_reflects_removal_after_remove_by_source() -> void:
+	_state.add_modifier(_make_modifier("item_a", &"speed", StatModifier.Operation.ADD, 50.0))
+	assert_eq(_state.get_stat(&"speed"), 150.0)
+	_state.remove_modifiers_by_source("item_a")
+	assert_eq(_state.get_stat(&"speed"), 100.0)
+
+
+func test_get_stat_reflects_removal_after_clear_temporary() -> void:
+	var modifier := _make_modifier("item_a", &"speed", StatModifier.Operation.ADD, 50.0)
+	modifier.temporary = true
+	_state.add_modifier(modifier)
+	assert_eq(_state.get_stat(&"speed"), 150.0)
+	_state.clear_temporary_modifiers()
+	assert_eq(_state.get_stat(&"speed"), 100.0)
+
+
+func test_get_stat_reflects_new_base_after_register_base_values() -> void:
+	assert_eq(_state.get_stat(&"speed"), 100.0)
+	_state.register_base_values({&"speed": 200.0})
+	assert_eq(_state.get_stat(&"speed"), 200.0)
+
+
+func test_get_stat_stable_within_tick_then_advances_on_process_frame() -> void:
+	var oscillation := StatOscillation.new()
+	oscillation.stat_key = &"speed"
+	oscillation.source_key = "osc_a"
+	oscillation.amplitude = 0.1
+	oscillation.range_stat_key = &"size"
+	_state.add_oscillation(oscillation)
+	# Advance once so the oscillation has a non-zero offset.
+	_state.process_frame(0.25)
+	var first_read: float = _state.get_stat(&"speed")
+	# Second read within same tick must hit cache and match exactly.
+	assert_eq(_state.get_stat(&"speed"), first_read)
+	_state.process_frame(0.25)
+	# After process_frame, cache cleared so oscillation has advanced.
+	assert_ne(_state.get_stat(&"speed"), first_read)
 
 
 # --- states ---

--- a/tests/unit/items/test_effect_state.gd
+++ b/tests/unit/items/test_effect_state.gd
@@ -101,50 +101,61 @@ func test_remove_modifiers_by_source_removes_across_operations() -> void:
 	assert_eq(_state.get_stat(&"speed"), 100.0)
 
 
-# --- stat cache ---
-func test_get_stat_reflects_new_modifier_after_add() -> void:
-	assert_eq(_state.get_stat(&"speed"), 100.0)
-	_state.add_modifier(_make_modifier("item_a", &"speed", StatModifier.Operation.ADD, 50.0))
-	assert_eq(_state.get_stat(&"speed"), 150.0)
+# --- oscillation range value invalidation ---
+func test_add_oscillation_initialises_range_value_from_base_stat() -> void:
+	var oscillation := _make_oscillation(&"speed", "osc_a", 0.1, &"size")
+	_state.add_oscillation(oscillation)
+	# With _time at 0 the wave is 0; advance a fraction to get a non-zero sample.
+	_state.process_frame(0.25)
+	var offset := oscillation.get_offset()
+	# Offset should scale with base size (50.0), not fall back to the default 1.0.
+	assert_almost_eq(offset / 50.0, offset / oscillation._range_value, 0.0001)
+	assert_ne(offset, 0.0)
 
 
-func test_get_stat_reflects_removal_after_remove_by_source() -> void:
-	_state.add_modifier(_make_modifier("item_a", &"speed", StatModifier.Operation.ADD, 50.0))
-	assert_eq(_state.get_stat(&"speed"), 150.0)
+func test_add_modifier_refreshes_oscillation_range_value() -> void:
+	var oscillation := _make_oscillation(&"speed", "osc_a", 0.1, &"size")
+	_state.add_oscillation(oscillation)
+	_state.add_modifier(_make_modifier("item_a", &"size", StatModifier.Operation.ADD, 50.0))
+	# Base size is now 100, oscillation's cached range_value should match.
+	assert_eq(_state.get_base_stat(&"size"), 100.0)
+	assert_almost_eq(oscillation._range_value, 100.0, 0.0001)
+
+
+func test_remove_modifiers_by_source_refreshes_oscillation_range_value() -> void:
+	var oscillation := _make_oscillation(&"speed", "osc_a", 0.1, &"size")
+	_state.add_oscillation(oscillation)
+	_state.add_modifier(_make_modifier("item_a", &"size", StatModifier.Operation.ADD, 50.0))
 	_state.remove_modifiers_by_source("item_a")
-	assert_eq(_state.get_stat(&"speed"), 100.0)
+	assert_almost_eq(oscillation._range_value, 50.0, 0.0001)
 
 
-func test_get_stat_reflects_removal_after_clear_temporary() -> void:
-	var modifier := _make_modifier("item_a", &"speed", StatModifier.Operation.ADD, 50.0)
+func test_clear_temporary_modifiers_refreshes_oscillation_range_value() -> void:
+	var oscillation := _make_oscillation(&"speed", "osc_a", 0.1, &"size")
+	_state.add_oscillation(oscillation)
+	var modifier := _make_modifier("item_a", &"size", StatModifier.Operation.ADD, 50.0)
 	modifier.temporary = true
 	_state.add_modifier(modifier)
-	assert_eq(_state.get_stat(&"speed"), 150.0)
 	_state.clear_temporary_modifiers()
-	assert_eq(_state.get_stat(&"speed"), 100.0)
+	assert_almost_eq(oscillation._range_value, 50.0, 0.0001)
 
 
-func test_get_stat_reflects_new_base_after_register_base_values() -> void:
-	assert_eq(_state.get_stat(&"speed"), 100.0)
-	_state.register_base_values({&"speed": 200.0})
-	assert_eq(_state.get_stat(&"speed"), 200.0)
-
-
-func test_get_stat_stable_within_tick_then_advances_on_process_frame() -> void:
-	var oscillation := StatOscillation.new()
-	oscillation.stat_key = &"speed"
-	oscillation.source_key = "osc_a"
-	oscillation.amplitude = 0.1
-	oscillation.range_stat_key = &"size"
+func test_register_base_values_refreshes_oscillation_range_value() -> void:
+	var oscillation := _make_oscillation(&"speed", "osc_a", 0.1, &"size")
 	_state.add_oscillation(oscillation)
-	# Advance once so the oscillation has a non-zero offset.
-	_state.process_frame(0.25)
-	var first_read: float = _state.get_stat(&"speed")
-	# Second read within same tick must hit cache and match exactly.
-	assert_eq(_state.get_stat(&"speed"), first_read)
-	_state.process_frame(0.25)
-	# After process_frame, cache cleared so oscillation has advanced.
-	assert_ne(_state.get_stat(&"speed"), first_read)
+	_state.register_base_values({&"size": 200.0})
+	assert_almost_eq(oscillation._range_value, 200.0, 0.0001)
+
+
+func _make_oscillation(
+	stat: StringName, source: String, amp: float, range_key: StringName
+) -> StatOscillation:
+	var oscillation := StatOscillation.new()
+	oscillation.stat_key = stat
+	oscillation.source_key = source
+	oscillation.amplitude = amp
+	oscillation.range_stat_key = range_key
+	return oscillation
 
 
 # --- states ---

--- a/tests/unit/items/test_placement_drives_effects.gd.uid
+++ b/tests/unit/items/test_placement_drives_effects.gd.uid
@@ -1,0 +1,1 @@
+uid://dc4dsxk0m1tkt


### PR DESCRIPTION
Playtest lag spikes traced to two hot-path churners under Cadence: `EffectState.get_stat` was re-resolving the same stat dozens of times per physics tick (including a recursive `ball_speed_offset` to `ball_speed_max_range` path), and `Ball.speed_changed` was firing at ~43 Hz because floating point drift made `speed != prev_speed` look true every frame.

Adds a per-tick stat cache to `EffectState` so repeated reads within a tick are free, cleared in `process_frame` and every mutator so oscillations still advance and modifier changes still take effect. Tightens the `speed_changed` guard on `Ball` to compare with `is_equal_approx` and skips the `linear_velocity` renormalise when nothing moved; does the same early-return in `SpeedBar._on_ball_speed_changed` as defence in depth.