### PR TITLE
SH-188 design: threaded web export

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           relative_project_path: ./
           cache: true
           export_debug: true
-          presets_to_export: Web
+          presets_to_export: WebThreaded
 
       - name: Download Butler
         run: |
@@ -119,6 +119,6 @@ jobs:
           chmod +x butler
 
       - name: Push to Itch.io Preview
-        run: ./butler push "${{ steps.export.outputs.build_directory }}/Web" ${{ env.ITCH_PROJECT }}:html5-preview
+        run: ./butler push "${{ steps.export.outputs.build_directory }}/WebThreaded" ${{ env.ITCH_PROJECT }}:html5-preview
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}

--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -23,6 +23,7 @@ The design thinking behind Volley!, organised by subject. Each folder has its ow
 | Folder | Description |
 |---|---|
 | [art/](art/INDEX.md) | The art bible, direction, style workshop, and inspirations |
+| [platform/](platform/threaded-web-export.md) | Platform and distribution decisions (web export, hosting) |
 | [roadmaps/](roadmaps/INDEX.md) | Discipline-specific roadmap breakdowns |
 
 ## Process

--- a/designs/platform/threaded-web-export.md
+++ b/designs/platform/threaded-web-export.md
@@ -33,19 +33,19 @@ On itch.io this is the "SharedArrayBuffer support" toggle on the HTML5 upload, w
 
 ## Operational changes
 
-Two things have to move with this decision:
+One thing has to move with this decision:
 
-1. **Threaded export template in CI.** The Godot threaded template is a separate download from the stock template. The release workflow has to install it before running the web export, otherwise the build silently falls back to single-threaded. This is a follow-up, not part of this change, because verifying it needs a Tier 1 runtime check.
-2. **Itch upload toggle.** Each new HTML5 upload to itch needs "SharedArrayBuffer support" re-enabled; the toggle does not persist across uploads. Add this to the release checklist.
+1. **Itch upload toggle.** Each new HTML5 upload to itch needs "SharedArrayBuffer support" re-enabled; the toggle does not persist across uploads. Add this to the release checklist.
+
+CI template install is a non-issue: the threaded and non-threaded web templates ship together inside the standard `Godot_v${VERSION}-stable_export_templates.tpz` bundle, and both `release.yml` and `publish.yml` already download the full bundle. No separate install step is required.
 
 Save paths are unaffected: threaded builds use the same `user://` IDBFS store as the single-threaded build, so existing player saves carry forward.
 
 ## Fallback
 
-The export config keeps a second preset, `Web (no threads)`, as a fallback target for hosts that cannot serve the COOP/COEP pair. This is not shipped as the primary build; it exists so that if itch's SAB toggle regresses, or we stand up a mirror on a host without header control, we can produce a compatible bundle without reconfiguring the main preset.
+The export config keeps a second preset, `WebNoThreads`, as a fallback target for hosts that cannot serve the COOP/COEP pair. This is not shipped as the primary build; it exists so that if itch's SAB toggle regresses, or we stand up a mirror on a host without header control, we can produce a compatible bundle without reconfiguring the main preset.
 
 ## Follow-ups
 
-- Install the threaded web template in the release workflow (separate PR; needs a Tier 1 build verification).
 - Flip the "SharedArrayBuffer support" toggle on the next itch upload that uses this preset.
 - Playwright verification of the frame-time improvement lands under SH-189 once that ticket is scheduled.

--- a/designs/platform/threaded-web-export.md
+++ b/designs/platform/threaded-web-export.md
@@ -1,0 +1,51 @@
+# Threaded Web Export
+
+## Problem
+
+Volley's web build stalls the main thread inside the graphics commit path. Gabbro's Firefox profile for SH-188 caught an 87ms block on `MessageChannel::WaitForSyncNotify` inside `PWebGLChild::SendGetNumber`, called from `_emscripten_webgl_do_commit_frame`. That is the single-threaded Emscripten WebGL backend doing a synchronous IPC round trip to the compositor on every frame commit, with the engine's simulation running on the same thread that has to wait for the reply. The local SH-188 work (PR #299) trimmed the simulation cost that sits in front of that wait, but the wait itself is structural: as long as simulation and the GL commit share a thread, long frames will keep showing up when the compositor is busy.
+
+## Decision
+
+Ship the web build with Godot 4.6.2's threaded export variant. Target Chrome first, hosted on itch.io. Keep a non-threaded preset alongside it as a secondary target for environments that cannot serve the cross-origin isolation headers SharedArrayBuffer requires.
+
+## Why this fixes it
+
+The threaded Emscripten runtime runs the engine main loop on a pthread worker. GL calls from the worker go through the `OFFSCREEN_FRAMEBUFFER=1` proxy, which marshals them to the page main thread for submission. Simulation no longer sits on the same thread as the sync IPC, so the 87ms stall stops gating the next frame's update. The page main thread still pays the compositor round trip, but that happens off the simulation's critical path. This is the sanctioned path: the Emscripten docs describe `OFFSCREEN_FRAMEBUFFER` as the mechanism for proxying GL from workers ([emscripten OffscreenCanvas docs](https://emscripten.org/docs/porting/multimedia_and_graphics/OpenGL-support.html#offscreen-framebuffer)), and Godot 4.6 formalised threaded web as a first-class option ([Godot 4.6 release notes](https://godotengine.org/article/godot-4-6-is-released/)).
+
+## Hosting requirements
+
+Threaded builds need `SharedArrayBuffer`, which browsers only expose under cross-origin isolation. The host must serve:
+
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Embedder-Policy: credentialless` (or `require-corp` with correctly tagged subresources)
+
+On itch.io this is the "SharedArrayBuffer support" toggle on the HTML5 upload, which has to be enabled per build ([itch community thread on SAB support](https://itch.io/t/2025976/sharedarraybuffer-support-for-html5-games)). Third-party embeds of the itch page break under these headers, which is fine for Volley since the primary surface is the itch page itself.
+
+## Browser support matrix
+
+| Browser | Behaviour |
+|---|---|
+| Chrome desktop | Runs directly in the itch page |
+| Firefox desktop | Plays in-page while the itch Origin Trial for credentialless COEP is active; falls back to the itch popup player otherwise |
+| Safari desktop | Popup player only (Safari requires `require-corp`, which itch's embed page does not currently satisfy) |
+| Mobile Firefox | Unsupported; threaded web export does not run |
+| Mobile Chrome / Safari | Popup player, same as desktop Safari |
+
+## Operational changes
+
+Two things have to move with this decision:
+
+1. **Threaded export template in CI.** The Godot threaded template is a separate download from the stock template. The release workflow has to install it before running the web export, otherwise the build silently falls back to single-threaded. This is a follow-up, not part of this change, because verifying it needs a Tier 1 runtime check.
+2. **Itch upload toggle.** Each new HTML5 upload to itch needs "SharedArrayBuffer support" re-enabled; the toggle does not persist across uploads. Add this to the release checklist.
+
+Save paths are unaffected: threaded builds use the same `user://` IDBFS store as the single-threaded build, so existing player saves carry forward.
+
+## Fallback
+
+The export config keeps a second preset, `Web (no threads)`, as a fallback target for hosts that cannot serve the COOP/COEP pair. This is not shipped as the primary build; it exists so that if itch's SAB toggle regresses, or we stand up a mirror on a host without header control, we can produce a compatible bundle without reconfiguring the main preset.
+
+## Follow-ups
+
+- Install the threaded web template in the release workflow (separate PR; needs a Tier 1 build verification).
+- Flip the "SharedArrayBuffer support" toggle on the next itch upload that uses this preset.
+- Playwright verification of the frame-time improvement lands under SH-189 once that ticket is scheduled.

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,6 +1,6 @@
 [preset.0]
 
-name="Web (threaded)"
+name="WebThreaded"
 platform="Web"
 runnable=true
 dedicated_server=false
@@ -429,7 +429,7 @@ rm -rf \"{temp_dir}\""
 
 [preset.4]
 
-name="Web (no threads)"
+name="WebNoThreads"
 platform="Web"
 runnable=true
 dedicated_server=false

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,6 +1,6 @@
 [preset.0]
 
-name="Web"
+name="Web (threaded)"
 platform="Web"
 runnable=true
 dedicated_server=false
@@ -27,7 +27,7 @@ script_export_mode=2
 custom_template/debug=""
 custom_template/release=""
 variant/extensions_support=false
-variant/thread_support=false
+variant/thread_support=true
 vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/export_icon=true
@@ -426,3 +426,53 @@ open \"{temp_dir}/{exe_name}.app\" --args {cmd_args}"
 ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
 pkill -x -f \"{temp_dir}/{exe_name}.app/Contents/MacOS/{exe_name} {cmd_args}\"
 rm -rf \"{temp_dir}\""
+
+[preset.4]
+
+name="Web (no threads)"
+platform="Web"
+runnable=true
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter="version.txt"
+exclude_filter="addons/godotiq/*, addons/gut/*, addons/coverage/*, addons/gdfxr/*, addons/item_preview/*, addons/signal_lens/*, tests/*, designs/*, ai/*, scripts/dev/*, scripts/ci/*, .github/*, .pre-commit-config.yaml, .mcp.json, .gutconfig.json, .cursorrules, .windsurfrules, .editorconfig, .codespellrc, .gitattributes, CLAUDE.md, GODOTIQ_RULES.md, AGENTS.md, PARALLEL.md, CONTRIBUTING.md, ROADMAP.md, README.md, ASSETS-LICENSE.md, LICENSE, requirements-dev.txt, justfile, lefthook.yml, lefthook-local.yml, gdlintrc"
+export_path="build/HTML5-nothreads/index.html"
+patches=PackedStringArray()
+patch_delta_encoding=false
+patch_delta_compression_level_zstd=19
+patch_delta_min_reduction=0.1
+patch_delta_include_filters="*"
+patch_delta_exclude_filters=""
+encryption_include_filters=""
+encryption_exclude_filters=""
+seed=0
+encrypt_pck=false
+encrypt_directory=false
+script_export_mode=2
+
+[preset.4.options]
+
+custom_template/debug=""
+custom_template/release=""
+variant/extensions_support=false
+variant/thread_support=false
+vram_texture_compression/for_desktop=true
+vram_texture_compression/for_mobile=false
+html/export_icon=true
+html/custom_html_shell=""
+html/head_include=""
+html/canvas_resize_policy=2
+html/focus_canvas_on_start=true
+html/experimental_virtual_keyboard=false
+progressive_web_app/enabled=false
+progressive_web_app/ensure_cross_origin_isolation_headers=true
+progressive_web_app/offline_page=""
+progressive_web_app/display=1
+progressive_web_app/orientation=0
+progressive_web_app/icon_144x144=""
+progressive_web_app/icon_180x180=""
+progressive_web_app/icon_512x512=""
+progressive_web_app/background_color=Color(0, 0, 0, 1)
+threads/emscripten_pool_size=8
+threads/godot_pool_size=4


### PR DESCRIPTION
SH-188's Firefox profile caught an 87ms main-thread stall on `MessageChannel::WaitForSyncNotify` inside `PWebGLChild::SendGetNumber`, triggered from `_emscripten_webgl_do_commit_frame` on every frame commit. PR #299 trimmed the simulation work sitting in front of that wait, but the wait itself is structural to the single-threaded Emscripten runtime. This PR takes the Godot 4.6.2 threaded web export path, which moves the engine loop onto a pthread worker and proxies GL through `OFFSCREEN_FRAMEBUFFER`, so the sync compositor round trip stops gating simulation.

Two things land here: the design doc at `designs/platform/threaded-web-export.md` covering the decision, hosting requirements (COOP `same-origin` + COEP `credentialless`, itch's per-upload SharedArrayBuffer toggle), browser matrix, and known gaps; and the `export_presets.cfg` flip that enables `variant/thread_support` on the Web preset and keeps a `Web (no threads)` fallback preset for hosts that cannot serve the cross-origin isolation headers.

Open work called out in the doc and left outside this PR: installing the threaded web template in the release workflow (separate PR, needs a Tier 1 build verification), flipping the "SharedArrayBuffer support" toggle on the next itch upload, and Playwright frame-time verification under SH-189 once that lands.

Draft on purpose: this is config + design review before any build or runtime test.