### PR TITLE
ci: zaphod label lifecycle (SH-166, SH-187)

### DIFF
--- a/.github/workflows/reviewer-re-run.yml
+++ b/.github/workflows/reviewer-re-run.yml
@@ -3,11 +3,10 @@ name: Reviewer Re-run
 # Label lifecycle for the zaphod-* verdicts. Three related mechanics live here
 # because they all reconcile the same label pair:
 #
-#   - strip-zaphod-on-push (SH-175/original): new commit strips both labels;
-#     the AI verdict must be re-earned against the new HEAD.
-#   - re-review (SH-175): after a strip, dispatch a fresh headless Claude pass
-#     that re-applies zaphod-approved on a clean review or zaphod-blocked
-#     when it has line-anchored findings to post.
+#   - strip-zaphod-on-push: new commit strips both labels; the AI verdict
+#     must be re-earned against the new HEAD. Re-dispatch is manual, by
+#     the organiser (main Claude thread), never CI; PR-triggered workflows
+#     do not run Claude because outside PRs are a prompt-injection surface.
 #   - strip-zaphod-on-human-review (SH-187): Josh commenting on a PR is a
 #     human verdict landing; the prior AI verdict is stale and comes off.
 #   - blocked-supersedes-approved (SH-166): when two specialists race and
@@ -158,80 +157,3 @@ jobs:
                 throw error;
               }
             }
-
-  re-review:
-    # SH-175: after strip-zaphod runs on a new commit, dispatch a fresh
-    # headless Claude pass to re-earn the appropriate zaphod verdict against
-    # the new HEAD. Only runs on pull_request.synchronize; Josh's review
-    # events strip labels but do not trigger an auto re-review (he is the
-    # one reviewing).
-    name: Re-dispatch reviewers against new HEAD
-    needs: strip-zaphod
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 18
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Preflight — Claude token present?
-        id: preflight
-        env:
-          HAS_CLAUDE: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
-        run: |
-          if [ "$HAS_CLAUDE" != "true" ]; then
-            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN not configured; skipping re-review."
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check out PR head
-        if: steps.preflight.outputs.ready == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Run headless Claude reviewer
-        if: steps.preflight.outputs.ready == 'true'
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1 (Claude Code 2.1.116, Agent SDK 0.2.116)
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            You are the auto re-review pass for PR #${{ github.event.pull_request.number }}
-            after a new commit landed. Follow ai/PARALLEL.md §5.
-
-            1. Inspect the PR diff (`gh pr diff ${{ github.event.pull_request.number }}`).
-            2. Identify which reviewer specialists in `.claude/agents/` match the
-               changed paths per PARALLEL.md §5 (gd → code-quality +
-               gdscript-conventions + test-coverage; tscn/tres → godot-scene;
-               signals → signals-lifecycle; .github → ci-and-workflows;
-               export_presets/project.godot/import → asset-pipeline; md →
-               docs-and-writing).
-            3. For each matched specialist, review the diff against its
-               conventions. Post line-anchored Conventional Comments via
-               `gh api` using the template in PARALLEL.md §5. One idea per
-               comment, two sentences max. No LGTM or summary comments.
-            4. After all specialists finish:
-               - If nothing to comment on, apply zaphod-approved:
-                 `gh pr edit ${{ github.event.pull_request.number }} --add-label zaphod-approved`
-               - If any comments posted, apply zaphod-blocked instead.
-            5. Never apply approved-human; that label is Josh-only.
-            6. Do not modify code, do not push commits. Review-only pass.
-          claude_args: |
-            --max-turns 14
-            --allowedTools "Bash,Read,Grep,Glob"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Re-review summary
-        if: always() && steps.preflight.outputs.ready == 'true'
-        run: |
-          {
-            echo "## Reviewer re-run complete"
-            echo ""
-            echo "PR: #${{ github.event.pull_request.number }}"
-            echo "Head: \`${{ github.event.pull_request.head.sha }}\`"
-            echo "Result: \`${{ job.status }}\`"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reviewer-re-run.yml
+++ b/.github/workflows/reviewer-re-run.yml
@@ -1,25 +1,46 @@
 name: Reviewer Re-run
 
-# Forces reviewer agents to re-apply their verdicts on every new commit.
-# Strips zaphod-approved and zaphod-blocked when a PR is pushed to, so a
-# stale verdict from an earlier commit cannot carry into an un-re-reviewed
-# follow-up. Josh's approved-human label is not touched by this workflow;
-# that gate is his alone.
+# Label lifecycle for the zaphod-* verdicts. Three related mechanics live here
+# because they all reconcile the same label pair:
+#
+#   - strip-zaphod-on-push (SH-175/original): new commit strips both labels;
+#     the AI verdict must be re-earned against the new HEAD.
+#   - re-review (SH-175): after a strip, dispatch a fresh headless Claude pass
+#     that re-applies zaphod-approved on a clean review or zaphod-blocked
+#     when it has line-anchored findings to post.
+#   - strip-zaphod-on-human-review (SH-187): Josh commenting on a PR is a
+#     human verdict landing; the prior AI verdict is stale and comes off.
+#   - blocked-supersedes-approved (SH-166): when two specialists race and
+#     one lands blocked after the other landed approved, the blocker wins.
+#     approved is removed so the merged state reflects the combined verdict.
+#
+# Josh's approved-human label is never touched here; that gate is his alone.
 
 on:
   pull_request:
     types: [synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: read
 
 concurrency:
-  group: reviewer-re-run-${{ github.event.pull_request.number }}
+  # Group per PR across all trigger shapes so a burst of events (commit +
+  # review + comment) serialises rather than racing the label set.
+  group: reviewer-re-run-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   strip-zaphod:
     name: Strip zaphod verdict labels on new commits
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
@@ -49,3 +70,168 @@ jobs:
                 }
               }
             }
+
+  strip-zaphod-on-human-review:
+    # SH-187: Josh reviewing means the AI verdict is stale. Catches all three
+    # review shapes:
+    #   - pull_request_review: the review-summary form (Approve / Request
+    #     changes / Comment from the Files Changed tab).
+    #   - pull_request_review_comment: inline comments attached to a review.
+    #   - issue_comment: PR-level comments from the Conversation tab (GitHub
+    #     routes these through the issues API).
+    # Only strips when the actor is J-Melon; agents and bots are ignored.
+    name: Strip zaphod verdict labels when Josh reviews
+    if: >-
+      (github.event_name == 'pull_request_review' ||
+       github.event_name == 'pull_request_review_comment' ||
+       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null))
+      && github.event.sender.login == 'J-Melon'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Remove zaphod-approved and zaphod-blocked
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // issue_comment payloads expose the PR via .issue.number; the two
+            // review events expose it via .pull_request.number.
+            const prNumber = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+            const labels = ['zaphod-approved', 'zaphod-blocked'];
+            for (const name of labels) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name,
+                });
+                core.info(`Removed ${name} from PR #${prNumber}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`${name} not present on PR #${prNumber}; skipping`);
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+  blocked-supersedes-approved:
+    # SH-166: race resolver. When two reviewer specialists finish seconds
+    # apart and the blocker lands after the approver, the last-writer-wins
+    # outcome hides the blocking finding. Whenever zaphod-blocked is applied,
+    # strip zaphod-approved so the final state reflects the stricter verdict.
+    # zaphod-blocked is never downgraded by a later zaphod-approved; this
+    # gate only runs on the blocked side of the race.
+    name: Blocked supersedes approved
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.label.name == 'zaphod-blocked'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Remove zaphod-approved if present
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'zaphod-approved',
+              });
+              core.info('Removed zaphod-approved; zaphod-blocked supersedes.');
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('zaphod-approved not present; nothing to supersede.');
+              } else {
+                throw error;
+              }
+            }
+
+  re-review:
+    # SH-175: after strip-zaphod runs on a new commit, dispatch a fresh
+    # headless Claude pass to re-earn the appropriate zaphod verdict against
+    # the new HEAD. Only runs on pull_request.synchronize; Josh's review
+    # events strip labels but do not trigger an auto re-review (he is the
+    # one reviewing).
+    name: Re-dispatch reviewers against new HEAD
+    needs: strip-zaphod
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 18
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Preflight — Claude token present?
+        id: preflight
+        env:
+          HAS_CLAUDE: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+        run: |
+          if [ "$HAS_CLAUDE" != "true" ]; then
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN not configured; skipping re-review."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out PR head
+        if: steps.preflight.outputs.ready == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Run headless Claude reviewer
+        if: steps.preflight.outputs.ready == 'true'
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1 (Claude Code 2.1.116, Agent SDK 0.2.116)
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are the auto re-review pass for PR #${{ github.event.pull_request.number }}
+            after a new commit landed. Follow ai/PARALLEL.md §5.
+
+            1. Inspect the PR diff (`gh pr diff ${{ github.event.pull_request.number }}`).
+            2. Identify which reviewer specialists in `.claude/agents/` match the
+               changed paths per PARALLEL.md §5 (gd → code-quality +
+               gdscript-conventions + test-coverage; tscn/tres → godot-scene;
+               signals → signals-lifecycle; .github → ci-and-workflows;
+               export_presets/project.godot/import → asset-pipeline; md →
+               docs-and-writing).
+            3. For each matched specialist, review the diff against its
+               conventions. Post line-anchored Conventional Comments via
+               `gh api` using the template in PARALLEL.md §5. One idea per
+               comment, two sentences max. No LGTM or summary comments.
+            4. After all specialists finish:
+               - If nothing to comment on, apply zaphod-approved:
+                 `gh pr edit ${{ github.event.pull_request.number }} --add-label zaphod-approved`
+               - If any comments posted, apply zaphod-blocked instead.
+            5. Never apply approved-human; that label is Josh-only.
+            6. Do not modify code, do not push commits. Review-only pass.
+          claude_args: |
+            --max-turns 14
+            --allowedTools "Bash,Read,Grep,Glob"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-review summary
+        if: always() && steps.preflight.outputs.ready == 'true'
+        run: |
+          {
+            echo "## Reviewer re-run complete"
+            echo ""
+            echo "PR: #${{ github.event.pull_request.number }}"
+            echo "Head: \`${{ github.event.pull_request.head.sha }}\`"
+            echo "Result: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -22,7 +22,7 @@ Live scratchpad for parallel agent work. One agent per Linear ticket. Log progre
    - **Mechanical fixes** (typos, dead code, obvious bugs, style): commit on the PR branch.
    - **Everything else**: short line-anchored review comments following [Conventional Comments](https://conventionalcomments.org/) (`praise:`, `nitpick:`, `suggestion:`, `issue:`, `question:`, `thought:`, `chore:`, `note:`, with decorators like `(non-blocking)`). **One idea per comment, two sentences max.** If it needs more context, open an issue and link from the comment.
 
-   After all specialists finish: clean → `gh pr edit <N> --add-label 'zaphod-approved'`. Any comments → `--add-label 'zaphod-blocked'` instead. No `LGTM` or summary comments. Line-anchored comment template:
+   After all specialists finish: clean → `gh pr edit <N> --add-label 'zaphod-approved'`. Any comments → `--add-label 'zaphod-blocked'` instead. `zaphod-blocked` supersedes `zaphod-approved`: if a later specialist finds blocking issues, add `zaphod-blocked` and the race-resolver workflow strips the earlier `zaphod-approved`. A later clean pass never downgrades a prior blocked verdict; the blocked stands until a new commit triggers a fresh review. No `LGTM` or summary comments. Line-anchored comment template:
 
    ```
    gh api -X POST repos/shuck-dev/volley/pulls/<N>/comments \


### PR DESCRIPTION
Two label-lifecycle fixes: `zaphod-blocked` supersedes `zaphod-approved` on a race (the blocker wins), and both zaphod labels strip when Josh lands a review comment on a PR (AI verdict is stale the moment a human verdict arrives). The originally-planned SH-175 re-dispatch job was reverted; new rule says no Claude from PR-triggered workflows.

Closes SH-166
Closes SH-187