### PR TITLE
docs: agent definition refresh (SH-160, SH-162, SH-163, SH-182)

### DIFF
--- a/.claude/agents/asset-pipeline.md
+++ b/.claude/agents/asset-pipeline.md
@@ -26,4 +26,4 @@ You review Godot project-config and import-pipeline diffs. `gdlint` does not tou
 
 ## Output
 
-Mechanical fixes (flipping `codesign=1` with empty identity to `0`, adding a missing comma in an exclude list) as commits. Everything else (preset parity questions, runtime-path excludes, platform-flag tradeoffs) as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Orchestrator applies `ai-approved` or `action-required` based on your output.
+Mechanical fixes (flipping `codesign=1` with empty identity to `0`, adding a missing comma in an exclude list) as commits. Everything else (preset parity questions, runtime-path excludes, platform-flag tradeoffs) as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Organiser applies `zaphod-approved` when your verdict is clean, or `zaphod-blocked` with your line-anchored items. PR comments prefix with `**<role-name>**\n\n<body>` per `ai/swarm/README.md`.

--- a/.claude/agents/ci-and-workflows.md
+++ b/.claude/agents/ci-and-workflows.md
@@ -25,4 +25,4 @@ You review GitHub Actions workflow changes. CI runs them; nothing reviews whethe
 
 ## Output
 
-Mechanical fixes (add a missing `permissions:` block, move a secret inline, add a timeout) as commits. Broader suggestions (e.g. restructure job graph) as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Orchestrator applies `ai-approved` or `action-required` based on your output; this specialist does not post comments beyond the review content.
+Mechanical fixes (add a missing `permissions:` block, move a secret inline, add a timeout) as commits. Broader suggestions (e.g. restructure job graph) as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Organiser applies `zaphod-approved` when your verdict is clean, or `zaphod-blocked` with your line-anchored items. PR comments prefix with `**<role-name>**\n\n<body>` per `ai/swarm/README.md`.

--- a/.claude/agents/code-quality.md
+++ b/.claude/agents/code-quality.md
@@ -28,6 +28,6 @@ Do not re-report any of the above.
 
 ## Output
 
-Mechanical fixes (typos in identifier names, obvious dead code, clear duplication with an obvious dedupe) as commits. Everything else (naming debates, design tradeoffs, architectural suggestions) as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Orchestrator applies `ai-approved` or `action-required` based on your output.
+Mechanical fixes (typos in identifier names, obvious dead code, clear duplication with an obvious dedupe) as commits. Everything else (naming debates, design tradeoffs, architectural suggestions) as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Organiser applies `zaphod-approved` when your verdict is clean, or `zaphod-blocked` with your line-anchored items. PR comments prefix with `**<role-name>**\n\n<body>` per `ai/swarm/README.md`.
 
 Never flag an item that is already covered by `ai/PARALLEL.md`, `CLAUDE.md`, or CI hooks. Those rules exist; your value is pattern-matching against the diff.

--- a/.claude/agents/docs-and-writing.md
+++ b/.claude/agents/docs-and-writing.md
@@ -1,7 +1,7 @@
 ---
 name: docs-and-writing
 description: Review `.md` diffs for `ai/STYLE.md` compliance: no em dashes, no AI-tell vocabulary, narrative voice, citation format. Skips spelling (codespell covers). Fires on any `**/*.md` change.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Edit, Bash
 ---
 
 You review markdown diffs for prose quality against the project style guide at `ai/STYLE.md`. That guide is authoritative; this agent enforces it.
@@ -27,4 +27,4 @@ You review markdown diffs for prose quality against the project style guide at `
 
 ## Output
 
-Mechanical rewrites (em dashes, banned words, filler) as commits. Reserve short line-anchored review comments for structural issues ("this section restates the thesis", "this paragraph should end two sentences earlier"), following Conventional Comments per `ai/PARALLEL.md`. Orchestrator applies `ai-approved` or `action-required` based on your output.
+Mechanical rewrites (em dashes, banned words, filler) as commits. Reserve short line-anchored review comments for structural issues ("this section restates the thesis", "this paragraph should end two sentences earlier"), following Conventional Comments per `ai/PARALLEL.md`. Organiser applies `zaphod-approved` when your verdict is clean, or `zaphod-blocked` with your line-anchored items. PR comments prefix with `**<role-name>**\n\n<body>` per `ai/swarm/README.md`.

--- a/.claude/agents/gdscript-conventions.md
+++ b/.claude/agents/gdscript-conventions.md
@@ -23,4 +23,4 @@ You review `.gd` diffs for Volley-specific GDScript conventions that `gdlint` do
 
 ## Output
 
-Mechanical fixes (e.g. `@onready` → `@export` for a simple node ref; adding types to an obvious function) as commits. Broader structural suggestions as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Orchestrator applies `ai-approved` or `action-required` based on your output.
+Mechanical fixes (e.g. `@onready` → `@export` for a simple node ref; adding types to an obvious function) as commits. Broader structural suggestions as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Organiser applies `zaphod-approved` when your verdict is clean, or `zaphod-blocked` with your line-anchored items. PR comments prefix with `**<role-name>**\n\n<body>` per `ai/swarm/README.md`.

--- a/.claude/agents/godot-scene.md
+++ b/.claude/agents/godot-scene.md
@@ -23,4 +23,4 @@ You review Godot scene and resource diffs. `gdlint` does not read `.tscn`, so ev
 
 ## Output
 
-Scene edits are hard to auto-rewrite, so expect comments over commits. Post short line-anchored review comments on the `[node name="X"]` or `[ext_resource]` line, following Conventional Comments per `ai/PARALLEL.md`. Orchestrator applies `ai-approved` or `action-required` based on your output.
+Scene edits are hard to auto-rewrite, so expect comments over commits. Post short line-anchored review comments on the `[node name="X"]` or `[ext_resource]` line, following Conventional Comments per `ai/PARALLEL.md`. Organiser applies `zaphod-approved` when your verdict is clean, or `zaphod-blocked` with your line-anchored items. PR comments prefix with `**<role-name>**\n\n<body>` per `ai/swarm/README.md`.

--- a/.claude/agents/save-format-warden.md
+++ b/.claude/agents/save-format-warden.md
@@ -46,4 +46,4 @@ Return a structured verdict to the organiser. Three fields:
 
 Never propose the `approved-human` label. That gate is Josh's alone.
 
-The organiser posts your blocked verdicts as inline review comments on the flagged lines (resolvable in the PR UI) and applies the label. Approved verdicts apply the label with no comment. On follow-up pushes the organiser re-dispatches you and re-applies whatever you return.
+The organiser posts your blocked verdicts as inline review comments on the flagged lines (resolvable in the PR UI) and applies the label. Approved verdicts apply the label with no comment. On follow-up pushes the organiser re-dispatches you and re-applies whatever you return. PR comments prefix with `**save-format-warden**\n\n<body>` per `ai/swarm/README.md`.

--- a/.claude/agents/signals-lifecycle.md
+++ b/.claude/agents/signals-lifecycle.md
@@ -23,4 +23,4 @@ You review signal-wiring and tree-lifecycle changes. These bugs are subtle and u
 
 ## Output
 
-Mechanical fixes (e.g. a clear `tree_exited` → `tree_exiting` typo) as commits. Everything else as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Orchestrator applies `ai-approved` or `action-required` based on your output.
+Mechanical fixes (e.g. a clear `tree_exited` → `tree_exiting` typo) as commits. Everything else as short line-anchored review comments following Conventional Comments per `ai/PARALLEL.md`. Organiser applies `zaphod-approved` when your verdict is clean, or `zaphod-blocked` with your line-anchored items. PR comments prefix with `**<role-name>**\n\n<body>` per `ai/swarm/README.md`.

--- a/.claude/agents/supply-chain-scout.md
+++ b/.claude/agents/supply-chain-scout.md
@@ -47,4 +47,4 @@ Return a structured verdict to the organiser. Three fields:
 
 Never propose the `approved-human` label. That gate is Josh's alone.
 
-Use `WebFetch` freely for upstream repos and changelogs while investigating. The organiser posts blocked verdicts as inline review comments on the flagged lines (resolvable in the PR UI) and applies the label. Approved verdicts apply the label with no comment.
+Use `WebFetch` freely for upstream repos and changelogs while investigating. The organiser posts blocked verdicts as inline review comments on the flagged lines (resolvable in the PR UI) and applies the label. Approved verdicts apply the label with no comment. PR comments prefix with `**supply-chain-scout**\n\n<body>` per `ai/swarm/README.md`.

--- a/.claude/agents/test-coverage.md
+++ b/.claude/agents/test-coverage.md
@@ -1,7 +1,7 @@
 ---
 name: test-coverage
 description: Check that new GDScript code has matching tests and that the assertions test behaviour, not implementation. Fires when a `**/*.gd` diff has no matching `tests/unit/**` change.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Edit
 ---
 
 You review whether new production code ships with tests, and whether those tests assert behaviour (what the system does for the player) rather than implementation details (how it does it).
@@ -22,4 +22,4 @@ You review whether new production code ships with tests, and whether those tests
 
 ## Output
 
-Add small missing tests inline as commits when you have the context. Everything else ("this new feature has no test for X", "the assertion here checks implementation, not behaviour") as short line-anchored review comments on the source or test file, following Conventional Comments per `ai/PARALLEL.md`. Orchestrator applies `ai-approved` or `action-required` based on your output.
+Add small missing tests inline as commits when you have the context. Everything else ("this new feature has no test for X", "the assertion here checks implementation, not behaviour") as short line-anchored review comments on the source or test file, following Conventional Comments per `ai/PARALLEL.md`. Organiser applies `zaphod-approved` when your verdict is clean, or `zaphod-blocked` with your line-anchored items. PR comments prefix with `**<role-name>**\n\n<body>` per `ai/swarm/README.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Small, friendly PR reviews are the norm. If something needs rework we will say w
 
 ### How review and merge work
 
-A set of AI reviewers read your PR first. Small fixes land as commits on your branch. Anything else shows up as a short comment on the line it's about. The PR gets one of two labels: `ai-approved` if the reviewers had nothing to say, or `action-required` if they left comments. These are just a heads-up, not a decision.
+A set of AI reviewers read your PR first. Small fixes land as commits on your branch. Anything else shows up as a short comment on the line it's about. The PR gets one of two labels: `zaphod-approved` if the reviewers had nothing to say, or `zaphod-blocked` if they left comments. These are just a heads-up, not a decision.
 
 A maintainer then reads the PR and adds `human-approved` to sign off. The PR merges on its own once it has `human-approved` and no open reviewer comments. If you push new commits, `human-approved` comes off so the next push gets a fresh look.
 

--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -97,6 +97,10 @@ The organiser is entity-driven. Point it at a thing and it does the right thing.
 
 Phrases do not trigger recipes. "Can you look at SH-42" does. The shape of the entity chooses the shape of the team.
 
+### Pre-dispatch ticket-state recheck
+
+Before spinning up a worktree the organiser re-reads each candidate ticket's Linear state and searches for a merged PR on its branch pattern (`feature/sh-N-*`, `sh-N-*`). If the ticket is Done, Canceled, or its branch pattern resolves to a merged PR, the organiser skips dispatch and flags the stale entity. One turn of `mcp__linear__get_issue` plus `gh pr list --search "sh-N" --state merged` is enough; the cost is negligible next to spinning up a worktree for work that has already shipped.
+
 ## Recipes
 
 Every recipe is a parallel fan-out. The organiser dispatches several sub-agents at once, lets them work independently, and reconvenes only at the sync points below.

--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -77,6 +77,8 @@ The organiser merges worktrees back without squashing, preserving per-agent attr
 
 Review happens in the pull request, never on local files. "Ready for your review" means the branch is pushed and a PR is open with the reviewer fan-out running. Local file-review bypasses the `zaphod-approved` / `zaphod-blocked` surface and the existing reactive reviewers.
 
+PRs open as drafts so Linear transitions the ticket to In Progress without pulling reviewers onto a moving target. When the work is done, flip to ready via `gh pr ready <N>` and immediately confirm with `gh pr view <N> --json isDraft --jq '.isDraft'`; that must return `false`. The CLI has a documented silent-success failure mode where it reports the flip but the PR stays in draft, so verification is mandatory. If the flip did not take, retry through the raw GraphQL mutation: grab the PR node id via `gh pr view <N> --json id -q .id`, then `gh api graphql -f query='mutation($id:ID!){markPullRequestReadyForReview(input:{pullRequestId:$id}){pullRequest{isDraft}}}' -F id="$PR_ID"` and read the returned `isDraft` directly.
+
 ## Godot session tiers
 
 The swarm inherits the session-tier system from `ai/PARALLEL.md`. Every agent declares a tier ceiling in its `.claude/agents/*.md` body; the organiser respects it and never elevates silently.


### PR DESCRIPTION
Four small edits to `.claude/agents/` definitions: rename the stale `ai-approved`/`action-required` labels to current `zaphod-approved`/`zaphod-blocked` across every reviewer and CONTRIBUTING; widen docs-and-writing (Edit, Bash) and test-coverage (Edit) so reviewer specialists can commit mechanical fixes instead of round-tripping through general-purpose; add a pre-dispatch ticket-state recheck to the swarm README so the organiser skips worktrees for already-shipped work; and propagate the bold-name PR-comment prefix into every reviewer definition.

Closes SH-160
Closes SH-162
Closes SH-163
Closes SH-182