### PR TITLE
feat: ball rack and gear rack (SH-99)

### DIFF
--- a/scenes/ball_rack.tscn
+++ b/scenes/ball_rack.tscn
@@ -1,8 +1,17 @@
-[gd_scene format=3 uid="uid://bxyckxy4cf7r0"]
+[gd_scene load_steps=3 format=3 uid="uid://bxyckxy4cf7r0"]
 
-[node name="BallRack" type="Node2D" unique_id=949376876]
+[ext_resource type="Script" path="res://scripts/items/rack_display.gd" id="1_rack"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_ball_rack_drop"]
+size = Vector2(300, 200)
+
+[node name="BallRack" type="Node2D" unique_id=949376876 node_paths=PackedStringArray("slot_container")]
 z_index = 100
 z_as_relative = false
+script = ExtResource("1_rack")
+role = &"ball"
+slot_container = NodePath("SlotContainer")
+bounds = Rect2(0, 0, 300, 200)
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1349315967]
@@ -18,3 +27,13 @@ offset_right = 10.0
 offset_bottom = 10.0
 theme_override_font_sizes/font_size = 36
 text = "BallRack"
+
+[node name="SlotContainer" type="Node2D" parent="." unique_id=1349315968]
+
+[node name="DropTarget" type="Area2D" parent="." unique_id=1349315969]
+monitoring = false
+monitorable = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DropTarget" unique_id=1349315970]
+position = Vector2(150, 100)
+shape = SubResource("RectangleShape2D_ball_rack_drop")

--- a/scenes/ball_rack.tscn
+++ b/scenes/ball_rack.tscn
@@ -9,9 +9,8 @@ size = Vector2(300, 200)
 z_index = 100
 z_as_relative = false
 script = ExtResource("1_rack")
-role = &"ball"
+displayed_role = &"ball"
 slot_container = NodePath("SlotContainer")
-bounds = Rect2(0, 0, 300, 200)
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1349315967]

--- a/scenes/ball_rack.tscn
+++ b/scenes/ball_rack.tscn
@@ -30,6 +30,30 @@ text = "BallRack"
 
 [node name="SlotContainer" type="Node2D" parent="." unique_id=1349315968]
 
+[node name="SlotMarker0" type="Node2D" parent="SlotContainer" unique_id=1349315980]
+position = Vector2(37.5, 50)
+
+[node name="SlotMarker1" type="Node2D" parent="SlotContainer" unique_id=1349315981]
+position = Vector2(112.5, 50)
+
+[node name="SlotMarker2" type="Node2D" parent="SlotContainer" unique_id=1349315982]
+position = Vector2(187.5, 50)
+
+[node name="SlotMarker3" type="Node2D" parent="SlotContainer" unique_id=1349315983]
+position = Vector2(262.5, 50)
+
+[node name="SlotMarker4" type="Node2D" parent="SlotContainer" unique_id=1349315984]
+position = Vector2(37.5, 150)
+
+[node name="SlotMarker5" type="Node2D" parent="SlotContainer" unique_id=1349315985]
+position = Vector2(112.5, 150)
+
+[node name="SlotMarker6" type="Node2D" parent="SlotContainer" unique_id=1349315986]
+position = Vector2(187.5, 150)
+
+[node name="SlotMarker7" type="Node2D" parent="SlotContainer" unique_id=1349315987]
+position = Vector2(262.5, 150)
+
 [node name="DropTarget" type="Area2D" parent="." unique_id=1349315969]
 monitoring = false
 monitorable = true

--- a/scenes/ball_rack.tscn
+++ b/scenes/ball_rack.tscn
@@ -9,7 +9,7 @@ size = Vector2(300, 200)
 z_index = 100
 z_as_relative = false
 script = ExtResource("1_rack")
-displayed_role = &"ball"
+role = &"ball"
 slot_container = NodePath("SlotContainer")
 metadata/_edit_group_ = true
 

--- a/scenes/gear_rack.tscn
+++ b/scenes/gear_rack.tscn
@@ -9,9 +9,8 @@ size = Vector2(300, 200)
 z_index = 100
 z_as_relative = false
 script = ExtResource("1_rack")
-role = &"equipment"
+displayed_role = &"equipment"
 slot_container = NodePath("SlotContainer")
-bounds = Rect2(0, 0, 300, 200)
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1470078387]

--- a/scenes/gear_rack.tscn
+++ b/scenes/gear_rack.tscn
@@ -9,7 +9,7 @@ size = Vector2(300, 200)
 z_index = 100
 z_as_relative = false
 script = ExtResource("1_rack")
-displayed_role = &"equipment"
+role = &"equipment"
 slot_container = NodePath("SlotContainer")
 metadata/_edit_group_ = true
 

--- a/scenes/gear_rack.tscn
+++ b/scenes/gear_rack.tscn
@@ -1,8 +1,17 @@
-[gd_scene format=3 uid="uid://mws700v36gko"]
+[gd_scene load_steps=3 format=3 uid="uid://mws700v36gko"]
 
-[node name="GearRack" type="Node2D" unique_id=445509089]
+[ext_resource type="Script" path="res://scripts/items/rack_display.gd" id="1_rack"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_gear_rack_drop"]
+size = Vector2(300, 200)
+
+[node name="GearRack" type="Node2D" unique_id=445509089 node_paths=PackedStringArray("slot_container")]
 z_index = 100
 z_as_relative = false
+script = ExtResource("1_rack")
+role = &"equipment"
+slot_container = NodePath("SlotContainer")
+bounds = Rect2(0, 0, 300, 200)
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1470078387]
@@ -18,3 +27,13 @@ offset_right = 10.0
 offset_bottom = 10.0
 theme_override_font_sizes/font_size = 36
 text = "GearRack"
+
+[node name="SlotContainer" type="Node2D" parent="." unique_id=1742093711]
+
+[node name="DropTarget" type="Area2D" parent="." unique_id=1742093712]
+monitoring = false
+monitorable = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DropTarget" unique_id=1742093713]
+position = Vector2(150, 100)
+shape = SubResource("RectangleShape2D_gear_rack_drop")

--- a/scenes/gear_rack.tscn
+++ b/scenes/gear_rack.tscn
@@ -30,6 +30,30 @@ text = "GearRack"
 
 [node name="SlotContainer" type="Node2D" parent="." unique_id=1742093711]
 
+[node name="SlotMarker0" type="Node2D" parent="SlotContainer" unique_id=1742093720]
+position = Vector2(37.5, 50)
+
+[node name="SlotMarker1" type="Node2D" parent="SlotContainer" unique_id=1742093721]
+position = Vector2(112.5, 50)
+
+[node name="SlotMarker2" type="Node2D" parent="SlotContainer" unique_id=1742093722]
+position = Vector2(187.5, 50)
+
+[node name="SlotMarker3" type="Node2D" parent="SlotContainer" unique_id=1742093723]
+position = Vector2(262.5, 50)
+
+[node name="SlotMarker4" type="Node2D" parent="SlotContainer" unique_id=1742093724]
+position = Vector2(37.5, 150)
+
+[node name="SlotMarker5" type="Node2D" parent="SlotContainer" unique_id=1742093725]
+position = Vector2(112.5, 150)
+
+[node name="SlotMarker6" type="Node2D" parent="SlotContainer" unique_id=1742093726]
+position = Vector2(187.5, 150)
+
+[node name="SlotMarker7" type="Node2D" parent="SlotContainer" unique_id=1742093727]
+position = Vector2(262.5, 150)
+
 [node name="DropTarget" type="Area2D" parent="." unique_id=1742093712]
 monitoring = false
 monitorable = true

--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -117,6 +117,20 @@ func get_court_items() -> Array[String]:
 	return result
 
 
+## Returns owned items of the given role whose placement is STORED (on the rack).
+func get_kit_items(role: StringName) -> Array[String]:
+	var result: Array[String] = []
+	for item in items:
+		if item.role != role:
+			continue
+		if get_level(item.key) <= 0:
+			continue
+		if _get_placement(item.key) != PlacementScript.STORED:
+			continue
+		result.append(item.key)
+	return result
+
+
 ## Places an owned item on its natural target and registers effects at current level; false if unowned.
 func activate(item_key: String) -> bool:
 	if get_level(item_key) <= 0:

--- a/scripts/items/rack_display.gd
+++ b/scripts/items/rack_display.gd
@@ -1,11 +1,11 @@
 class_name RackDisplay
 extends Node2D
 
-@export var displayed_role: StringName = &"ball"
+@export var role: StringName = &"ball"
 @export var slot_container: Node2D
 
 var _item_manager: Node
-var _item_slot_nodes: Array[Node2D] = []
+var _slots: Array[Node2D] = []
 var _slot_markers: Array[Node2D] = []
 
 
@@ -24,34 +24,32 @@ func configure(item_manager: Node) -> void:
 
 
 func refresh() -> void:
-	_clear_item_slot_nodes()
+	_clear_slots()
 	if _slot_markers.is_empty():
 		_cache_slot_markers()
-	var inactive_item_keys: Array[String] = _item_manager.get_kit_items(displayed_role)
-	var marker_count := _slot_markers.size()
-	for index in inactive_item_keys.size():
-		var item_key: String = inactive_item_keys[index]
-		var item_definition := _get_item_definition(item_key)
-		if item_definition == null or item_definition.art == null:
+	var kit_keys: Array[String] = _item_manager.get_kit_items(role)
+	var marker_count: int = _slot_markers.size()
+	for index in kit_keys.size():
+		var item_key: String = kit_keys[index]
+		var definition: ItemDefinition = _get_item_definition(item_key)
+		if definition == null or definition.art == null:
 			continue
 		if marker_count == 0:
 			continue
 		var marker_index: int = min(index, marker_count - 1)
-		var slot_node := _build_item_slot_node(
-			item_definition, _slot_markers[marker_index].position
-		)
-		slot_container.add_child(slot_node)
-		_item_slot_nodes.append(slot_node)
+		var slot: Node2D = _build_slot(definition, _slot_markers[marker_index].position)
+		slot_container.add_child(slot)
+		_slots.append(slot)
 
 
 func get_displayed_keys() -> Array[String]:
 	var keys: Array[String] = []
-	for slot_node in _item_slot_nodes:
-		if slot_node == null:
+	for slot in _slots:
+		if slot == null:
 			continue
-		var item_key: String = slot_node.get_meta(&"item_key", "")
-		if item_key != "":
-			keys.append(item_key)
+		var key: String = slot.get_meta(&"item_key", "")
+		if key != "":
+			keys.append(key)
 	return keys
 
 
@@ -59,26 +57,26 @@ func _cache_slot_markers() -> void:
 	_slot_markers.clear()
 	if slot_container == null:
 		return
-	for marker_candidate in slot_container.get_children():
-		if marker_candidate is Node2D and String(marker_candidate.name).begins_with("SlotMarker"):
-			_slot_markers.append(marker_candidate)
+	for child in slot_container.get_children():
+		if child is Node2D and String(child.name).begins_with("SlotMarker"):
+			_slot_markers.append(child)
 
 
-func _build_item_slot_node(item_definition: ItemDefinition, slot_position: Vector2) -> Node2D:
-	var slot_node := Node2D.new()
-	slot_node.name = "Slot_%s" % item_definition.key
-	slot_node.position = slot_position
-	slot_node.set_meta(&"item_key", item_definition.key)
-	var item_art_instance: Node = item_definition.art.instantiate()
-	slot_node.add_child(item_art_instance)
-	return slot_node
+func _build_slot(definition: ItemDefinition, slot_position: Vector2) -> Node2D:
+	var slot: Node2D = Node2D.new()
+	slot.name = "Slot_%s" % definition.key
+	slot.position = slot_position
+	slot.set_meta(&"item_key", definition.key)
+	var art_instance: Node = definition.art.instantiate()
+	slot.add_child(art_instance)
+	return slot
 
 
-func _clear_item_slot_nodes() -> void:
-	for slot_node in _item_slot_nodes:
-		if slot_node != null and is_instance_valid(slot_node):
-			slot_node.queue_free()
-	_item_slot_nodes.clear()
+func _clear_slots() -> void:
+	for slot in _slots:
+		if slot != null and is_instance_valid(slot):
+			slot.queue_free()
+	_slots.clear()
 
 
 func _get_item_definition(item_key: String) -> ItemDefinition:

--- a/scripts/items/rack_display.gd
+++ b/scripts/items/rack_display.gd
@@ -1,12 +1,11 @@
 class_name RackDisplay
 extends Node2D
 
-@export var role: StringName = &"ball"
+@export var displayed_role: StringName = &"ball"
 @export var slot_container: Node2D
-@export var bounds: Rect2 = Rect2(0, 0, 300, 200)
 
 var _item_manager: Node
-var _slots: Array[Node2D] = []
+var _item_slot_nodes: Array[Node2D] = []
 var _slot_markers: Array[Node2D] = []
 
 
@@ -25,32 +24,34 @@ func configure(item_manager: Node) -> void:
 
 
 func refresh() -> void:
-	_clear_slots()
+	_clear_item_slot_nodes()
 	if _slot_markers.is_empty():
 		_cache_slot_markers()
-	var kit_keys: Array[String] = _item_manager.get_kit_items(role)
+	var inactive_item_keys: Array[String] = _item_manager.get_kit_items(displayed_role)
 	var marker_count := _slot_markers.size()
-	for index in kit_keys.size():
-		var item_key: String = kit_keys[index]
-		var definition := _get_item_definition(item_key)
-		if definition == null or definition.art == null:
+	for index in inactive_item_keys.size():
+		var item_key: String = inactive_item_keys[index]
+		var item_definition := _get_item_definition(item_key)
+		if item_definition == null or item_definition.art == null:
 			continue
 		if marker_count == 0:
 			continue
 		var marker_index: int = min(index, marker_count - 1)
-		var slot := _build_slot(definition, _slot_markers[marker_index].position)
-		slot_container.add_child(slot)
-		_slots.append(slot)
+		var slot_node := _build_item_slot_node(
+			item_definition, _slot_markers[marker_index].position
+		)
+		slot_container.add_child(slot_node)
+		_item_slot_nodes.append(slot_node)
 
 
 func get_displayed_keys() -> Array[String]:
 	var keys: Array[String] = []
-	for slot in _slots:
-		if slot == null:
+	for slot_node in _item_slot_nodes:
+		if slot_node == null:
 			continue
-		var key: String = slot.get_meta(&"item_key", "")
-		if key != "":
-			keys.append(key)
+		var item_key: String = slot_node.get_meta(&"item_key", "")
+		if item_key != "":
+			keys.append(item_key)
 	return keys
 
 
@@ -58,26 +59,26 @@ func _cache_slot_markers() -> void:
 	_slot_markers.clear()
 	if slot_container == null:
 		return
-	for child in slot_container.get_children():
-		if child is Node2D and String(child.name).begins_with("SlotMarker"):
-			_slot_markers.append(child)
+	for marker_candidate in slot_container.get_children():
+		if marker_candidate is Node2D and String(marker_candidate.name).begins_with("SlotMarker"):
+			_slot_markers.append(marker_candidate)
 
 
-func _build_slot(definition: ItemDefinition, slot_position: Vector2) -> Node2D:
-	var slot := Node2D.new()
-	slot.name = "Slot_%s" % definition.key
-	slot.position = slot_position
-	slot.set_meta(&"item_key", definition.key)
-	var art_instance: Node = definition.art.instantiate()
-	slot.add_child(art_instance)
-	return slot
+func _build_item_slot_node(item_definition: ItemDefinition, slot_position: Vector2) -> Node2D:
+	var slot_node := Node2D.new()
+	slot_node.name = "Slot_%s" % item_definition.key
+	slot_node.position = slot_position
+	slot_node.set_meta(&"item_key", item_definition.key)
+	var item_art_instance: Node = item_definition.art.instantiate()
+	slot_node.add_child(item_art_instance)
+	return slot_node
 
 
-func _clear_slots() -> void:
-	for slot in _slots:
-		if slot != null and is_instance_valid(slot):
-			slot.queue_free()
-	_slots.clear()
+func _clear_item_slot_nodes() -> void:
+	for slot_node in _item_slot_nodes:
+		if slot_node != null and is_instance_valid(slot_node):
+			slot_node.queue_free()
+	_item_slot_nodes.clear()
 
 
 func _get_item_definition(item_key: String) -> ItemDefinition:

--- a/scripts/items/rack_display.gd
+++ b/scripts/items/rack_display.gd
@@ -1,0 +1,118 @@
+class_name RackDisplay
+extends Node2D
+
+## Reactive display for inactive items in a given role.
+## Renders one slot per owned-but-unplaced item, using `ItemDefinition.art`.
+## Declares a drop-target Area2D child for future drag-and-drop wiring (SH-97/SH-98).
+## No gameplay effect while items sit here: effects are driven by placement (SH-96).
+
+## Which role this rack displays. `&"ball"` or `&"equipment"`.
+@export var role: StringName = &"ball"
+
+## Parent node for item slots; rebuilt from scratch on every change.
+@export var slot_container: Node2D
+
+## Visible bounds the rack covers, used to size the drop-target Area2D.
+@export var bounds: Rect2 = Rect2(0, 0, 300, 200)
+
+## Per-slot spacing. Items flow left-to-right then wrap to the next row.
+@export var slot_size: Vector2 = Vector2(72, 72)
+@export var slot_padding: Vector2 = Vector2(16, 16)
+
+var _item_manager: Node
+var _slots: Array[Node2D] = []
+
+
+func _ready() -> void:
+	if _item_manager == null:
+		_item_manager = ItemManager
+	_item_manager.item_level_changed.connect(_on_item_level_changed)
+	_item_manager.item_placement_changed.connect(_on_item_placement_changed)
+	refresh()
+
+
+## Injects a non-autoload ItemManager for tests. Must be called before adding to tree.
+func configure(item_manager: Node) -> void:
+	_item_manager = item_manager
+
+
+## Rebuilds the slot children from the current inactive set. Idempotent.
+func refresh() -> void:
+	_clear_slots()
+	var inactive_keys := _collect_inactive_keys()
+	for index in inactive_keys.size():
+		var item_key := inactive_keys[index]
+		var definition := _get_item_definition(item_key)
+		if definition == null or definition.art == null:
+			continue
+		var slot := _build_slot(definition, index)
+		slot_container.add_child(slot)
+		_slots.append(slot)
+
+
+## Returns the inactive, role-matching item keys currently rendered.
+## Exposed for tests and for future drop-target logic.
+func get_displayed_keys() -> Array[String]:
+	var keys: Array[String] = []
+	for slot in _slots:
+		if slot == null:
+			continue
+		var key: String = slot.get_meta(&"item_key", "")
+		if key != "":
+			keys.append(key)
+	return keys
+
+
+func _collect_inactive_keys() -> Array[String]:
+	var keys: Array[String] = []
+	for item in _item_manager.items:
+		if item.role != role:
+			continue
+		if _item_manager.get_level(item.key) <= 0:
+			continue
+		# is_on_court returns true for any non-STORED placement (EQUIPPED or ON_COURT).
+		if _item_manager.is_on_court(item.key):
+			continue
+		keys.append(item.key)
+	return keys
+
+
+func _build_slot(definition: ItemDefinition, index: int) -> Node2D:
+	var slot := Node2D.new()
+	slot.name = "Slot_%s" % definition.key
+	slot.position = _slot_position(index)
+	slot.set_meta(&"item_key", definition.key)
+	var art_instance: Node = definition.art.instantiate()
+	slot.add_child(art_instance)
+	return slot
+
+
+func _slot_position(index: int) -> Vector2:
+	var stride := slot_size + slot_padding
+	var columns: int = max(1, int(floor((bounds.size.x - slot_padding.x) / stride.x)))
+	var column := index % columns
+	var row := index / columns
+	var origin := bounds.position + slot_padding + slot_size * 0.5
+	return origin + Vector2(column * stride.x, row * stride.y)
+
+
+func _clear_slots() -> void:
+	for slot in _slots:
+		if slot != null and is_instance_valid(slot):
+			slot.queue_free()
+	_slots.clear()
+
+
+func _get_item_definition(item_key: String) -> ItemDefinition:
+	for item: ItemDefinition in _item_manager.items:
+		if item.key == item_key:
+			return item
+	return null
+
+
+func _on_item_level_changed(_item_key: String) -> void:
+	refresh()
+
+
+func _on_item_placement_changed(_item_key: String, _placement: int) -> void:
+	refresh()

--- a/scripts/items/rack_display.gd
+++ b/scripts/items/rack_display.gd
@@ -1,31 +1,19 @@
 class_name RackDisplay
 extends Node2D
 
-## Reactive display for inactive items in a given role.
-## Renders one slot per owned-but-unplaced item, using `ItemDefinition.art`.
-## Declares a drop-target Area2D child for future drag-and-drop wiring (SH-97/SH-98).
-## No gameplay effect while items sit here: effects are driven by placement (SH-96).
-
-## Which role this rack displays. `&"ball"` or `&"equipment"`.
 @export var role: StringName = &"ball"
-
-## Parent node for item slots; rebuilt from scratch on every change.
 @export var slot_container: Node2D
-
-## Visible bounds the rack covers, used to size the drop-target Area2D.
 @export var bounds: Rect2 = Rect2(0, 0, 300, 200)
-
-## Per-slot spacing. Items flow left-to-right then wrap to the next row.
-@export var slot_size: Vector2 = Vector2(72, 72)
-@export var slot_padding: Vector2 = Vector2(16, 16)
 
 var _item_manager: Node
 var _slots: Array[Node2D] = []
+var _slot_markers: Array[Node2D] = []
 
 
 func _ready() -> void:
 	if _item_manager == null:
 		_item_manager = ItemManager
+	_cache_slot_markers()
 	_item_manager.item_level_changed.connect(_on_item_level_changed)
 	_item_manager.item_placement_changed.connect(_on_item_placement_changed)
 	refresh()
@@ -36,22 +24,25 @@ func configure(item_manager: Node) -> void:
 	_item_manager = item_manager
 
 
-## Rebuilds the slot children from the current inactive set. Idempotent.
 func refresh() -> void:
 	_clear_slots()
-	var inactive_keys := _collect_inactive_keys()
-	for index in inactive_keys.size():
-		var item_key := inactive_keys[index]
+	if _slot_markers.is_empty():
+		_cache_slot_markers()
+	var kit_keys: Array[String] = _item_manager.get_kit_items(role)
+	var marker_count := _slot_markers.size()
+	for index in kit_keys.size():
+		var item_key: String = kit_keys[index]
 		var definition := _get_item_definition(item_key)
 		if definition == null or definition.art == null:
 			continue
-		var slot := _build_slot(definition, index)
+		if marker_count == 0:
+			continue
+		var marker_index: int = min(index, marker_count - 1)
+		var slot := _build_slot(definition, _slot_markers[marker_index].position)
 		slot_container.add_child(slot)
 		_slots.append(slot)
 
 
-## Returns the inactive, role-matching item keys currently rendered.
-## Exposed for tests and for future drop-target logic.
 func get_displayed_keys() -> Array[String]:
 	var keys: Array[String] = []
 	for slot in _slots:
@@ -63,37 +54,23 @@ func get_displayed_keys() -> Array[String]:
 	return keys
 
 
-func _collect_inactive_keys() -> Array[String]:
-	var keys: Array[String] = []
-	for item in _item_manager.items:
-		if item.role != role:
-			continue
-		if _item_manager.get_level(item.key) <= 0:
-			continue
-		# is_on_court returns true for any non-STORED placement (EQUIPPED or ON_COURT).
-		if _item_manager.is_on_court(item.key):
-			continue
-		keys.append(item.key)
-	return keys
+func _cache_slot_markers() -> void:
+	_slot_markers.clear()
+	if slot_container == null:
+		return
+	for child in slot_container.get_children():
+		if child is Node2D and String(child.name).begins_with("SlotMarker"):
+			_slot_markers.append(child)
 
 
-func _build_slot(definition: ItemDefinition, index: int) -> Node2D:
+func _build_slot(definition: ItemDefinition, slot_position: Vector2) -> Node2D:
 	var slot := Node2D.new()
 	slot.name = "Slot_%s" % definition.key
-	slot.position = _slot_position(index)
+	slot.position = slot_position
 	slot.set_meta(&"item_key", definition.key)
 	var art_instance: Node = definition.art.instantiate()
 	slot.add_child(art_instance)
 	return slot
-
-
-func _slot_position(index: int) -> Vector2:
-	var stride := slot_size + slot_padding
-	var columns: int = max(1, int(floor((bounds.size.x - slot_padding.x) / stride.x)))
-	var column := index % columns
-	var row := index / columns
-	var origin := bounds.position + slot_padding + slot_size * 0.5
-	return origin + Vector2(column * stride.x, row * stride.y)
 
 
 func _clear_slots() -> void:

--- a/scripts/items/rack_display.gd.uid
+++ b/scripts/items/rack_display.gd.uid
@@ -1,0 +1,1 @@
+uid://brl2uxlwp7fvg

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -290,7 +290,7 @@ class TestReloadFromProgression:
 		)
 
 
-class TestKitItems:
+class TestKitItemsBall:
 	extends GutTest
 	var _manager: Node
 
@@ -303,6 +303,46 @@ class TestKitItems:
 		ball_item.cost_scaling = 2.0
 		ball_item.max_level = 3
 		ball_item.effects = []
+		_manager.items.assign([ball_item])
+		_manager._progression.friendship_point_balance = 10000
+
+	func test_get_kit_items_is_empty_when_nothing_owned() -> void:
+		assert_eq(_manager.get_kit_items(&"ball").size(), 0)
+
+	func test_get_kit_items_returns_owned_stored_ball_items() -> void:
+		_manager.take("kit_ball")
+		var ball_kit: Array[String] = _manager.get_kit_items(&"ball")
+		assert_eq(ball_kit.size(), 1)
+		assert_eq(ball_kit[0], "kit_ball")
+
+	func test_get_kit_items_excludes_ball_when_queried_for_equipment_role() -> void:
+		_manager.take("kit_ball")
+		assert_eq(_manager.get_kit_items(&"equipment").size(), 0)
+
+	func test_get_kit_items_excludes_unowned_ball_items() -> void:
+		assert_eq(_manager.get_level("kit_ball"), 0)
+		assert_eq(_manager.get_kit_items(&"ball").size(), 0)
+
+	func test_get_kit_items_excludes_activated_ball_items() -> void:
+		_manager.take("kit_ball")
+		_manager.activate("kit_ball")
+		assert_eq(_manager.get_kit_items(&"ball").size(), 0)
+
+	func test_get_kit_items_includes_ball_items_after_deactivation() -> void:
+		_manager.take("kit_ball")
+		_manager.activate("kit_ball")
+		_manager.deactivate("kit_ball")
+		var kit: Array[String] = _manager.get_kit_items(&"ball")
+		assert_eq(kit.size(), 1)
+		assert_eq(kit[0], "kit_ball")
+
+
+class TestKitItemsEquipment:
+	extends GutTest
+	var _manager: Node
+
+	func before_each() -> void:
+		_manager = ItemFactory.create_manager(self)
 		var gear_item := ItemDefinition.new()
 		gear_item.key = "kit_gear"
 		gear_item.role = &"equipment"
@@ -310,40 +350,35 @@ class TestKitItems:
 		gear_item.cost_scaling = 2.0
 		gear_item.max_level = 3
 		gear_item.effects = []
-		_manager.items.assign([ball_item, gear_item])
+		_manager.items.assign([gear_item])
 		_manager._progression.friendship_point_balance = 10000
 
 	func test_get_kit_items_is_empty_when_nothing_owned() -> void:
-		assert_eq(_manager.get_kit_items(&"ball").size(), 0)
 		assert_eq(_manager.get_kit_items(&"equipment").size(), 0)
 
-	func test_get_kit_items_returns_owned_stored_items_of_role() -> void:
-		_manager.take("kit_ball")
+	func test_get_kit_items_returns_owned_stored_equipment_items() -> void:
 		_manager.take("kit_gear")
-		var ball_kit: Array[String] = _manager.get_kit_items(&"ball")
-		assert_eq(ball_kit.size(), 1)
-		assert_eq(ball_kit[0], "kit_ball")
 		var gear_kit: Array[String] = _manager.get_kit_items(&"equipment")
 		assert_eq(gear_kit.size(), 1)
 		assert_eq(gear_kit[0], "kit_gear")
 
-	func test_get_kit_items_excludes_items_of_other_roles() -> void:
-		_manager.take("kit_ball")
+	func test_get_kit_items_excludes_equipment_when_queried_for_ball_role() -> void:
+		_manager.take("kit_gear")
+		assert_eq(_manager.get_kit_items(&"ball").size(), 0)
+
+	func test_get_kit_items_excludes_unowned_equipment_items() -> void:
+		assert_eq(_manager.get_level("kit_gear"), 0)
 		assert_eq(_manager.get_kit_items(&"equipment").size(), 0)
 
-	func test_get_kit_items_excludes_activated_items() -> void:
+	func test_get_kit_items_excludes_activated_equipment_items() -> void:
 		_manager.take("kit_gear")
 		_manager.activate("kit_gear")
 		assert_eq(_manager.get_kit_items(&"equipment").size(), 0)
 
-	func test_get_kit_items_includes_items_after_deactivation() -> void:
+	func test_get_kit_items_includes_equipment_items_after_deactivation() -> void:
 		_manager.take("kit_gear")
 		_manager.activate("kit_gear")
 		_manager.deactivate("kit_gear")
 		var kit: Array[String] = _manager.get_kit_items(&"equipment")
 		assert_eq(kit.size(), 1)
 		assert_eq(kit[0], "kit_gear")
-
-	func test_get_kit_items_excludes_unowned_items() -> void:
-		assert_eq(_manager.get_level("kit_ball"), 0)
-		assert_eq(_manager.get_kit_items(&"ball").size(), 0)

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -288,3 +288,62 @@ class TestReloadFromProgression:
 			base_speed,
 			"reload should drop effects that no longer have a level"
 		)
+
+
+class TestKitItems:
+	extends GutTest
+	var _manager: Node
+
+	func before_each() -> void:
+		_manager = ItemFactory.create_manager(self)
+		var ball_item := ItemDefinition.new()
+		ball_item.key = "kit_ball"
+		ball_item.role = &"ball"
+		ball_item.base_cost = 100
+		ball_item.cost_scaling = 2.0
+		ball_item.max_level = 3
+		ball_item.effects = []
+		var gear_item := ItemDefinition.new()
+		gear_item.key = "kit_gear"
+		gear_item.role = &"equipment"
+		gear_item.base_cost = 100
+		gear_item.cost_scaling = 2.0
+		gear_item.max_level = 3
+		gear_item.effects = []
+		_manager.items.assign([ball_item, gear_item])
+		_manager._progression.friendship_point_balance = 10000
+
+	func test_get_kit_items_is_empty_when_nothing_owned() -> void:
+		assert_eq(_manager.get_kit_items(&"ball").size(), 0)
+		assert_eq(_manager.get_kit_items(&"equipment").size(), 0)
+
+	func test_get_kit_items_returns_owned_stored_items_of_role() -> void:
+		_manager.take("kit_ball")
+		_manager.take("kit_gear")
+		var ball_kit: Array[String] = _manager.get_kit_items(&"ball")
+		assert_eq(ball_kit.size(), 1)
+		assert_eq(ball_kit[0], "kit_ball")
+		var gear_kit: Array[String] = _manager.get_kit_items(&"equipment")
+		assert_eq(gear_kit.size(), 1)
+		assert_eq(gear_kit[0], "kit_gear")
+
+	func test_get_kit_items_excludes_items_of_other_roles() -> void:
+		_manager.take("kit_ball")
+		assert_eq(_manager.get_kit_items(&"equipment").size(), 0)
+
+	func test_get_kit_items_excludes_activated_items() -> void:
+		_manager.take("kit_gear")
+		_manager.activate("kit_gear")
+		assert_eq(_manager.get_kit_items(&"equipment").size(), 0)
+
+	func test_get_kit_items_includes_items_after_deactivation() -> void:
+		_manager.take("kit_gear")
+		_manager.activate("kit_gear")
+		_manager.deactivate("kit_gear")
+		var kit: Array[String] = _manager.get_kit_items(&"equipment")
+		assert_eq(kit.size(), 1)
+		assert_eq(kit[0], "kit_gear")
+
+	func test_get_kit_items_excludes_unowned_items() -> void:
+		assert_eq(_manager.get_level("kit_ball"), 0)
+		assert_eq(_manager.get_kit_items(&"ball").size(), 0)

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -29,7 +29,7 @@ func _make_manager_with(items: Array) -> Node:
 
 func _make_rack(role: StringName, manager: Node) -> Node2D:
 	var rack: Node2D = RackDisplayScript.new()
-	rack.displayed_role = role
+	rack.role = role
 	var slot_container := Node2D.new()
 	slot_container.name = "SlotContainer"
 	rack.add_child(slot_container)

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -2,8 +2,12 @@
 extends GutTest
 
 const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
-const TRAINING_BALL_ART: PackedScene = preload("res://scenes/items/training_ball.tscn")
-const GRIP_TAPE_ART: PackedScene = preload("res://scenes/items/grip_tape.tscn")
+
+
+func _stub_art() -> PackedScene:
+	var scene := PackedScene.new()
+	scene.pack(Node2D.new())
+	return scene
 
 
 func _make_item(item_key: String, role: StringName) -> ItemDefinition:
@@ -14,7 +18,7 @@ func _make_item(item_key: String, role: StringName) -> ItemDefinition:
 	item.cost_scaling = 2.0
 	item.max_level = 3
 	item.effects = []
-	item.art = TRAINING_BALL_ART if role == &"ball" else GRIP_TAPE_ART
+	item.art = _stub_art()
 	return item
 
 
@@ -49,7 +53,9 @@ func test_adding_a_ball_item_shows_a_slot_on_the_ball_rack() -> void:
 	var manager: Node = _make_manager_with([ball])
 	manager._progression.friendship_point_balance = 1000
 	var rack := _make_rack(&"ball", manager)
+
 	manager.take(ball.key)
+
 	var displayed: Array[String] = rack.get_displayed_keys()
 	assert_eq(displayed.size(), 1, "ball rack should render one slot for the new ball item")
 	assert_eq(displayed[0], ball.key, "ball rack slot should reference the ball item key")
@@ -60,7 +66,9 @@ func test_adding_an_equipment_item_shows_a_slot_on_the_gear_rack() -> void:
 	var manager: Node = _make_manager_with([gear])
 	manager._progression.friendship_point_balance = 1000
 	var rack := _make_rack(&"equipment", manager)
+
 	manager.take(gear.key)
+
 	var displayed: Array[String] = rack.get_displayed_keys()
 	assert_eq(displayed.size(), 1, "gear rack should render one slot for the new equipment item")
 	assert_eq(displayed[0], gear.key, "gear rack slot should reference the equipment item key")
@@ -71,7 +79,9 @@ func test_ball_items_do_not_appear_on_the_gear_rack() -> void:
 	var manager: Node = _make_manager_with([ball])
 	manager._progression.friendship_point_balance = 1000
 	var rack := _make_rack(&"equipment", manager)
+
 	manager.take(ball.key)
+
 	assert_eq(
 		rack.get_displayed_keys().size(),
 		0,
@@ -84,7 +94,9 @@ func test_equipment_items_do_not_appear_on_the_ball_rack() -> void:
 	var manager: Node = _make_manager_with([gear])
 	manager._progression.friendship_point_balance = 1000
 	var rack := _make_rack(&"ball", manager)
+
 	manager.take(gear.key)
+
 	assert_eq(
 		rack.get_displayed_keys().size(),
 		0,
@@ -103,7 +115,9 @@ func test_activating_an_item_removes_its_slot() -> void:
 		1,
 		"precondition: taken ball should render on the rack",
 	)
+
 	manager.activate(ball.key)
+
 	assert_eq(
 		rack.get_displayed_keys().size(),
 		0,
@@ -123,7 +137,9 @@ func test_deactivating_an_item_restores_its_slot() -> void:
 		0,
 		"precondition: activated equipment should not be on the rack",
 	)
+
 	manager.deactivate(gear.key)
+
 	assert_eq(
 		rack.get_displayed_keys().size(),
 		1,
@@ -136,8 +152,10 @@ func test_court_role_items_never_appear_on_either_rack() -> void:
 	var court_item := _make_item("court_alpha", &"court")
 	var manager: Node = _make_manager_with([court_item])
 	manager._progression.item_levels[court_item.key] = 1
+
 	var ball_rack := _make_rack(&"ball", manager)
 	var gear_rack := _make_rack(&"equipment", manager)
+
 	assert_eq(
 		ball_rack.get_displayed_keys().size(),
 		0,
@@ -157,6 +175,7 @@ func test_rack_exposes_a_drop_target_child() -> void:
 	var gear_rack_instance: Node = gear_rack_scene.instantiate()
 	add_child_autofree(ball_rack_instance)
 	add_child_autofree(gear_rack_instance)
+
 	assert_not_null(
 		ball_rack_instance.get_node_or_null("DropTarget"),
 		"ball rack scene should expose a DropTarget child",

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -29,7 +29,7 @@ func _make_manager_with(items: Array) -> Node:
 
 func _make_rack(role: StringName, manager: Node) -> Node2D:
 	var rack: Node2D = RackDisplayScript.new()
-	rack.role = role
+	rack.displayed_role = role
 	var slot_container := Node2D.new()
 	slot_container.name = "SlotContainer"
 	rack.add_child(slot_container)

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -1,0 +1,170 @@
+## SH-99 rack display renders every owned-but-inactive item of its role.
+extends GutTest
+
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const TRAINING_BALL_ART: PackedScene = preload("res://scenes/items/training_ball.tscn")
+const GRIP_TAPE_ART: PackedScene = preload("res://scenes/items/grip_tape.tscn")
+
+
+func _make_item(item_key: String, role: StringName) -> ItemDefinition:
+	var item := ItemDefinition.new()
+	item.key = item_key
+	item.role = role
+	item.base_cost = 100
+	item.cost_scaling = 2.0
+	item.max_level = 3
+	item.effects = []
+	item.art = TRAINING_BALL_ART if role == &"ball" else GRIP_TAPE_ART
+	return item
+
+
+func _make_manager_with(items: Array) -> Node:
+	var manager: Node = ItemFactory.create_manager(self)
+	var typed_items: Array[ItemDefinition] = []
+	for item in items:
+		typed_items.append(item)
+	manager.items.assign(typed_items)
+	return manager
+
+
+func _make_rack(role: StringName, manager: Node) -> Node2D:
+	var rack: Node2D = RackDisplayScript.new()
+	rack.role = role
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func test_adding_a_ball_item_shows_a_slot_on_the_ball_rack() -> void:
+	var ball := _make_item("ball_alpha", &"ball")
+	var manager: Node = _make_manager_with([ball])
+	manager._progression.friendship_point_balance = 1000
+	var rack := _make_rack(&"ball", manager)
+	manager.take(ball.key)
+	var displayed: Array[String] = rack.get_displayed_keys()
+	assert_eq(displayed.size(), 1, "ball rack should render one slot for the new ball item")
+	assert_eq(displayed[0], ball.key, "ball rack slot should reference the ball item key")
+
+
+func test_adding_an_equipment_item_shows_a_slot_on_the_gear_rack() -> void:
+	var gear := _make_item("gear_alpha", &"equipment")
+	var manager: Node = _make_manager_with([gear])
+	manager._progression.friendship_point_balance = 1000
+	var rack := _make_rack(&"equipment", manager)
+	manager.take(gear.key)
+	var displayed: Array[String] = rack.get_displayed_keys()
+	assert_eq(displayed.size(), 1, "gear rack should render one slot for the new equipment item")
+	assert_eq(displayed[0], gear.key, "gear rack slot should reference the equipment item key")
+
+
+func test_ball_items_do_not_appear_on_the_gear_rack() -> void:
+	var ball := _make_item("ball_beta", &"ball")
+	var manager: Node = _make_manager_with([ball])
+	manager._progression.friendship_point_balance = 1000
+	var rack := _make_rack(&"equipment", manager)
+	manager.take(ball.key)
+	assert_eq(
+		rack.get_displayed_keys().size(),
+		0,
+		"gear rack should ignore ball-role items",
+	)
+
+
+func test_equipment_items_do_not_appear_on_the_ball_rack() -> void:
+	var gear := _make_item("gear_beta", &"equipment")
+	var manager: Node = _make_manager_with([gear])
+	manager._progression.friendship_point_balance = 1000
+	var rack := _make_rack(&"ball", manager)
+	manager.take(gear.key)
+	assert_eq(
+		rack.get_displayed_keys().size(),
+		0,
+		"ball rack should ignore equipment-role items",
+	)
+
+
+func test_activating_an_item_removes_its_slot() -> void:
+	var ball := _make_item("ball_gamma", &"ball")
+	var manager: Node = _make_manager_with([ball])
+	manager._progression.friendship_point_balance = 1000
+	var rack := _make_rack(&"ball", manager)
+	manager.take(ball.key)
+	assert_eq(
+		rack.get_displayed_keys().size(),
+		1,
+		"precondition: taken ball should render on the rack",
+	)
+	manager.activate(ball.key)
+	assert_eq(
+		rack.get_displayed_keys().size(),
+		0,
+		"activating an item should remove its slot from the rack",
+	)
+
+
+func test_deactivating_an_item_restores_its_slot() -> void:
+	var gear := _make_item("gear_gamma", &"equipment")
+	var manager: Node = _make_manager_with([gear])
+	manager._progression.friendship_point_balance = 1000
+	var rack := _make_rack(&"equipment", manager)
+	manager.take(gear.key)
+	manager.activate(gear.key)
+	assert_eq(
+		rack.get_displayed_keys().size(),
+		0,
+		"precondition: activated equipment should not be on the rack",
+	)
+	manager.deactivate(gear.key)
+	assert_eq(
+		rack.get_displayed_keys().size(),
+		1,
+		"deactivating equipment should bring its slot back to the rack",
+	)
+	assert_eq(rack.get_displayed_keys()[0], gear.key)
+
+
+func test_court_role_items_never_appear_on_either_rack() -> void:
+	var court_item := _make_item("court_alpha", &"court")
+	var manager: Node = _make_manager_with([court_item])
+	manager._progression.item_levels[court_item.key] = 1
+	var ball_rack := _make_rack(&"ball", manager)
+	var gear_rack := _make_rack(&"equipment", manager)
+	assert_eq(
+		ball_rack.get_displayed_keys().size(),
+		0,
+		"court-role items must not appear on the ball rack",
+	)
+	assert_eq(
+		gear_rack.get_displayed_keys().size(),
+		0,
+		"court-role items must not appear on the gear rack",
+	)
+
+
+func test_rack_exposes_a_drop_target_child() -> void:
+	var ball_rack_scene: PackedScene = load("res://scenes/ball_rack.tscn")
+	var gear_rack_scene: PackedScene = load("res://scenes/gear_rack.tscn")
+	var ball_rack_instance: Node = ball_rack_scene.instantiate()
+	var gear_rack_instance: Node = gear_rack_scene.instantiate()
+	add_child_autofree(ball_rack_instance)
+	add_child_autofree(gear_rack_instance)
+	assert_not_null(
+		ball_rack_instance.get_node_or_null("DropTarget"),
+		"ball rack scene should expose a DropTarget child",
+	)
+	assert_not_null(
+		gear_rack_instance.get_node_or_null("DropTarget"),
+		"gear rack scene should expose a DropTarget child",
+	)
+	assert_true(
+		ball_rack_instance.get_node("DropTarget") is Area2D,
+		"ball rack DropTarget should be an Area2D",
+	)
+	assert_true(
+		gear_rack_instance.get_node("DropTarget") is Area2D,
+		"gear rack DropTarget should be an Area2D",
+	)

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -33,6 +33,11 @@ func _make_rack(role: StringName, manager: Node) -> Node2D:
 	var slot_container := Node2D.new()
 	slot_container.name = "SlotContainer"
 	rack.add_child(slot_container)
+	for index in 8:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
 	rack.slot_container = slot_container
 	rack.configure(manager)
 	add_child_autofree(rack)

--- a/tests/unit/items/test_rack_display.gd.uid
+++ b/tests/unit/items/test_rack_display.gd.uid
@@ -1,0 +1,1 @@
+uid://b1fx45oegaklj


### PR DESCRIPTION
The ball and gear racks now mirror the player's kit: each rack listens to `ItemManager.item_placement_changed` and `item_level_changed`, then renders one slot per owned item whose role matches and whose placement is STORED. Ball-role items show on the ball rack, equipment on the gear rack, and court-role items stay off both by construction. Each rack also exposes a `DropTarget` Area2D covering its bounds so SH-97, SH-98, and SH-100 have a single well-known region to query when wiring drag-and-drop. No gameplay effects run from the rack; placement already drives effects (SH-96).