### PR TITLE
docs: spike new features as design and tech tickets

### DIFF
--- a/.claude/agents/ticket-writer.md
+++ b/.claude/agents/ticket-writer.md
@@ -28,6 +28,7 @@ Before drafting, preload these pointers and keep them authoritative:
 - Intake status (Backlog, not Triage): `~/.claude/projects/-home-josh-gamedev-volley/memory/feedback_triage_status.md`
 - Regression linking: `~/.claude/projects/-home-josh-gamedev-volley/memory/feedback_bug_blocks_feature.md`
 - Native relations over prose links: `~/.claude/projects/-home-josh-gamedev-volley/memory/feedback_use_linear_native_relations.md`
+- Spike split for new features: `~/.claude/projects/-home-josh-gamedev-volley/memory/feedback_spike_split_design_tech.md`
 
 Read the ticket-writing guide every session before drafting; it is the source of truth and it changes.
 

--- a/.claude/agents/ticket-writer.md
+++ b/.claude/agents/ticket-writer.md
@@ -39,6 +39,8 @@ Do not file proactively. If you spot gaps while working other tasks, surface the
 
 Defaults for every new ticket: status Backlog (`d41fb73e-32af-40b2-a7e5-5052900ab0fc`), no cycle, unassigned. Feature label for stories, bug label for bug reports. Estimates: bugs 0, spikes 1, stories left unpointed for Josh. Never use Triage; that column is for external incoming tickets.
 
+A spike for a feature that does not yet exist in the game is filed as at least two tickets: one design spike (shape, feel, player experience, narrative framing) and one tech spike (feasibility, architecture, dependencies). Design and tech pull each other sideways when they share a ticket. Spikes against an existing system (a perf regression, a refactor question) do not need to split.
+
 Use Linear's native relations rather than a "References:" block in the description. Regressions `blocks` the feature that introduced them. Foundation tickets (style guides, pipelines, specs, spikes) block the production or integration work that depends on them. Cross-links to GitHub use absolute URLs.
 
 Keep acceptance criteria to a tight testable checklist. No computed values hardcoded; describe the behaviour, not the number. Bug reports always include steps to reproduce, expected vs actual, and environment (scene path, conditions).

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -97,6 +97,8 @@ Labels: `spike`, `feature`, `bug`.
 
 **Spike** (explore). Question-led. Output is a written recommendation: option A vs B, with reasoning, risks, and a suggested path. Spikes answer "can we" or "how would we" before a feature is written against them. Keep them small; if a spike looks large, it probably contains a feature underneath.
 
+A spike for a feature that does not yet exist in the game is filed as at least two tickets: one design spike (shape, feel, player experience, narrative framing) and one tech spike (feasibility, architecture, dependencies). Design and tech questions drag each other sideways when they share a ticket; the split lets each run at its own pace and produces two clean writeups. The feature ticket is drafted against both spike outputs, after they resolve. Spikes that investigate a single existing system (a perf regression, a refactor question) do not need to split.
+
 **Feature** (produce). Most features at Shuck are System Stories because they describe internal capability. Player-facing interaction uses User Story form. Either way, AC describes observable system or player outcomes. Insomniac's engineering practice (Mike Acton, GDC 2014–2019) adds target platform and frame-time budget to tickets touching the runtime; adopt the same discipline when perf is load-bearing.
 
 **Bug** (restore). The Bug format in CLAUDE.md is the full template. Regressions block their originating feature.


### PR DESCRIPTION
New rule from Josh: spikes for features that do not yet exist in the game split into at least two tickets, one design and one tech. The two vectors pull each other sideways when they share a ticket; separating them lets each run at its own pace and produces two clean writeups. Spikes that investigate a single existing system (perf regression, refactor question) still run as one.

Lands in both the human-facing guide (designs/process/ticket-writing.md) and the ticket-writer agent definition so the rule survives between sessions.