### PR TITLE
docs: add Lair framing guide

### DIFF
--- a/ai/lair/contributors.md
+++ b/ai/lair/contributors.md
@@ -1,0 +1,17 @@
+# Contributors
+
+You are in the doorway. This page is for anyone thinking about helping build Volley!, whether you stay for one contribution or a hundred.
+
+Our base is called the Lair. It is where the planning happens, where the docs live, and where the scripts and workflows that keep the work moving are kept in good order. It is also where the crew gathers at the start of a cycle and again when something is ready to ship.
+
+The Lair sits inside the Anti-Villain League. The Anti-Villain League is the broader circle around the project: Josh, the regular crew, and every contributor who turns up with something to offer. Membership is whoever is here and building, under whatever name fits.
+
+Contribution is whatever you bring. Code and art, music and sound, writing and translation, accessibility notes and playtest reports, a suggested name, a bug you tripped over, documentation and tutorials, community care, or quiet attention from the sidelines. All of it counts, and credit follows the contribution by name every time.
+
+Where to go next:
+
+- The repository [README](https://github.com/shuck-dev/volley/blob/main/README.md) is the starting point for the project itself: what Volley! is, how to build it, and how to get in touch.
+- The [internal guide](https://github.com/shuck-dev/volley/blob/main/ai/lair/guide.md) at `ai/lair/guide.md` describes how the crew runs day-to-day, with all the vocabulary we use among ourselves. Read it if you are curious about how missions are planned and reviewed.
+- The [Shuck manifesto](https://github.com/shuck-dev/volley/blob/main/SHUCK.md) at `SHUCK.md` explains why we build the way we do.
+
+Welcome in. We are glad you are here.

--- a/ai/lair/contributors.md
+++ b/ai/lair/contributors.md
@@ -14,4 +14,4 @@ Where to go next:
 - The [internal guide](https://github.com/shuck-dev/volley/blob/main/ai/lair/guide.md) at `ai/lair/guide.md` describes how the crew runs day-to-day, with all the vocabulary we use among ourselves. Read it if you are curious about how missions are planned and reviewed.
 - The [Shuck manifesto](https://github.com/shuck-dev/volley/blob/main/SHUCK.md) at `SHUCK.md` explains why we build the way we do.
 
-Welcome in. We are glad you are here.
+Come on through. We are glad you are here.

--- a/ai/lair/guide.md
+++ b/ai/lair/guide.md
@@ -1,0 +1,97 @@
+# The Lair: a guide to how Volley gets made
+
+Volley is built by a small crew with a big cast. Director Josh runs the operation from the Lair. Gru is the field lead. Lucy briefs him before every shift and keeps him current between them. Nefario arms the minions with the tools they need. The minions do the specialised work. The girls playtest the build before it ships. The public are the players who get what the crew returns to the world.
+
+This page is the doorway. Read it once and you will recognise everyone by name.
+
+## The cast
+
+**Director Josh.** Josh Hartley, the human. Sets priorities, approves designs, signs off releases. Everything upstream of a dispatch is his call; everything downstream of a merge is his playtest.
+
+**The Lair.** Volley's operational base: the repo docs, the agent infrastructure, the scripts and workflows that let the crew run a mission without reinventing the wheel each time. If a rule is worth keeping, it lives in the Lair.
+
+**Gru.** The main Claude thread, field lead for the day. Gru reads the briefing, casts the minions, dispatches them in parallel, merges their work, and reports back. Gru writes almost no code directly. The job is coordination.
+
+**Lucy.** The continuity layer: skills, memory, `CLAUDE.md`, `ai/` docs. Every fresh Gru session starts with Lucy walking through the current state of play, what's in flight, what Josh decided last week, what's allowed, what isn't. Without Lucy, Gru starts every shift from zero.
+
+**Nefario.** The tool layer. GodotIQ, MCP servers, Bash, Read, Write, WebSearch, WebFetch. Nefario does not decide anything; Nefario hands out the right instrument for the job and keeps it in working order.
+
+**The minions.** Specialist sub-agents, one per trade: code quality, GDScript conventions, signals, scene structure, docs, CI, test coverage, save format, supply chain, and the rest. A minion gets dispatched for a task, does that task, writes its report, and steps back.
+
+**The girls.** Margo, Edith, and Agnes: the testers who play the build before it goes out. Release candidates pass through their hands.
+
+**The public.** The players. The reason any of this happens.
+
+## The cycle
+
+Each cycle is a week. The beats are the same every time.
+
+**Dossier.** Before the cycle opens, Josh and Gru assemble the Dossier: the issues ready for the upcoming cycle, estimated, labelled, linked to their designs. A Dossier is what turns Backlog into a plan.
+
+**Mission briefing.** Before each mission inside the cycle, Gru writes a short briefing: which issues are in scope, which minions are cast, the ship-by. One paragraph is usually enough. The briefing is what the minions read first.
+
+**Dandori.** A verb. To dandori is to arrange the work strategically so parallel hands can close it without tripping over each other. "Gru dandoris the review round" means Gru reads the diff, partitions it by reviewer scope, and fires off the right minions at once.
+
+**Dandori Challenge.** A pull request. A time-boxed race where minions close out a mission together. The Challenge opens when the PR opens; it ends when the PR merges.
+
+**Dandori Battle.** The adversarial review round inside the Challenge. Reviewers post their verdicts, blocks supersede approves, authors revise, the Battle resolves when the diff is clean and Josh signs off.
+
+**The Carnival.** The build as a playable experience. Every release candidate is its own Carnival. The girls ride it first.
+
+**The Heist.** The release operation. Named for Gru's moon heist, with the polarity flipped: this one gives the prize to the world instead of taking it.
+
+**The Return.** The release moment itself. Named for the end of *Despicable Me 1*, when Gru returns the moon. It is the only heist that ends by handing the loot over.
+
+**Mission debrief.** After a mission closes, the crew debriefs. What shipped, what surprised, what to do differently.
+
+**Cycle retro.** At the end of the cycle, a retro. "Retro" stays as-is; the word is already cross-industry and nobody needs a new one.
+
+## Glossary
+
+| Term | What it means |
+|---|---|
+| Director Josh | Josh Hartley. Sets priorities, approves, signs off. |
+| The Lair | Volley's operational base: agent infra and repo docs. |
+| Gru | Main Claude thread. Field lead; coordinates, rarely codes. |
+| Lucy | Skills, memory, `CLAUDE.md`, `ai/` docs. The continuity layer. |
+| Nefario | Tool layer: GodotIQ, MCP, Bash, Read, Write, WebSearch, WebFetch. |
+| Minions | Specialist sub-agents dispatched per task. |
+| The girls | Margo, Edith, Agnes. Testers. |
+| The public | Players who get the shipped game. |
+| Mission | A bundle of Linear issues dispatched as one coordinated push. |
+| Dossier | Pre-cycle ritual: the issues readied for the upcoming cycle. |
+| Mission briefing | Pre-mission ritual: scope, cast, ship-by. |
+| Dandori | Verb. Arrange the work strategically, dispatch in parallel. |
+| Dandori Challenge | A PR. Time-boxed parallel-minion race to close a mission. |
+| Dandori Battle | The adversarial review round inside a Dandori Challenge. |
+| The Carnival | The build as a playable experience. Each RC is its own Carnival. |
+| The Heist | The release operation. Inverted polarity: gives to the world. |
+| The Return | The release moment itself. |
+| Mission debrief | Post-mission retrospective. |
+| Cycle retro | End-of-cycle reflection. |
+
+Usage examples, so the words feel natural:
+
+- "Gru dandoris the Muppets cycle Dossier before Tuesday."
+- "SH-321 opened its Dandori Challenge this morning; Trillian and Marvin are in the Battle."
+- "The Carnival on `rc-0.4` passed Margo's test. Edith is on it next."
+- "The Return ships Monday if nothing blocks."
+- "Nefario added a new MCP server; the minions pick it up next session."
+
+## What stays the same
+
+Three layers do not change under any of this. The Lair sits on top of them; it does not replace them.
+
+**Linear.** Issues, cycles, states (Backlog, Icebox, Ready, In Progress, In Review, Done), projects, labels. The Linear vocabulary is what every dashboard and API call already speaks.
+
+**GitHub.** Pull requests, reviews, merges, tags, releases, branches. When Gru says "PR" it means pull request; when Gru says "Dandori Challenge" it means the same pull request from the mission side.
+
+**Cycle names.** Every cycle spends its week at the Lair under its own name. Right now the names march alphabetically through famous puppets. Future cycles may pick a different theme; what matters is the habit of naming each cycle, not the theme it happens to wear.
+
+**Agent codenames.** Every minion gets a codename per work unit, rotated from a fixed pool: *Gravity Falls*, *Hitchhiker's Guide to the Galaxy*, *Oddworld*, *Omori*, *Outer Wilds* (Hearthians and Nomai), Volley's own cast (Martha and friends), and now *Minions* too where a Minion-flavoured name fits the case. Trillian reviewing a PR is still Trillian; the role underneath is `code-quality` or whichever slot fits.
+
+## If you are new
+
+Don't worry about memorising the cast. The crew briefs you when you arrive: Lucy hands over the current state of play, Gru points you at the mission, the minion whose slot matches your strength picks up its trade. Ask questions in the open. The Lair is built for it.
+
+Welcome in.

--- a/ai/lair/guide.md
+++ b/ai/lair/guide.md
@@ -4,6 +4,10 @@ Volley is built by a small crew with a big cast. Director Josh runs the operatio
 
 This page is the doorway. Read it once and you will recognise everyone by name.
 
+## The Anti-Villain League
+
+The Lair is a base inside the Anti-Villain League. The Anti-Villain League grows as people arrive, and Volley grows with it. Welcome in.
+
 ## The cast
 
 **Director Josh.** Josh Hartley, the human. Sets priorities, approves designs, signs off releases. Everything upstream of a dispatch is his call; everything downstream of a merge is his playtest.
@@ -92,6 +96,6 @@ Three layers do not change under any of this. The Lair sits on top of them; it d
 
 ## If you are new
 
-Don't worry about memorising the cast. The crew briefs you when you arrive: Lucy hands over the current state of play, Gru points you at the mission, the minion whose slot matches your strength picks up its trade. Ask questions in the open. The Lair is built for it.
+Don't worry about memorising the cast. The crew briefs you when you arrive: Lucy hands over the current state of play, Gru points you at the mission, the minion whose slot matches your strength picks up its trade. Ask questions in the open. The Lair is built for it, and the Anti-Villain League is bigger every time someone new steps through.
 
 Welcome in.

--- a/ai/lair/guide.md
+++ b/ai/lair/guide.md
@@ -2,7 +2,7 @@
 
 ## What the Lair is
 
-The Lair is Volley!'s operational base. It holds the repo docs, the agent infrastructure, and the scripts and workflows that let a week of work run without reinventing the wheel each time. If a rule is worth keeping, it lives in the Lair.
+The Lair is Volley!'s operational base. It holds the repo docs, the agent infrastructure, and the scripts and workflows that let two weeks of work run without reinventing the wheel each time. If a rule is worth keeping, it lives in the Lair.
 
 The Lair sits inside the Anti-Villain League, which is the broader circle around the project: Josh, the regular crew, and every contributor who turns up to help.
 
@@ -10,7 +10,7 @@ This page is the internal guide. It names the crew, walks through a cycle of wor
 
 ## What happens here
 
-A week of work at the Lair looks like this. Josh decides what matters next. A plan for the cycle gets assembled. The work is split across specialist AI helpers, one per trade, who are dispatched one task at a time and who we call minions. The main Claude thread coordinates them. When a batch of work is ready, it goes through review, then through playtest, then out to the public as a release.
+Two weeks of work at the Lair looks like this. Josh decides what matters next. A plan for the cycle gets assembled. The work is split across specialist AI helpers, one per trade, who are dispatched one task at a time and who we call minions. The main Claude thread coordinates them. When a batch of work is ready, it goes through review, then through playtest, then out to the public as a release.
 
 The names for each of those beats get introduced below in the order you meet them.
 
@@ -36,7 +36,7 @@ Two supporting layers keep Gru and the minions current.
 
 ## The cycle
 
-Each cycle is a week. The beats are the same every time.
+Each cycle is two weeks. The beats are the same every time.
 
 **Dossier.** Before the cycle opens, Josh and Gru assemble the Dossier: the issues ready for the upcoming cycle, estimated, labelled, linked to their designs. A Dossier is what turns Backlog into a plan.
 
@@ -119,7 +119,7 @@ Three layers do not change under any of this. The Lair sits on top of them; it d
 
 **GitHub.** Pull requests, reviews, merges, tags, releases, branches. When Gru says "PR" it means pull request; when Gru says "Dandori Challenge" it means the same pull request from the mission side.
 
-**Cycle names.** Every cycle spends its week at the Lair under its own name. Right now the names march alphabetically through famous puppets. Future cycles may pick a different theme; what matters is the habit of naming each cycle, not the theme it happens to wear.
+**Cycle names.** Every cycle spends its two weeks at the Lair under its own name. Right now the names march alphabetically through famous puppets. Future cycles may pick a different theme; what matters is the habit of naming each cycle, not the theme it happens to wear.
 
 **Agent codenames.** Every minion gets a codename per work unit, rotated from a fixed pool: *Gravity Falls*, *Hitchhiker's Guide to the Galaxy*, *Oddworld*, *Omori*, *Outer Wilds* (Hearthians and Nomai), Volley!'s own cast (Martha and friends), and *Minions* too where a Minion-flavoured name fits the case. Trillian reviewing a PR is still Trillian; the role underneath is `code-quality` or whichever slot fits.
 

--- a/ai/lair/guide.md
+++ b/ai/lair/guide.md
@@ -1,30 +1,38 @@
 # The Lair: a guide to how Volley gets made
 
-Volley is built by a crew with a big cast. Director Josh runs the operation from the Lair. Gru is the field lead. Lucy briefs him before every shift and keeps him current between them. Nefario arms the minions with the tools they need. The minions do the specialised work. The girls ride the Carnival before any of it leaves the Lair. The public play what the Return brings them.
+## What the Lair is
 
-This page is the doorway. Read it once and you will recognise everyone by name.
+The Lair is Volley!'s operational base. It holds the repo docs, the agent infrastructure, and the scripts and workflows that let a week of work run without reinventing the wheel each time. If a rule is worth keeping, it lives in the Lair.
 
-## The Anti-Villain League
+The Lair sits inside the Anti-Villain League, which is the broader circle around the project: Josh, the regular crew, and every contributor who turns up to help.
 
-The Lair is a base inside the Anti-Villain League. Welcome in.
+This page is the internal guide. It names the crew, walks through a cycle of work, and gathers the vocabulary in one place at the end. Read it once and you will recognise everyone.
 
-## The cast
+## What happens here
 
-**Director Josh.** Josh Hartley, the human. Sets priorities, approves designs, signs off the Return. Every mission starts with his call and ends with his playtest.
+A week of work at the Lair looks like this. Josh decides what matters next. A plan for the cycle gets assembled. The work is split across specialist AI helpers, one per trade, who are dispatched one task at a time and who we call minions. The main Claude thread coordinates them. When a batch of work is ready, it goes through review, then through playtest, then out to the public as a release.
 
-**The Lair.** Volley's operational base: repo docs, agent infrastructure, the scripts and workflows that let the crew run a mission without reinventing the wheel. If a rule is worth keeping, it lives in the Lair.
+The names for each of those beats get introduced below in the order you meet them.
 
-**Gru.** The main Claude thread, field lead for the day. Gru reads the briefing, casts the minions, dandoris them into a Dandori Challenge, and reports back when the Battle settles. The job is coordination, not code.
+## Director Josh
 
-**Lucy.** The continuity layer: skills, memory, `CLAUDE.md`, `ai/` docs. Every fresh Gru session opens with Lucy's briefing on what's in flight, what Josh decided last week, and what the Lair currently allows.
+Josh Hartley. The human. Josh directs the game: he sets priorities, approves designs, and signs off releases. The crew does the work; Josh says what the work is for and whether it is ready to ship.
 
-**Nefario.** The tool layer. GodotIQ, MCP servers, Bash, Read, Write, WebSearch, WebFetch. Nefario hands each minion the right instrument for its trade and keeps the workshop in working order.
+## Gru, the field lead
 
-**The minions.** Specialist sub-agents, one per trade: code quality, GDScript conventions, signals, scene structure, docs, CI, test coverage, save format, supply chain, and more. A minion joins a Dandori Challenge, does its trade, files its report, and steps back.
+Gru is the main Claude thread, the coordinator on shift. Gru reads the briefing for the day, picks which minions to dispatch, arranges the work so parallel hands do not trip over each other, and reports back when the round settles. The job is coordination, not code.
 
-**The girls.** Margo, Edith, and Agnes. They ride every Carnival before it leaves the Lair; the Return waits on their nod.
+## The minions
 
-**The public.** The players who get to play what the Return brings. The reason any of this happens.
+Minions are the specialist AI helpers, dispatched one per task. Each has a trade: code quality, GDScript conventions, signals, scene structure, docs, CI, test coverage, save format, supply chain, and more. A minion joins a round of work, does its trade, files its report, and steps back. Under the hood they are sub-agents; in conversation we call them minions.
+
+## Lucy and Nefario
+
+Two supporting layers keep Gru and the minions current.
+
+**Lucy** is the continuity layer: the long-term notes and conventions the crew draws on. In practical terms, that is the skills library, the memory store, the top-level `CLAUDE.md`, and everything under `ai/`. Every fresh Gru session opens with Lucy's briefing on what is in flight, what Josh decided recently, and what the Lair currently allows.
+
+**Nefario** is the tool layer: the instruments the minions use to get anything done. In practical terms, that is GodotIQ (the Godot-aware tooling), the MCP servers, and the file and shell and web tools (Bash, Read, Write, WebSearch, WebFetch). Nefario hands each minion the right instrument for its trade and keeps the workshop in working order.
 
 ## The cycle
 
@@ -32,41 +40,62 @@ Each cycle is a week. The beats are the same every time.
 
 **Dossier.** Before the cycle opens, Josh and Gru assemble the Dossier: the issues ready for the upcoming cycle, estimated, labelled, linked to their designs. A Dossier is what turns Backlog into a plan.
 
-**Mission briefing.** Before each mission inside the cycle, Gru writes a short briefing: which issues are in scope, which minions are cast, the ship-by. One paragraph is usually enough. The briefing is what the minions read first.
+**Mission briefing.** Before each mission inside the cycle, Gru writes a short briefing: which issues are in scope, which minions are cast, and the deadline. One paragraph is usually enough. The briefing is what the minions read first. A mission is a bundle of issues dispatched as one coordinated push.
 
-**Dandori.** A verb. To dandori is to arrange the work strategically so parallel hands can close it without tripping over each other. "Gru dandoris the review round" means Gru reads the diff, partitions it by reviewer scope, and fires off the right minions at once.
+**Dandori.** A verb, borrowed from Shigeru Miyamoto, who uses it to mean good planning. To dandori is to plan the work so parallel hands can close it without tripping over each other. "Gru dandoris the review round" means Gru reads the diff, partitions it by reviewer scope, and dispatches the right minions at once.
 
-**Dandori Challenge.** A pull request. A time-boxed race where minions close out a mission together. The Challenge opens when the PR opens; it ends when the PR merges.
+**Dandori Challenge.** A pull request. A Challenge is where minions close out a mission together. The Challenge opens when the PR opens; it ends when the PR merges.
 
-**Dandori Battle.** The adversarial review round inside the Challenge. Reviewers post their verdicts, blocks supersede approves, authors revise, the Battle resolves when the diff is clean and Josh signs off.
+**Dandori Battle.** The adversarial review round inside the Challenge. Reviewer minions post their verdicts, blocks supersede approves, authors revise, and the Battle resolves when the diff is clean and Josh signs off.
 
-**The Carnival.** The build as a playable experience. Every release candidate is its own Carnival. The girls ride it first.
+**The Carnival.** The build as a playable experience. Every release candidate is its own Carnival. The playtesters ride it first.
 
-**The Heist.** The release operation. Named for Gru's moon heist, with the polarity flipped: this one gives the prize to the world instead of taking it.
+**The Heist.** The release operation. Named after Gru's moon heist, with the polarity flipped: this one gives the prize to the world instead of taking it.
 
 **The Return.** The release moment itself. Named for the end of *Despicable Me 1*, when Gru returns the moon. It is the only heist that ends by handing the loot over.
 
 **Mission debrief.** After a mission closes, the crew debriefs. What shipped, what surprised, what to do differently.
 
-**Cycle retro.** At the end of the cycle, a retro. "Retro" stays as-is; the word is already cross-industry and nobody needs a new one.
+**Cycle retro.** At the end of the cycle, a retro. The word is already cross-industry and nobody needs a new one.
+
+## The playtesters
+
+Margo, Edith, and Agnes ride every Carnival before it leaves the Lair. The Return waits on their nod.
+
+They have their own ways of playing. **Margo** is the analytical one: she reads the systems, notices the edges, and writes up what the numbers feel like in the hand. **Edith** tries to break it: she holds the controller wrong on purpose, mashes inputs, and finds the rough corner you forgot to round off. **Agnes** is the vibe check: she plays the way a first-time player would, and tells you whether the thing is actually fun before any of the detail matters.
+
+## The public
+
+The players who get to play what the Return brings them. The reason any of this happens.
+
+## The cast, in one glance
+
+- **Director Josh.** Human. Directs the game.
+- **Gru.** Main Claude thread. Coordinates the day's work.
+- **Minions.** Specialist AI helpers, dispatched one per task.
+- **Lucy.** Continuity layer: skills, memory, `CLAUDE.md`, `ai/` docs.
+- **Nefario.** Tool layer: GodotIQ, MCP, Bash, Read, Write, WebSearch, WebFetch.
+- **Margo, Edith, Agnes.** Playtesters. Analytical, break-it, vibe-check.
+- **The public.** Players of the shipped game.
 
 ## Glossary
 
 | Term | What it means |
 |---|---|
+| The Lair | Volley!'s operational base: agent infrastructure and repo docs. |
+| Anti-Villain League | The broader circle around the project: crew and contributors. |
 | Director Josh | Josh Hartley. Sets priorities, approves, signs off. |
-| The Lair | Volley's operational base: agent infra and repo docs. |
 | Gru | Main Claude thread. Field lead; coordinates, rarely codes. |
-| Lucy | Skills, memory, `CLAUDE.md`, `ai/` docs. The continuity layer. |
+| Minions | Specialist AI helpers dispatched one per task. |
+| Lucy | Continuity layer: skills, memory, `CLAUDE.md`, `ai/` docs. |
 | Nefario | Tool layer: GodotIQ, MCP, Bash, Read, Write, WebSearch, WebFetch. |
-| Minions | Specialist sub-agents dispatched per task. |
-| The girls | Margo, Edith, Agnes. Testers. |
+| Margo, Edith, Agnes | Playtesters. Analytical, break-it, vibe-check. |
 | The public | Players who get the shipped game. |
 | Mission | A bundle of Linear issues dispatched as one coordinated push. |
 | Dossier | Pre-cycle ritual: the issues readied for the upcoming cycle. |
-| Mission briefing | Pre-mission ritual: scope, cast, ship-by. |
-| Dandori | Verb. Arrange the work strategically, dispatch in parallel. |
-| Dandori Challenge | A PR. Time-boxed parallel-minion race to close a mission. |
+| Mission briefing | Pre-mission ritual: scope, cast, deadline. |
+| Dandori | Verb. Plan the work so parallel hands can close it cleanly. |
+| Dandori Challenge | A pull request, seen from the mission side. |
 | Dandori Battle | The adversarial review round inside a Dandori Challenge. |
 | The Carnival | The build as a playable experience. Each RC is its own Carnival. |
 | The Heist | The release operation. Inverted polarity: gives to the world. |
@@ -92,10 +121,10 @@ Three layers do not change under any of this. The Lair sits on top of them; it d
 
 **Cycle names.** Every cycle spends its week at the Lair under its own name. Right now the names march alphabetically through famous puppets. Future cycles may pick a different theme; what matters is the habit of naming each cycle, not the theme it happens to wear.
 
-**Agent codenames.** Every minion gets a codename per work unit, rotated from a fixed pool: *Gravity Falls*, *Hitchhiker's Guide to the Galaxy*, *Oddworld*, *Omori*, *Outer Wilds* (Hearthians and Nomai), Volley's own cast (Martha and friends), and now *Minions* too where a Minion-flavoured name fits the case. Trillian reviewing a PR is still Trillian; the role underneath is `code-quality` or whichever slot fits.
+**Agent codenames.** Every minion gets a codename per work unit, rotated from a fixed pool: *Gravity Falls*, *Hitchhiker's Guide to the Galaxy*, *Oddworld*, *Omori*, *Outer Wilds* (Hearthians and Nomai), Volley!'s own cast (Martha and friends), and *Minions* too where a Minion-flavoured name fits the case. Trillian reviewing a PR is still Trillian; the role underneath is `code-quality` or whichever slot fits.
 
 ## If you are new
 
-Don't worry about memorising the cast. The crew briefs you when you arrive: Lucy hands over the current state of play, Gru points you at the mission, the minion whose slot matches your strength picks up its trade. Ask questions in the open. The Lair is built for it, and the Anti-Villain League is bigger every time someone new steps through.
+Don't worry about memorising the cast. The crew briefs you when you arrive: Lucy hands over the current state of play, Gru points you at the mission, and the minion whose slot matches your strength picks up its trade. Ask questions in the open. The Lair is built for it, and the Anti-Villain League is bigger every time someone new steps through.
 
 Welcome in.

--- a/ai/lair/guide.md
+++ b/ai/lair/guide.md
@@ -122,9 +122,3 @@ Three layers do not change under any of this. The Lair sits on top of them; it d
 **Cycle names.** Every cycle spends its two weeks at the Lair under its own name. Right now the names march alphabetically through famous puppets. Future cycles may pick a different theme; what matters is the habit of naming each cycle, not the theme it happens to wear.
 
 **Agent codenames.** Every minion gets a codename per work unit, rotated from a fixed pool: *Gravity Falls*, *Hitchhiker's Guide to the Galaxy*, *Oddworld*, *Omori*, *Outer Wilds* (Hearthians and Nomai), Volley!'s own cast (Martha and friends), and *Minions* too where a Minion-flavoured name fits the case. Trillian reviewing a PR is still Trillian; the role underneath is `code-quality` or whichever slot fits.
-
-## If you are new
-
-Don't worry about memorising the cast. The crew briefs you when you arrive: Lucy hands over the current state of play, Gru points you at the mission, and the minion whose slot matches your strength picks up its trade. Ask questions in the open. The Lair is built for it, and the Anti-Villain League is bigger every time someone new steps through.
-
-The door is open; come on through.

--- a/ai/lair/guide.md
+++ b/ai/lair/guide.md
@@ -127,4 +127,4 @@ Three layers do not change under any of this. The Lair sits on top of them; it d
 
 Don't worry about memorising the cast. The crew briefs you when you arrive: Lucy hands over the current state of play, Gru points you at the mission, and the minion whose slot matches your strength picks up its trade. Ask questions in the open. The Lair is built for it, and the Anti-Villain League is bigger every time someone new steps through.
 
-Welcome in.
+The door is open; come on through.

--- a/ai/lair/guide.md
+++ b/ai/lair/guide.md
@@ -1,30 +1,30 @@
 # The Lair: a guide to how Volley gets made
 
-Volley is built by a small crew with a big cast. Director Josh runs the operation from the Lair. Gru is the field lead. Lucy briefs him before every shift and keeps him current between them. Nefario arms the minions with the tools they need. The minions do the specialised work. The girls playtest the build before it ships. The public are the players who get what the crew returns to the world.
+Volley is built by a crew with a big cast. Director Josh runs the operation from the Lair. Gru is the field lead. Lucy briefs him before every shift and keeps him current between them. Nefario arms the minions with the tools they need. The minions do the specialised work. The girls ride the Carnival before any of it leaves the Lair. The public play what the Return brings them.
 
 This page is the doorway. Read it once and you will recognise everyone by name.
 
 ## The Anti-Villain League
 
-The Lair is a base inside the Anti-Villain League. The Anti-Villain League grows as people arrive, and Volley grows with it. Welcome in.
+The Lair is a base inside the Anti-Villain League. Welcome in.
 
 ## The cast
 
-**Director Josh.** Josh Hartley, the human. Sets priorities, approves designs, signs off releases. Everything upstream of a dispatch is his call; everything downstream of a merge is his playtest.
+**Director Josh.** Josh Hartley, the human. Sets priorities, approves designs, signs off the Return. Every mission starts with his call and ends with his playtest.
 
-**The Lair.** Volley's operational base: the repo docs, the agent infrastructure, the scripts and workflows that let the crew run a mission without reinventing the wheel each time. If a rule is worth keeping, it lives in the Lair.
+**The Lair.** Volley's operational base: repo docs, agent infrastructure, the scripts and workflows that let the crew run a mission without reinventing the wheel. If a rule is worth keeping, it lives in the Lair.
 
-**Gru.** The main Claude thread, field lead for the day. Gru reads the briefing, casts the minions, dispatches them in parallel, merges their work, and reports back. Gru writes almost no code directly. The job is coordination.
+**Gru.** The main Claude thread, field lead for the day. Gru reads the briefing, casts the minions, dandoris them into a Dandori Challenge, and reports back when the Battle settles. The job is coordination, not code.
 
-**Lucy.** The continuity layer: skills, memory, `CLAUDE.md`, `ai/` docs. Every fresh Gru session starts with Lucy walking through the current state of play, what's in flight, what Josh decided last week, what's allowed, what isn't. Without Lucy, Gru starts every shift from zero.
+**Lucy.** The continuity layer: skills, memory, `CLAUDE.md`, `ai/` docs. Every fresh Gru session opens with Lucy's briefing on what's in flight, what Josh decided last week, and what the Lair currently allows.
 
-**Nefario.** The tool layer. GodotIQ, MCP servers, Bash, Read, Write, WebSearch, WebFetch. Nefario does not decide anything; Nefario hands out the right instrument for the job and keeps it in working order.
+**Nefario.** The tool layer. GodotIQ, MCP servers, Bash, Read, Write, WebSearch, WebFetch. Nefario hands each minion the right instrument for its trade and keeps the workshop in working order.
 
-**The minions.** Specialist sub-agents, one per trade: code quality, GDScript conventions, signals, scene structure, docs, CI, test coverage, save format, supply chain, and the rest. A minion gets dispatched for a task, does that task, writes its report, and steps back.
+**The minions.** Specialist sub-agents, one per trade: code quality, GDScript conventions, signals, scene structure, docs, CI, test coverage, save format, supply chain, and more. A minion joins a Dandori Challenge, does its trade, files its report, and steps back.
 
-**The girls.** Margo, Edith, and Agnes: the testers who play the build before it goes out. Release candidates pass through their hands.
+**The girls.** Margo, Edith, and Agnes. They ride every Carnival before it leaves the Lair; the Return waits on their nod.
 
-**The public.** The players. The reason any of this happens.
+**The public.** The players who get to play what the Return brings. The reason any of this happens.
 
 ## The cycle
 


### PR DESCRIPTION
Introduces `ai/lair/guide.md`, a first-encounter tour of Volley's new process vocabulary: the Lair where work happens, Gru as the main thread, Lucy and Nefario at his side, minions and girls doing the doing, and the dandori verbs that move a ticket from dossier to debrief.

The shared language had thinned out to "swarm" and "organiser", which described the mechanics but carried none of the feel. This guide lands first so the follow-up renames (the `ai/swarm/` directory move, the memory sweep, the Linear project retitles) have a canonical doorway to point at instead of re-explaining the framing each time.