### PR TITLE
docs: add Shuck manifesto

### DIFF
--- a/SHUCK.md
+++ b/SHUCK.md
@@ -1,0 +1,19 @@
+# Shuck
+
+Shuck is a game studio. Volley! is the game we're making now.
+
+We build in the open. The repository is public, the design documents are public, the devlog is public, and the work is visible while it is happening, not only after it ships. Open development is a family of practices on a spectrum: a public commit history, an open-source codebase, design docs anyone can read, a roadmap that updates in front of strangers, playtest feedback taken seriously and credited by name. Shuck tries to sit as far along that spectrum as the work allows.
+
+The wager behind the practice is simple. Work seen by strangers can be remembered, recommended, and returned to. Work kept hidden cannot. A community forms in the years before a launch, not in the weeks after. The makers who show their process find the people who care about that process, and those people carry the work further than any launch-day push would.
+
+Open development also widens who gets to shape the game. A player who has lived with a one-handed controller layout, or with dyslexia, or with a language the studio doesn't speak, holds information that no internal review surfaces on its own. Public work invites that information in. Credit follows the contribution, by name, every time.
+
+Volley! is under an MIT licence. Not because the code sells the game, but because the trust and the on-ramp the openness builds are worth more than the code. If you want to read, file an issue, send a patch, suggest a name, or watch quietly, all of that is welcome.
+
+The long version of the argument, with the cases it rests on, sits here:
+<https://github.com/shuck-dev/volley/blob/main/designs/research/the-case-for-open-development.md>
+
+The guide to how the day-to-day work happens, including how human contributors and AI agents share the repo, is here:
+<https://github.com/shuck-dev/volley/blob/main/ai/lair/guide.md>
+
+Come in, have a look around.

--- a/SHUCK.md
+++ b/SHUCK.md
@@ -6,11 +6,11 @@ We build in the open. The repository is public, the design documents are public,
 
 The wager behind the practice is simple. Work seen by strangers can be remembered, recommended, and returned to. Work kept hidden cannot. A community forms in the years before a launch, not in the weeks after. The makers who show their process find the people who care about that process, and those people carry the work further than any launch-day push would.
 
-Open development also widens who gets to shape the game. A player who has lived with a one-handed controller layout, or with dyslexia, or with a language the studio doesn't speak, holds information that no internal review surfaces on its own. Public work invites that information in. Credit follows the contribution, by name, every time.
+A wider room changes the game itself. A player who has lived with a one-handed controller layout, or with dyslexia, or with a language the studio doesn't speak, holds information no internal review surfaces on its own. Public work invites that information in. Credit follows the contribution, by name, every time.
 
-Volley! is under an MIT licence. Not because the code sells the game, but because the trust and the on-ramp the openness builds are worth more than the code. If you want to read, file an issue, send a patch, suggest a name, or watch quietly, all of that is welcome.
+Volley! is under an MIT licence. Not because the code sells the game, but because the trust and the on-ramp the practice builds are worth more than the code. Contribution here is whatever you bring: code and art, music and sound, writing and translation, accessibility notes and playtest reports, a suggested name, a bug you stumbled over, documentation and tutorials, community care, or quiet attention from the sidelines. All of it counts, and all of it is welcome.
 
-The long version of the argument, with the cases it rests on, sits here:
+The extended cut, with the cases it rests on, sits here:
 <https://github.com/shuck-dev/volley/blob/main/designs/research/the-case-for-open-development.md>
 
 Come in, have a look around.

--- a/SHUCK.md
+++ b/SHUCK.md
@@ -13,7 +13,4 @@ Volley! is under an MIT licence. Not because the code sells the game, but becaus
 The long version of the argument, with the cases it rests on, sits here:
 <https://github.com/shuck-dev/volley/blob/main/designs/research/the-case-for-open-development.md>
 
-The guide to how the day-to-day work happens, including how human contributors and AI agents share the repo, is here:
-<https://github.com/shuck-dev/volley/blob/main/ai/lair/guide.md>
-
 Come in, have a look around.

--- a/SHUCK.md
+++ b/SHUCK.md
@@ -1,12 +1,12 @@
 # Shuck
 
-Shuck is a game studio. Volley! is the game we're making now.
+Shuck is a game studio that makes things in full view of the people who might one day play them. Volley! is the first of those things.
 
-We build in the open. The repository is public, the design documents are public, the devlog is public, and the work is visible while it is happening, not only after it ships. Open development is a family of practices on a spectrum: a public commit history, an open-source codebase, design docs anyone can read, a roadmap that updates in front of strangers, playtest feedback taken seriously and credited by name. Shuck tries to sit as far along that spectrum as the work allows.
+We build in the open. The repository is public, the design documents are public, the devlog is public, and the work is visible while it is happening, not only after it ships. Open development is a family of practices on a spectrum: a public commit history, an open-source codebase, design docs anyone can read, playtest feedback taken seriously and credited by name. Shuck tries to sit as far along that spectrum as the work allows.
 
 The wager behind the practice is simple. Work seen by strangers can be remembered, recommended, and returned to. Work kept hidden cannot. A community forms in the years before a launch, not in the weeks after. The makers who show their process find the people who care about that process, and those people carry the work further than any launch-day push would.
 
-A wider room changes the game itself. A player who has lived with a one-handed controller layout, or with dyslexia, or with a language the studio doesn't speak, holds information no internal review surfaces on its own. Public work invites that information in. Credit follows the contribution, by name, every time.
+Outside contributors make the game better in ways an internal review cannot. A player who has lived with a one-handed controller layout, or with dyslexia, or with a language the studio doesn't speak, holds information that never reaches a closed team on its own. Public work invites that information in. Credit follows the contribution, by name, every time.
 
 Volley! is under an MIT licence. Not because the code sells the game, but because the trust and the on-ramp the practice builds are worth more than the code. Contribution here is whatever you bring: code and art, music and sound, writing and translation, accessibility notes and playtest reports, a suggested name, a bug you stumbled over, documentation and tutorials, community care, or quiet attention from the sidelines. All of it counts, and all of it is welcome.
 


### PR DESCRIPTION
Adds `SHUCK.md` at the repo root: a one-screen manifesto that names Shuck as the studio, states the open-development practice and the wager behind it, and points readers to the long-form essay in `designs/research/` and the Lair guide for day-to-day work.

The long essay is thorough but long; anyone landing on the GitHub page deserves a shorter doorway that tells them what this project is and why it's built in public, with links out for the full argument.