### PR TITLE
SH-98 feat: timeout controller for equip pose

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -64,6 +64,11 @@ toggle_autoplay={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+call_timeout={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":84,"physical_keycode":0,"key_label":0,"unicode":116,"location":0,"echo":false,"script":null)
+]
+}
 camera_left={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)

--- a/resources/timeout_config.tres
+++ b/resources/timeout_config.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="TimeoutConfig" format=3 uid="uid://iq04trmvlswer"]
+
+[ext_resource type="Script" uid="uid://twzcw4zqandao" path="res://scripts/core/timeout_config.gd" id="1_tcfg0"]
+
+[resource]
+script = ExtResource("1_tcfg0")
+walk_duration_seconds = 0.6
+equip_pose_offset_x = -320.0

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://c4d57kq6juqi0" path="res://scenes/ball.tscn" id="1_o5qli"]
 [ext_resource type="Script" uid="uid://glw3v53y7eyu" path="res://scripts/core/court.gd" id="1_tbgi4"]
 [ext_resource type="Script" uid="uid://dpq2mxc834vw4" path="res://scripts/core/autoplay_controller.gd" id="7_tipki"]
+[ext_resource type="Script" path="res://scripts/core/timeout_controller.gd" id="19_timeout"]
 [ext_resource type="Resource" uid="uid://bgop07op1bnc7" path="res://resources/autoplay_config.tres" id="8_85g3d"]
 [ext_resource type="PackedScene" uid="uid://bxyckxy4cf7r0" path="res://scenes/ball_rack.tscn" id="8_h0b8m"]
 [ext_resource type="PackedScene" uid="uid://pglvgky7ryvi" path="res://scenes/player_paddle.tscn" id="9_0tnpc"]
@@ -24,7 +25,7 @@ size = Vector2(36, 1472)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vert"]
 size = Vector2(36, 1172)
 
-[node name="Court" type="Node2D" unique_id=75800363 node_paths=PackedStringArray("ball", "player_spawn", "autoplay_controller", "right_wall", "partner_spawn")]
+[node name="Court" type="Node2D" unique_id=75800363 node_paths=PackedStringArray("ball", "player_spawn", "autoplay_controller", "right_wall", "partner_spawn", "timeout_controller")]
 script = ExtResource("1_tbgi4")
 ball = NodePath("Ball")
 player_paddle_scene = ExtResource("9_0tnpc")
@@ -32,6 +33,7 @@ player_spawn = NodePath("PlayerSpawn")
 autoplay_controller = NodePath("AutoplayController")
 right_wall = NodePath("Bounds/Right Wall")
 partner_spawn = NodePath("PartnerSpawn")
+timeout_controller = NodePath("TimeoutController")
 
 [node name="CourtBackground" type="Parallax2D" parent="." unique_id=1053024008]
 scroll_scale = Vector2(0, 0)
@@ -114,6 +116,9 @@ position = Vector2(18, 586)
 [node name="AutoplayController" type="Node" parent="." unique_id=280970194]
 script = ExtResource("7_tipki")
 config = ExtResource("8_85g3d")
+
+[node name="TimeoutController" type="Node" parent="." unique_id=1998734210]
+script = ExtResource("19_timeout")
 
 [node name="PartnerSpawn" type="Marker2D" parent="." unique_id=618859562]
 position = Vector2(500, 0)

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://c4d57kq6juqi0" path="res://scenes/ball.tscn" id="1_o5qli"]
 [ext_resource type="Script" uid="uid://glw3v53y7eyu" path="res://scripts/core/court.gd" id="1_tbgi4"]
 [ext_resource type="Script" uid="uid://dpq2mxc834vw4" path="res://scripts/core/autoplay_controller.gd" id="7_tipki"]
-[ext_resource type="Script" path="res://scripts/core/timeout_controller.gd" id="19_timeout"]
+[ext_resource type="Script" uid="uid://o6ajsnor2wqt" path="res://scripts/core/timeout_controller.gd" id="19_timeout"]
 [ext_resource type="Resource" uid="uid://bgop07op1bnc7" path="res://resources/autoplay_config.tres" id="8_85g3d"]
 [ext_resource type="PackedScene" uid="uid://bxyckxy4cf7r0" path="res://scenes/ball_rack.tscn" id="8_h0b8m"]
 [ext_resource type="PackedScene" uid="uid://pglvgky7ryvi" path="res://scenes/player_paddle.tscn" id="9_0tnpc"]

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -18,6 +18,7 @@
 [ext_resource type="Script" uid="uid://doc6now6a5i3e" path="res://scripts/court/friendship_points.gd" id="16_fp"]
 [ext_resource type="Script" uid="uid://bbrvypfsmukn" path="res://scripts/court/auto_indicator.gd" id="17_auto"]
 [ext_resource type="Script" uid="uid://bab6qm77112cl" path="res://scripts/court/fp_bonus.gd" id="18_fpb"]
+[ext_resource type="Resource" uid="uid://iq04trmvlswer" path="res://resources/timeout_config.tres" id="20_timeout_cfg"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_horz"]
 size = Vector2(36, 1472)
@@ -119,6 +120,7 @@ config = ExtResource("8_85g3d")
 
 [node name="TimeoutController" type="Node" parent="." unique_id=1998734210]
 script = ExtResource("19_timeout")
+config = ExtResource("20_timeout_cfg")
 
 [node name="PartnerSpawn" type="Marker2D" parent="." unique_id=618859562]
 position = Vector2(500, 0)

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -15,6 +15,7 @@ const MissZoneScene: PackedScene = preload("res://scenes/miss_zone.tscn")
 @export var autoplay_controller: AutoplayController
 @export var right_wall: StaticBody2D
 @export var partner_spawn: Marker2D
+@export var timeout_controller: TimeoutController
 
 var player_paddle: Paddle
 var partner_paddle: PartnerPaddle
@@ -48,6 +49,9 @@ func _ready() -> void:
 	player_paddle.paddle_hit.connect(_on_paddle_hit)
 	ball.effect_processor.paddles = [player_paddle]
 
+	if timeout_controller != null:
+		timeout_controller.configure(player_paddle)
+
 	for zone in get_tree().get_nodes_in_group(&"miss_zones"):
 		ball.register_miss_zone(zone)
 
@@ -67,6 +71,11 @@ func _ready() -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("toggle_autoplay"):
 		autoplay_controller.toggle()
+	if event.is_action_pressed("call_timeout") and timeout_controller != null:
+		if timeout_controller.can_call_timeout():
+			timeout_controller.call_timeout()
+		else:
+			timeout_controller.end_timeout()
 
 
 func _physics_process(delta: float) -> void:

--- a/scripts/core/timeout_config.gd
+++ b/scripts/core/timeout_config.gd
@@ -1,0 +1,9 @@
+class_name TimeoutConfig
+extends Resource
+
+## Tunables for TimeoutController: how long the walk takes and where the equip pose sits.
+
+## Seconds to walk from the lane to the equip pose (and back).
+@export var walk_duration_seconds: float = 0.6
+## Horizontal offset from lane x to equip pose, away from the court on the player's side.
+@export var equip_pose_offset_x: float = -320.0

--- a/scripts/core/timeout_config.gd.uid
+++ b/scripts/core/timeout_config.gd.uid
@@ -1,0 +1,1 @@
+uid://twzcw4zqandao

--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -1,0 +1,105 @@
+class_name TimeoutController
+extends Node
+
+## Manages the timeout-and-equip state machine.
+##
+## On a timeout call the main character walks off the court to an equip pose
+## where equipment can be dragged on or off. While the timeout is active the
+## main character no longer defends, so the rally ends on the next miss.
+## Ending the timeout walks the main character back on so a new rally can begin.
+
+signal timeout_started
+signal main_character_reached_equip_pose
+signal timeout_ended
+
+enum State { IDLE, WALKING_OFF, AT_EQUIP_POSE, WALKING_ON }
+
+const WALK_DURATION_SECONDS: float = 0.6
+## Horizontal distance from the main character's lane x to the equip pose,
+## away from the court on the player's side.
+const EQUIP_POSE_OFFSET_X: float = -320.0
+
+@export var main_character: Paddle
+
+var _state: int = State.IDLE
+var _lane_x: float = 0.0
+var _equip_pose_x: float = 0.0
+var _walk_tween: Tween
+
+
+func _ready() -> void:
+	if main_character == null:
+		return
+	_cache_positions()
+
+
+func configure(paddle: Paddle) -> void:
+	main_character = paddle
+	_cache_positions()
+
+
+func is_active() -> bool:
+	return _state != State.IDLE
+
+
+func can_call_timeout() -> bool:
+	return _state == State.IDLE
+
+
+func get_state() -> int:
+	return _state
+
+
+## Starts a timeout. The main character walks off the court toward the equip
+## pose. No-op if a timeout is already in progress.
+func call_timeout() -> void:
+	if not can_call_timeout():
+		return
+	if main_character == null:
+		push_warning("TimeoutController.call_timeout: main_character is null")
+		return
+	_cache_positions()
+	_state = State.WALKING_OFF
+	main_character.set_physics_process(false)
+	main_character.velocity = Vector2.ZERO
+	timeout_started.emit()
+	_walk_to(_equip_pose_x, _on_reached_equip_pose)
+
+
+## Ends a timeout and walks the main character back on court. No-op unless the
+## main character has finished walking off to the equip pose.
+func end_timeout() -> void:
+	if _state != State.AT_EQUIP_POSE:
+		return
+	if main_character == null:
+		return
+	_state = State.WALKING_ON
+	_walk_to(_lane_x, _on_reached_lane)
+
+
+func _cache_positions() -> void:
+	if main_character == null:
+		return
+	if _state == State.IDLE:
+		_lane_x = main_character.position.x
+		_equip_pose_x = _lane_x + EQUIP_POSE_OFFSET_X
+
+
+func _walk_to(target_x: float, on_finished: Callable) -> void:
+	if _walk_tween != null and _walk_tween.is_valid():
+		_walk_tween.kill()
+	_walk_tween = create_tween()
+	_walk_tween.tween_property(main_character, "position:x", target_x, WALK_DURATION_SECONDS)
+	_walk_tween.finished.connect(on_finished)
+
+
+func _on_reached_equip_pose() -> void:
+	_state = State.AT_EQUIP_POSE
+	main_character_reached_equip_pose.emit()
+
+
+func _on_reached_lane() -> void:
+	_state = State.IDLE
+	if main_character != null:
+		main_character.set_physics_process(true)
+	timeout_ended.emit()

--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -1,12 +1,7 @@
 class_name TimeoutController
 extends Node
 
-## Manages the timeout-and-equip state machine.
-##
-## On a timeout call the main character walks off the court to an equip pose
-## where equipment can be dragged on or off. While the timeout is active the
-## main character no longer defends, so the rally ends on the next miss.
-## Ending the timeout walks the main character back on so a new rally can begin.
+## State machine for timeout-and-equip: walks the main character off court to an equip pose and back.
 
 signal timeout_started
 signal main_character_reached_equip_pose
@@ -15,13 +10,12 @@ signal timeout_ended
 enum State { IDLE, WALKING_OFF, AT_EQUIP_POSE, WALKING_ON }
 
 const WALK_DURATION_SECONDS: float = 0.6
-## Horizontal distance from the main character's lane x to the equip pose,
-## away from the court on the player's side.
+## Horizontal offset from lane x to equip pose, away from the court on the player's side.
 const EQUIP_POSE_OFFSET_X: float = -320.0
 
 @export var main_character: Paddle
 
-var _state: int = State.IDLE
+var _state: State = State.IDLE
 var _lane_x: float = 0.0
 var _equip_pose_x: float = 0.0
 var _walk_tween: Tween
@@ -46,8 +40,11 @@ func can_call_timeout() -> bool:
 	return _state == State.IDLE
 
 
-## Starts a timeout. The main character walks off the court toward the equip
-## pose. No-op if a timeout is already in progress.
+func get_state() -> State:
+	return _state
+
+
+## Starts a timeout, walking the main character off to the equip pose. No-op if already active.
 func call_timeout() -> void:
 	if not can_call_timeout():
 		return
@@ -62,8 +59,7 @@ func call_timeout() -> void:
 	_walk_to(_equip_pose_x, _on_reached_equip_pose)
 
 
-## Ends a timeout and walks the main character back on court. No-op unless the
-## main character has finished walking off to the equip pose.
+## Ends a timeout and walks the main character back on court. No-op unless at the equip pose.
 func end_timeout() -> void:
 	if _state != State.AT_EQUIP_POSE:
 		return

--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -46,10 +46,6 @@ func can_call_timeout() -> bool:
 	return _state == State.IDLE
 
 
-func get_state() -> int:
-	return _state
-
-
 ## Starts a timeout. The main character walks off the court toward the equip
 ## pose. No-op if a timeout is already in progress.
 func call_timeout() -> void:
@@ -100,6 +96,6 @@ func _on_reached_equip_pose() -> void:
 
 func _on_reached_lane() -> void:
 	_state = State.IDLE
-	if main_character != null:
+	if is_instance_valid(main_character):
 		main_character.set_physics_process(true)
 	timeout_ended.emit()

--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -2,18 +2,19 @@ class_name TimeoutController
 extends Node
 
 ## State machine for timeout-and-equip: walks the main character off court to an equip pose and back.
+##
+## Invariant: when `_state != IDLE`, `main_character` is non-null and valid; enforced at
+## `call_timeout`, trusted elsewhere.
 
 signal timeout_started
 signal main_character_reached_equip_pose
 signal timeout_ended
 
+## Phases of the main character's timeout; IDLE means no timeout is in flight.
 enum State { IDLE, WALKING_OFF, AT_EQUIP_POSE, WALKING_ON }
 
-const WALK_DURATION_SECONDS: float = 0.6
-## Horizontal offset from lane x to equip pose, away from the court on the player's side.
-const EQUIP_POSE_OFFSET_X: float = -320.0
-
 @export var main_character: Paddle
+@export var config: TimeoutConfig
 
 var _state: State = State.IDLE
 var _lane_x: float = 0.0
@@ -22,12 +23,19 @@ var _walk_tween: Tween
 
 
 func _ready() -> void:
+	if config == null:
+		config = TimeoutConfig.new()
 	if main_character == null:
 		return
 	_cache_positions()
 
 
 func configure(paddle: Paddle) -> void:
+	assert(paddle != null, "TimeoutController.configure: paddle must not be null")
+	assert(
+		_state == State.IDLE,
+		"TimeoutController.configure: cannot reconfigure during active timeout",
+	)
 	main_character = paddle
 	_cache_positions()
 
@@ -63,8 +71,10 @@ func call_timeout() -> void:
 func end_timeout() -> void:
 	if _state != State.AT_EQUIP_POSE:
 		return
-	if main_character == null:
-		return
+	assert(
+		main_character != null,
+		"TimeoutController invariant: active state with null main_character",
+	)
 	_state = State.WALKING_ON
 	_walk_to(_lane_x, _on_reached_lane)
 
@@ -72,20 +82,23 @@ func end_timeout() -> void:
 func _cache_positions() -> void:
 	if main_character == null:
 		return
-	if _state == State.IDLE:
-		_lane_x = main_character.position.x
-		_equip_pose_x = _lane_x + EQUIP_POSE_OFFSET_X
+	if config == null:
+		config = TimeoutConfig.new()
+	_lane_x = main_character.position.x
+	_equip_pose_x = _lane_x + config.equip_pose_offset_x
 
 
 func _walk_to(target_x: float, on_finished: Callable) -> void:
 	if _walk_tween != null and _walk_tween.is_valid():
 		_walk_tween.kill()
 	_walk_tween = create_tween()
-	_walk_tween.tween_property(main_character, "position:x", target_x, WALK_DURATION_SECONDS)
+	_walk_tween.tween_property(main_character, "position:x", target_x, config.walk_duration_seconds)
 	_walk_tween.finished.connect(on_finished)
 
 
 func _on_reached_equip_pose() -> void:
+	if not is_instance_valid(main_character):
+		return
 	_state = State.AT_EQUIP_POSE
 	main_character_reached_equip_pose.emit()
 

--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -2,9 +2,7 @@ class_name TimeoutController
 extends Node
 
 ## State machine for timeout-and-equip: walks the main character off court to an equip pose and back.
-##
-## Invariant: when `_state != IDLE`, `main_character` is non-null and valid; enforced at
-## `call_timeout`, trusted elsewhere.
+## Invariant: when `_state != IDLE`, `main_character` is non-null; enforced at `call_timeout`, trusted elsewhere.
 
 signal timeout_started
 signal main_character_reached_equip_pose

--- a/scripts/core/timeout_controller.gd.uid
+++ b/scripts/core/timeout_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://o6ajsnor2wqt

--- a/tests/integration/test_timeout_wiring.gd
+++ b/tests/integration/test_timeout_wiring.gd
@@ -1,0 +1,51 @@
+extends GutTest
+
+## Verifies that court.gd forwards the call_timeout input action to the
+## TimeoutController and toggles correctly.
+
+var _game: Node2D
+var _paddle: Paddle
+var _timeout: TimeoutController
+
+
+func before_each() -> void:
+	_paddle = load("res://scripts/entities/paddle.gd").new()
+	var sound := AudioStreamPlayer.new()
+	_paddle.add_child(sound)
+	_paddle.hit_sound = sound
+	var tracker: HitTracker = load("res://scripts/core/hit_tracker.gd").new()
+	_paddle.tracker = tracker
+	_paddle.add_child(tracker)
+	_paddle.position = Vector2(-500.0, 0.0)
+
+	_timeout = load("res://scripts/core/timeout_controller.gd").new()
+	_timeout.configure(_paddle)
+
+	var autoplay_controller_stub: Node = load("res://tests/stubs/autoplay_controller_stub.gd").new()
+	add_child_autofree(autoplay_controller_stub)
+
+	_game = load("res://scripts/core/court.gd").new()
+	_game.autoplay_controller = autoplay_controller_stub
+	_game.timeout_controller = _timeout
+	add_child_autofree(_paddle)
+	add_child_autofree(_timeout)
+	add_child_autofree(_game)
+
+
+func _press(action: StringName) -> void:
+	var event := InputEventAction.new()
+	event.action = action
+	event.pressed = true
+	_game._unhandled_input(event)
+
+
+func test_pressing_call_timeout_starts_a_timeout() -> void:
+	watch_signals(_timeout)
+	_press(&"call_timeout")
+	assert_signal_emitted(_timeout, "timeout_started")
+
+
+func test_timeout_action_is_noop_without_controller() -> void:
+	_game.timeout_controller = null
+	_press(&"call_timeout")  # should not crash
+	assert_true(true)

--- a/tests/integration/test_timeout_wiring.gd
+++ b/tests/integration/test_timeout_wiring.gd
@@ -13,6 +13,7 @@ func before_each() -> void:
 	var sound := AudioStreamPlayer.new()
 	_paddle.add_child(sound)
 	_paddle.hit_sound = sound
+
 	var tracker: HitTracker = load("res://scripts/core/hit_tracker.gd").new()
 	_paddle.tracker = tracker
 	_paddle.add_child(tracker)

--- a/tests/integration/test_timeout_wiring.gd
+++ b/tests/integration/test_timeout_wiring.gd
@@ -47,5 +47,7 @@ func test_pressing_call_timeout_starts_a_timeout() -> void:
 
 func test_timeout_action_is_noop_without_controller() -> void:
 	_game.timeout_controller = null
-	_press(&"call_timeout")  # should not crash
-	assert_true(true)
+	watch_signals(_timeout)
+	_press(&"call_timeout")
+	assert_signal_not_emitted(_timeout, "timeout_started")
+	assert_false(_timeout.is_active())

--- a/tests/integration/test_timeout_wiring.gd.uid
+++ b/tests/integration/test_timeout_wiring.gd.uid
@@ -1,0 +1,1 @@
+uid://b2gb607wghuhh

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -1,0 +1,133 @@
+extends GutTest
+
+## Behavioural tests for TimeoutController.
+##
+## Drives the walk-off/walk-on state machine by advancing tweens via
+## SceneTree's process step so we do not inspect private state.
+
+const WALK_DURATION: float = TimeoutController.WALK_DURATION_SECONDS
+const LANE_X: float = -500.0
+
+var _paddle: Paddle
+var _controller: TimeoutController
+
+
+func before_each() -> void:
+	_paddle = load("res://scripts/entities/paddle.gd").new()
+	var sound := AudioStreamPlayer.new()
+	_paddle.add_child(sound)
+	_paddle.hit_sound = sound
+	var tracker: HitTracker = load("res://scripts/core/hit_tracker.gd").new()
+	_paddle.tracker = tracker
+	_paddle.add_child(tracker)
+	_paddle.position = Vector2(LANE_X, 0.0)
+	add_child_autofree(_paddle)
+
+	_controller = load("res://scripts/core/timeout_controller.gd").new()
+	_controller.configure(_paddle)
+	add_child_autofree(_controller)
+
+
+func _advance_walk() -> void:
+	# Advance the tween past completion. One extra frame lets the finished
+	# callback settle.
+	await wait_seconds(WALK_DURATION + 0.05)
+
+
+# --- initial state ---
+func test_starts_idle_and_can_call_timeout() -> void:
+	assert_false(_controller.is_active(), "should start idle")
+	assert_true(_controller.can_call_timeout(), "should accept a timeout when idle")
+
+
+# --- call_timeout ---
+func test_call_timeout_emits_started_signal() -> void:
+	watch_signals(_controller)
+	_controller.call_timeout()
+	assert_signal_emitted(_controller, "timeout_started")
+
+
+func test_call_timeout_disables_main_character_physics() -> void:
+	_controller.call_timeout()
+	assert_false(
+		_paddle.is_physics_processing(),
+		"main character should stop defending during timeout",
+	)
+
+
+func test_call_timeout_rejected_while_already_active() -> void:
+	_controller.call_timeout()
+	watch_signals(_controller)
+	_controller.call_timeout()
+	assert_signal_emit_count(_controller, "timeout_started", 0)
+
+
+func test_cannot_call_timeout_while_walking_off() -> void:
+	_controller.call_timeout()
+	assert_false(
+		_controller.can_call_timeout(),
+		"timeout cannot be re-called while main character is off the court",
+	)
+
+
+# --- walk to equip pose ---
+func test_main_character_reaches_equip_pose_after_walk() -> void:
+	watch_signals(_controller)
+	_controller.call_timeout()
+	await _advance_walk()
+	assert_signal_emitted(_controller, "main_character_reached_equip_pose")
+
+
+func test_equip_pose_is_off_the_lane() -> void:
+	_controller.call_timeout()
+	await _advance_walk()
+	assert_ne(
+		_paddle.position.x,
+		LANE_X,
+		"main character should not be standing on the lane during the timeout",
+	)
+
+
+# --- end_timeout ---
+func test_end_timeout_before_reaching_pose_is_ignored() -> void:
+	_controller.call_timeout()
+	watch_signals(_controller)
+	_controller.end_timeout()
+	assert_signal_emit_count(_controller, "timeout_ended", 0)
+
+
+func test_end_timeout_walks_main_character_back_to_lane() -> void:
+	_controller.call_timeout()
+	await _advance_walk()
+	_controller.end_timeout()
+	await _advance_walk()
+	assert_almost_eq(_paddle.position.x, LANE_X, 0.1)
+
+
+func test_end_timeout_restores_main_character_physics() -> void:
+	_controller.call_timeout()
+	await _advance_walk()
+	_controller.end_timeout()
+	await _advance_walk()
+	assert_true(
+		_paddle.is_physics_processing(),
+		"main character should defend again after the timeout ends",
+	)
+
+
+func test_end_timeout_emits_ended_signal_after_walk_on() -> void:
+	_controller.call_timeout()
+	await _advance_walk()
+	watch_signals(_controller)
+	_controller.end_timeout()
+	await _advance_walk()
+	assert_signal_emitted(_controller, "timeout_ended")
+
+
+func test_controller_returns_to_idle_after_full_cycle() -> void:
+	_controller.call_timeout()
+	await _advance_walk()
+	_controller.end_timeout()
+	await _advance_walk()
+	assert_false(_controller.is_active())
+	assert_true(_controller.can_call_timeout())

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -5,9 +5,9 @@ extends GutTest
 ## Drives the walk-off/walk-on state machine by advancing tweens via
 ## SceneTree's process step so we do not inspect private state.
 
-const WALK_DURATION: float = TimeoutController.WALK_DURATION_SECONDS
 const LANE_X: float = -500.0
 
+var _walk_duration: float
 var _paddle: Paddle
 var _controller: TimeoutController
 
@@ -17,13 +17,17 @@ func before_each() -> void:
 	var sound := AudioStreamPlayer.new()
 	_paddle.add_child(sound)
 	_paddle.hit_sound = sound
+
 	var tracker: HitTracker = load("res://scripts/core/hit_tracker.gd").new()
 	_paddle.tracker = tracker
 	_paddle.add_child(tracker)
 	_paddle.position = Vector2(LANE_X, 0.0)
 	add_child_autofree(_paddle)
 
+	var config: TimeoutConfig = load("res://resources/timeout_config.tres")
+	_walk_duration = config.walk_duration_seconds
 	_controller = load("res://scripts/core/timeout_controller.gd").new()
+	_controller.config = config
 	_controller.configure(_paddle)
 	add_child_autofree(_controller)
 
@@ -31,7 +35,7 @@ func before_each() -> void:
 func _advance_walk() -> void:
 	# Advance the tween past completion. One extra frame lets the finished
 	# callback settle.
-	await wait_seconds(WALK_DURATION + 0.05)
+	await wait_seconds(_walk_duration + 0.05)
 
 
 # --- initial state ---

--- a/tests/unit/paddle/test_timeout_controller.gd.uid
+++ b/tests/unit/paddle/test_timeout_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://sxmy4rsgwc1x


### PR DESCRIPTION
Adds a TimeoutController that walks the main character off the court to an equip pose when a timeout is called, and back on when the timeout ends. The rally continues without a defender during the timeout and ends naturally on the next miss. A new `call_timeout` input action (T key) toggles it from court.gd.

The equip pose x is computed from the main character's lane rather than carried as an authored marker in the scene, so no new geometry lives in court.tscn beyond the controller node itself. Drag-to-equip wiring on the gear rack stays for a follow-up ticket; this PR delivers the state-machine half of SH-98 that everything else hangs off.

Closes SH-98.