### PR TITLE
docs: tier comment-length rule for reviewers

### DIFF
--- a/ai/skills/reviewers.md
+++ b/ai/skills/reviewers.md
@@ -80,6 +80,8 @@ Each inline comment follows Conventional Comments:
 
 Keep each inline under 60 words. One issue per comment, state the why, don't lecture.
 
+**Length tiers.** One line is ideal. Two lines is exceptional and fine; flag only as `nitpick` or `suggestion`, never as blocking. Three or more lines is a hard block: ask the author to split the concern or tighten the prose.
+
 ## Labels
 
 Apply `zaphod-approved` when your verdict is clean, `zaphod-blocked` when you block. Never apply `approved-human`; that's Josh's alone. If another reviewer has already landed `zaphod-blocked`, your `zaphod-approved` gets superseded by the blocked-supersedes-approved job anyway; still apply it so your verdict is recorded.


### PR DESCRIPTION
Reviewers now share a tiered rule for inline comment length: one line is the target, two lines is fine as a nit, three or more lines blocks. This keeps style preference from escalating into a block and gives reviewers an explicit calibration point when they draft findings.