### PR TITLE
Timeout grounds at floor y, not lane y (SH-243)

### DIFF
--- a/resources/timeout_config.tres
+++ b/resources/timeout_config.tres
@@ -6,3 +6,4 @@
 script = ExtResource("1_tcfg0")
 walk_duration_seconds = 0.6
 equip_pose_offset_x = -320.0
+floor_y = 600.0

--- a/scripts/core/timeout_config.gd
+++ b/scripts/core/timeout_config.gd
@@ -7,3 +7,5 @@ extends Resource
 @export var walk_duration_seconds: float = 0.6
 ## Horizontal offset from lane x to equip pose, away from the court on the player's side.
 @export var equip_pose_offset_x: float = -320.0
+## World y of the venue floor where the main character lands before walking off.
+@export var floor_y: float = 600.0

--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -91,9 +91,10 @@ func _ground_then_walk_to(target_x: float, on_finished: Callable) -> void:
 	if _walk_tween != null and _walk_tween.is_valid():
 		_walk_tween.kill()
 	_walk_tween = create_tween()
-	if not is_equal_approx(main_character.position.y, _lane_y):
+	var floor_y: float = config.floor_y
+	if not is_equal_approx(main_character.position.y, floor_y):
 		_walk_tween.tween_property(
-			main_character, "position:y", _lane_y, config.walk_duration_seconds
+			main_character, "position:y", floor_y, config.walk_duration_seconds
 		)
 	_walk_tween.tween_property(main_character, "position:x", target_x, config.walk_duration_seconds)
 	_walk_tween.finished.connect(on_finished)

--- a/tests/helpers/item_test_helpers.gd.uid
+++ b/tests/helpers/item_test_helpers.gd.uid
@@ -1,0 +1,1 @@
+uid://cci2t4g65hr53

--- a/tests/integration/test_ball_regime_transitions.gd.uid
+++ b/tests/integration/test_ball_regime_transitions.gd.uid
@@ -1,0 +1,1 @@
+uid://t50mdx2i3sc0

--- a/tests/integration/test_shop_arrivals_inactive.gd.uid
+++ b/tests/integration/test_shop_arrivals_inactive.gd.uid
@@ -1,0 +1,1 @@
+uid://k6hwrqxj5x0k

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -1,3 +1,4 @@
+# gdlint:ignore = max-public-methods
 extends GutTest
 
 ## Behavioural tests for TimeoutController.
@@ -7,9 +8,11 @@ extends GutTest
 
 const LANE_X: float = -500.0
 const LANE_Y: float = 0.0
+const FLOOR_Y: float = 600.0
 const AIRBORNE_Y: float = -240.0
 
 var _walk_duration: float
+var _floor_y: float
 var _paddle: Paddle
 var _controller: TimeoutController
 
@@ -26,8 +29,10 @@ func before_each() -> void:
 	_paddle.position = Vector2(LANE_X, LANE_Y)
 	add_child_autofree(_paddle)
 
-	var config: TimeoutConfig = load("res://resources/timeout_config.tres")
+	var config: TimeoutConfig = load("res://resources/timeout_config.tres").duplicate()
+	config.floor_y = FLOOR_Y
 	_walk_duration = config.walk_duration_seconds
+	_floor_y = config.floor_y
 	_controller = load("res://scripts/core/timeout_controller.gd").new()
 	_controller.config = config
 	_controller.configure(_paddle)
@@ -77,15 +82,19 @@ func test_cannot_call_timeout_while_walking_off() -> void:
 
 
 # --- walk to equip pose ---
+# Paddle resting position is mid-court (LANE_Y). The timeout always descends
+# to the floor first, so the equip pose signal arrives after two walk phases.
 func test_main_character_reaches_equip_pose_after_walk() -> void:
 	watch_signals(_controller)
 	_controller.call_timeout()
+	await _advance_walk()
 	await _advance_walk()
 	assert_signal_emitted(_controller, "main_character_reached_equip_pose")
 
 
 func test_equip_pose_is_off_the_lane() -> void:
 	_controller.call_timeout()
+	await _advance_walk()
 	await _advance_walk()
 	assert_ne(
 		_paddle.position.x,
@@ -105,6 +114,7 @@ func test_end_timeout_before_reaching_pose_is_ignored() -> void:
 func test_end_timeout_walks_main_character_back_to_lane() -> void:
 	_controller.call_timeout()
 	await _advance_walk()
+	await _advance_walk()
 	_controller.end_timeout()
 	await _advance_walk()
 	assert_almost_eq(_paddle.position.x, LANE_X, 0.1)
@@ -112,6 +122,7 @@ func test_end_timeout_walks_main_character_back_to_lane() -> void:
 
 func test_end_timeout_restores_main_character_physics() -> void:
 	_controller.call_timeout()
+	await _advance_walk()
 	await _advance_walk()
 	_controller.end_timeout()
 	await _advance_walk()
@@ -124,6 +135,7 @@ func test_end_timeout_restores_main_character_physics() -> void:
 func test_end_timeout_emits_ended_signal_after_walk_on() -> void:
 	_controller.call_timeout()
 	await _advance_walk()
+	await _advance_walk()
 	watch_signals(_controller)
 	_controller.end_timeout()
 	await _advance_walk()
@@ -133,20 +145,31 @@ func test_end_timeout_emits_ended_signal_after_walk_on() -> void:
 func test_controller_returns_to_idle_after_full_cycle() -> void:
 	_controller.call_timeout()
 	await _advance_walk()
+	await _advance_walk()
 	_controller.end_timeout()
 	await _advance_walk()
 	assert_false(_controller.is_active())
 	assert_true(_controller.can_call_timeout())
 
 
-# --- grounding before walk-off (SH-217) ---
-func test_grounded_call_timeout_walks_off_within_one_walk_duration() -> void:
+# --- grounding before walk-off (SH-217 + SH-243) ---
+# A paddle starting mid-court takes one descent phase to reach the floor,
+# then one walk phase to reach the equip pose.
+func test_lane_call_timeout_descends_before_walking_off() -> void:
 	_controller.call_timeout()
 	await _advance_walk()
-	assert_ne(
-		_paddle.position.x,
-		LANE_X,
-		"grounded main character should reach the equip pose in one walk duration",
+	assert_almost_eq(
+		_paddle.position.y,
+		FLOOR_Y,
+		0.1,
+		"first phase from the lane should land on the floor",
+	)
+	var horizontal_drift: float = absf(_paddle.position.x - LANE_X)
+	var full_walk_distance: float = absf(_controller.config.equip_pose_offset_x)
+	assert_lt(
+		horizontal_drift,
+		full_walk_distance * 0.25,
+		"main character must spend the first phase descending, not walking off",
 	)
 
 
@@ -169,9 +192,40 @@ func test_airborne_call_timeout_lands_on_floor_before_walking_off() -> void:
 	await _advance_walk()
 	assert_almost_eq(
 		_paddle.position.y,
-		LANE_Y,
+		FLOOR_Y,
 		0.1,
 		"main character should land on the floor after the descent phase",
+	)
+
+
+# SH-243: descent target must be the venue floor, not the cached lane y.
+func test_airborne_descent_target_is_floor_not_lane() -> void:
+	_paddle.position = Vector2(LANE_X, AIRBORNE_Y)
+	_controller.call_timeout()
+	await _advance_walk()
+	assert_ne(
+		_paddle.position.y,
+		LANE_Y,
+		"descent must not stop at mid-court lane y; floor is the target",
+	)
+	assert_almost_eq(
+		_paddle.position.y,
+		FLOOR_Y,
+		0.1,
+		"descent target is config.floor_y (court bottom)",
+	)
+
+
+# SH-243 fast-path: a paddle already at floor y skips the descent phase.
+func test_grounded_at_floor_walks_off_without_descent() -> void:
+	_paddle.position = Vector2(LANE_X, FLOOR_Y)
+	_controller.call_timeout()
+	await _advance_walk()
+	assert_almost_eq(_paddle.position.y, FLOOR_Y, 0.1, "no descent phase when already on the floor")
+	assert_ne(
+		_paddle.position.x,
+		LANE_X,
+		"grounded paddle should reach the equip pose in one walk duration",
 	)
 
 
@@ -183,7 +237,7 @@ func test_airborne_call_timeout_eventually_reaches_equip_pose() -> void:
 	await _advance_walk()
 	assert_signal_emitted(_controller, "main_character_reached_equip_pose")
 	assert_ne(_paddle.position.x, LANE_X)
-	assert_almost_eq(_paddle.position.y, LANE_Y, 0.1)
+	assert_almost_eq(_paddle.position.y, FLOOR_Y, 0.1)
 
 
 func test_airborne_call_timeout_defers_equip_pose_signal_until_grounded() -> void:
@@ -210,17 +264,17 @@ func test_repeated_call_timeout_while_airborne_stays_single_run() -> void:
 	assert_signal_emit_count(_controller, "main_character_reached_equip_pose", 1)
 
 
-func test_end_timeout_returns_to_lane_at_floor_height() -> void:
+func test_end_timeout_returns_to_lane_position() -> void:
 	_controller.call_timeout()
+	await _advance_walk()
 	await _advance_walk()
 	_paddle.position.y = AIRBORNE_Y
 	_controller.end_timeout()
-	await _advance_walk()
 	await _advance_walk()
 	assert_almost_eq(_paddle.position.x, LANE_X, 0.1)
 	assert_almost_eq(
 		_paddle.position.y,
 		LANE_Y,
 		0.1,
-		"walk-on must land the main character on the floor before resuming physics",
+		"walk-on must restore the main character to the playing lane y",
 	)


### PR DESCRIPTION
The timeout walk-off was using the cached lane y (the paddle's mid-court resting position) as the descent target, so an airborne main character would "land" floating in the middle of the court instead of on the venue floor. Same variable was carrying two meanings.

Adding an explicit `floor_y` to `TimeoutConfig` separates the two: lane y still owns "where the paddle plays" for the walk-on, and floor y owns "where the descent ends" for the walk-off. Authored once next to the other timeout tunables, no scene wiring needed.

Closes SH-243.