### PR TITLE
Rebuild equip-loop drag for diegetic interaction

### DIFF
--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -4,6 +4,8 @@ extends RigidBody2D
 signal missed
 signal at_max_speed_changed(is_at_max: bool)
 signal speed_changed(speed: float, min_speed: float, max_speed: float)
+## Mid-rally grab entry: emitted when the player presses the live ball.
+signal pressed(ball: Ball)
 
 const SPEED_EMIT_THRESHOLD := 10.0
 
@@ -14,6 +16,7 @@ var speed_increment: float
 var effect_processor: BallEffectProcessor
 var is_temporary: bool = false
 var _dragging: bool = false
+var _item_art: Node2D = null
 
 var _item_manager: Node
 var _was_at_max_speed := false
@@ -131,3 +134,39 @@ func _ball_setup() -> void:
 	max_contacts_reported = 1
 	if not body_entered.is_connected(_on_body_entered):
 		body_entered.connect(_on_body_entered)
+	input_pickable = true
+	if not input_event.is_connected(_on_input_event):
+		input_event.connect(_on_input_event)
+
+
+## Press on the live ball routes through here and surfaces as the `pressed` signal so the drag controller can flip into mid-rally grab mode.
+func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
+	if _dragging:
+		return
+	if not (event is InputEventMouseButton):
+		return
+	var mouse_button: InputEventMouseButton = event
+	if mouse_button.button_index != MOUSE_BUTTON_LEFT:
+		return
+	if not mouse_button.pressed:
+		return
+	pressed.emit(self)
+
+
+## Replaces the default sprite with the item's authored art so the live ball reads as the same object the player grabbed.
+func apply_item_art(art_scene: PackedScene) -> void:
+	if art_scene == null:
+		return
+	if _item_art != null and is_instance_valid(_item_art):
+		_item_art.queue_free()
+	var instance: Node = art_scene.instantiate()
+	if instance is Node2D:
+		_item_art = instance
+	add_child(instance)
+	var default_sprite: Node = get_node_or_null("Sprite")
+	if default_sprite != null:
+		default_sprite.visible = false
+
+
+func has_item_art() -> bool:
+	return _item_art != null and is_instance_valid(_item_art)

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -2,6 +2,10 @@ class_name BallDragController
 extends Node2D
 
 ## Owns the held-token visual during a ball drag gesture.
+##
+## Press starts a hold (held token follows cursor); release decides the outcome.
+## Rack press: held token spawns, item stays inactive until release over court.
+## Live-ball press: live Ball is freed, held token takes over until release.
 
 signal pickup_started(item_key: String)
 signal drop_completed(item_key: String, position: Vector2, over_court: bool)
@@ -18,6 +22,8 @@ var _item_manager: Node
 var _held_token: Node2D = null
 var _held_key: String = ""
 var _held_is_temporary: bool = false
+## Was the item on-court before the gesture? Rack pickups defer activation, so a click-without-movement is a no-op.
+var _held_was_on_court: bool = false
 var _cursor_samples: Array = []
 
 
@@ -39,6 +45,10 @@ func _ready() -> void:
 
 	if rack != null and not rack.slot_pressed.is_connected(_on_rack_slot_pressed):
 		rack.slot_pressed.connect(_on_rack_slot_pressed)
+
+	if reconciler != null:
+		if not reconciler.ball_spawned.is_connected(_on_reconciler_ball_spawned):
+			reconciler.ball_spawned.connect(_on_reconciler_ball_spawned)
 
 
 func _process(_delta: float) -> void:
@@ -77,7 +87,7 @@ func get_held_token() -> Node2D:
 	return _held_token
 
 
-## Test seam / production entry for rack-origin pickups.
+## Test seam / production entry for rack-origin pickups. Activation defers to release-over-court (SH-245).
 func grab_from_rack(item_key: String) -> bool:
 	if _held_token != null:
 		return false
@@ -87,7 +97,7 @@ func grab_from_rack(item_key: String) -> bool:
 		return false
 
 	_spawn_held_token(item_key, _cursor_position(), false)
-	_item_manager.activate(item_key)
+	_held_was_on_court = false
 	pickup_started.emit(item_key)
 	return true
 
@@ -110,6 +120,7 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 		existing.call_deferred("queue_free")
 
 	_spawn_held_token(item_key, spawn_position, is_temporary)
+	_held_was_on_court = not is_temporary
 	pickup_started.emit(item_key)
 	return true
 
@@ -125,16 +136,21 @@ func attempt_release(release_position: Vector2) -> bool:
 	var item_key: String = _held_key
 	var token: Node2D = _held_token
 	var was_temporary: bool = _held_is_temporary
+	var was_on_court: bool = _held_was_on_court
 	var release_velocity: Vector2 = _compute_release_velocity()
 
 	_held_token = null
 	_held_key = ""
 	_held_is_temporary = false
+	_held_was_on_court = false
 	_cursor_samples.clear()
 	token.queue_free()
 
 	if over_rack:
-		if not was_temporary and _item_manager.is_on_court(item_key):
+		# Rack release returns the item to inactive storage; if it had been on court before
+		# the gesture, deactivate. Rack pickups that started inactive stay inactive (the
+		# click-without-movement no-op path).
+		if not was_temporary and was_on_court and _item_manager.is_on_court(item_key):
 			_item_manager.deactivate(item_key)
 	else:
 		_release_onto_court(
@@ -154,6 +170,8 @@ func _release_onto_court(
 	if is_temporary:
 		return
 
+	# Activation happens at release-over-court so a click without movement on the rack
+	# does not introduce the ball (SH-245).
 	if not _item_manager.is_on_court(item_key):
 		_item_manager.activate(item_key)
 
@@ -272,3 +290,12 @@ func _get_item_definition(item_key: String) -> ItemDefinition:
 
 func _on_rack_slot_pressed(item_key: String) -> void:
 	grab_from_rack(item_key)
+
+
+func _on_reconciler_ball_spawned(item_key: String, ball: Ball) -> void:
+	if not ball.pressed.is_connected(_on_live_ball_pressed):
+		ball.pressed.connect(_on_live_ball_pressed.bind(item_key))
+
+
+func _on_live_ball_pressed(_ball: Ball, item_key: String) -> void:
+	grab_live_ball(item_key, false)

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -293,8 +293,8 @@ func _on_rack_slot_pressed(item_key: String) -> void:
 
 
 func _on_reconciler_ball_spawned(item_key: String, ball: Ball) -> void:
-	if not ball.pressed.is_connected(_on_live_ball_pressed):
-		ball.pressed.connect(_on_live_ball_pressed.bind(item_key))
+	# Each Ball is a fresh instance from ensure_ball_for_key, no double-connect risk.
+	ball.pressed.connect(_on_live_ball_pressed.bind(item_key))
 
 
 func _on_live_ball_pressed(_ball: Ball, item_key: String) -> void:

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -3,6 +3,9 @@ extends Node
 
 ## Owns live Ball instances for permanent on-court ball items.
 
+signal ball_spawned(item_key: String, ball: Ball)
+signal ball_released(item_key: String, ball: Ball)
+
 const BallScene: PackedScene = preload("res://scenes/ball.tscn")
 
 @export var ball_scene: PackedScene = BallScene
@@ -55,7 +58,9 @@ func ensure_ball_for_key(
 	_ball_host.add_child(ball)
 	ball.global_position = spawn_position
 	ball.linear_velocity = initial_velocity
+	_apply_item_art(ball, item_key)
 	_balls_by_key[item_key] = ball
+	ball_spawned.emit(item_key, ball)
 	return ball
 
 
@@ -65,6 +70,7 @@ func release_ball(item_key: String) -> Ball:
 		return null
 
 	_balls_by_key.erase(item_key)
+	ball_released.emit(item_key, ball)
 	return ball
 
 
@@ -82,6 +88,7 @@ func _on_court_changed(item_key: String, on_court: bool) -> void:
 		return
 
 	_balls_by_key.erase(item_key)
+	ball_released.emit(item_key, ball)
 	ball.call_deferred("queue_free")
 
 
@@ -97,3 +104,17 @@ func _default_spawn_position() -> Vector2:
 	if _ball_host is Node2D:
 		return (_ball_host as Node2D).global_position
 	return Vector2.ZERO
+
+
+func _apply_item_art(ball: Ball, item_key: String) -> void:
+	var definition: ItemDefinition = _get_item_definition(item_key)
+	if definition == null or definition.art == null:
+		return
+	ball.apply_item_art(definition.art)
+
+
+func _get_item_definition(item_key: String) -> ItemDefinition:
+	for item: ItemDefinition in _item_manager.items:
+		if item.key == item_key:
+			return item
+	return null

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -4,7 +4,6 @@ extends Node
 ## Owns live Ball instances for permanent on-court ball items.
 
 signal ball_spawned(item_key: String, ball: Ball)
-signal ball_released(item_key: String, ball: Ball)
 
 const BallScene: PackedScene = preload("res://scenes/ball.tscn")
 
@@ -70,7 +69,6 @@ func release_ball(item_key: String) -> Ball:
 		return null
 
 	_balls_by_key.erase(item_key)
-	ball_released.emit(item_key, ball)
 	return ball
 
 
@@ -88,7 +86,6 @@ func _on_court_changed(item_key: String, on_court: bool) -> void:
 		return
 
 	_balls_by_key.erase(item_key)
-	ball_released.emit(item_key, ball)
 	ball.call_deferred("queue_free")
 
 

--- a/scripts/shop/shop.gd
+++ b/scripts/shop/shop.gd
@@ -1,7 +1,8 @@
 class_name Shop
 extends Node2D
 
-## Diegetic shop in the venue. Purchase fires on ShopArea.body_exited. See designs/01-prototype/08-shop.md.
+## Diegetic shop in the venue. Pressing an item starts a held-token drag; releasing
+## outside the shop area completes the purchase. See designs/01-prototype/08-shop.md.
 
 const DEFAULT_CONFIG: ShopConfig = preload("res://resources/shop_config.tres")
 const ShopItemScene: PackedScene = preload("res://scenes/shop_item.tscn")
@@ -20,8 +21,8 @@ func _ready() -> void:
 	if _item_manager == null:
 		_item_manager = ItemManager
 	_item_manager.friendship_point_balance_changed.connect(_on_friendship_point_balance_changed)
+	_item_manager.item_level_changed.connect(_on_item_level_changed)
 	_update_friendship_label(_item_manager.get_friendship_point_balance())
-	shop_area.body_exited.connect(_on_body_exited_shop_area)
 	_spawn_items()
 
 
@@ -37,6 +38,7 @@ func _spawn_items() -> void:
 		shop_item.position = Vector2(start_x + index * spacing, 0.0)
 		items_anchor.add_child(shop_item)
 		shop_item.configure(_item_manager, definition)
+		shop_item.bind_shop_area(shop_area)
 
 
 func _get_visible_items() -> Array[ItemDefinition]:
@@ -49,18 +51,18 @@ func _get_visible_items() -> Array[ItemDefinition]:
 	return available
 
 
-func _on_body_exited_shop_area(body: Node2D) -> void:
-	if not body is ShopItem:
-		return
-	var shop_item: ShopItem = body
-	if shop_item.is_owned():
-		return
-	_item_manager.take(shop_item.item_definition.key)
-
-
 func _update_friendship_label(balance: int) -> void:
 	friendship_label.text = "Friendship: %d" % balance
 
 
 func _on_friendship_point_balance_changed(balance: int) -> void:
 	_update_friendship_label(balance)
+
+
+# Refresh the shop pool when an item is purchased so its tile leaves the table.
+func _on_item_level_changed(item_key: String) -> void:
+	if _item_manager.get_level(item_key) <= 0:
+		return
+	var node: Node = items_anchor.get_node_or_null("ShopItem_%s" % item_key)
+	if node != null:
+		node.queue_free()

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -1,7 +1,11 @@
 class_name ShopItem
 extends RigidBody2D
 
-## Physics-based shop item: mouse-drag kinematically freezes, release restores gravity.
+## Diegetic shop item: pressing starts a held-token drag, releasing outside the
+## shop bounds completes the purchase. The drag IS the buy gesture (SH-246).
+
+signal pickup_started(item_key: String)
+signal drop_completed(item_key: String, position: Vector2, purchased: bool)
 
 @export var art_holder: Node2D
 @export var collision_shape: CollisionShape2D
@@ -11,8 +15,8 @@ var item_definition: ItemDefinition
 
 var _item_manager: Node
 var _art_instance: ItemArt
-var _dragging: bool = false
-var _drag_offset: Vector2 = Vector2.ZERO
+var _shop_area: Area2D
+var _held_token: Node2D = null
 var _last_input_frame: int = -1
 
 
@@ -21,6 +25,11 @@ func configure(item_manager: Node, definition: ItemDefinition) -> void:
 	item_definition = definition
 	_build_art()
 	_refresh_case_overlay()
+
+
+## The Shop scene injects its own ShopArea so release detection can hit-test against it.
+func bind_shop_area(area: Area2D) -> void:
+	_shop_area = area
 
 
 func can_be_owned() -> bool:
@@ -43,7 +52,11 @@ func is_owned() -> bool:
 
 
 func is_dragging() -> bool:
-	return _dragging
+	return _held_token != null
+
+
+func get_held_token() -> Node2D:
+	return _held_token
 
 
 func _ready() -> void:
@@ -57,21 +70,21 @@ func _ready() -> void:
 	_refresh_case_overlay()
 
 
-func _physics_process(_delta: float) -> void:
-	if not _dragging:
+func _process(_delta: float) -> void:
+	if _held_token == null:
 		return
-	global_position = get_global_mouse_position() + _drag_offset
+	_held_token.global_position = _cursor_position()
 
 
 # Release handled here so a fast drag that outruns collision still ends the drag.
 func _input(event: InputEvent) -> void:
-	if not _dragging:
+	if _held_token == null:
 		return
 	if not (event is InputEventMouseButton):
 		return
 	var mouse_button: InputEventMouseButton = event
 	if mouse_button.button_index == MOUSE_BUTTON_LEFT and not mouse_button.pressed:
-		_end_drag()
+		attempt_release(_cursor_position())
 
 
 func _build_art() -> void:
@@ -90,7 +103,7 @@ func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> voi
 	if mouse_button.button_index != MOUSE_BUTTON_LEFT:
 		return
 	_last_input_frame = Engine.get_physics_frames()
-	if mouse_button.pressed and can_be_dragged() and not _dragging:
+	if mouse_button.pressed and can_be_dragged() and _held_token == null:
 		_start_drag()
 
 
@@ -98,15 +111,89 @@ func get_last_input_frame() -> int:
 	return _last_input_frame
 
 
+## Test seam / production entry. Begins the held-token gesture from the item's current spot.
+func start_drag() -> bool:
+	if _held_token != null:
+		return false
+	if not can_be_dragged():
+		return false
+	_start_drag()
+	return true
+
+
+## Test seam / production entry. Outside shop bounds purchases; inside cancels.
+func attempt_release(release_position: Vector2) -> bool:
+	if _held_token == null:
+		return false
+
+	var token: Node2D = _held_token
+	_held_token = null
+	token.queue_free()
+
+	var purchased: bool = false
+	var inside_shop: bool = _is_position_inside_shop(release_position)
+	if not inside_shop:
+		purchased = _complete_purchase()
+
+	visible = inside_shop or is_owned() == false
+	# Items that purchase successfully leave the shop pool; the shop will despawn them
+	# on the next refresh. Until then, hide them so they don't sit visible on the table.
+	if purchased:
+		visible = false
+
+	drop_completed.emit(item_definition.key, release_position, purchased)
+	return true
+
+
 func _start_drag() -> void:
-	_dragging = true
-	_drag_offset = global_position - get_global_mouse_position()
-	freeze = true
+	var token: Node2D = Node2D.new()
+	token.name = "HeldToken_%s" % item_definition.key
+	if item_definition != null and item_definition.art != null:
+		var art_instance: Node = item_definition.art.instantiate()
+		token.add_child(art_instance)
+	# Parent at scene root so the held visual follows the cursor without being
+	# tied to the item's rigid body.
+	var current_scene: Node = get_tree().current_scene
+	if current_scene != null:
+		current_scene.add_child(token)
+	else:
+		add_child(token)
+	token.global_position = _cursor_position()
+	_held_token = token
+	pickup_started.emit(item_definition.key)
 
 
-func _end_drag() -> void:
-	_dragging = false
-	freeze = false
+func _complete_purchase() -> bool:
+	if is_owned():
+		return false
+	if not can_be_owned():
+		return false
+	return _item_manager.take(item_definition.key)
+
+
+func _is_position_inside_shop(position: Vector2) -> bool:
+	if _shop_area == null:
+		return false
+	var shape_node: CollisionShape2D = null
+	for child in _shop_area.get_children():
+		if child is CollisionShape2D:
+			shape_node = child
+			break
+	if shape_node == null:
+		return false
+	var rectangle: RectangleShape2D = shape_node.shape as RectangleShape2D
+	if rectangle == null:
+		return false
+	var half: Vector2 = rectangle.size * 0.5
+	var center: Vector2 = _shop_area.global_position + shape_node.position
+	return Rect2(center - half, rectangle.size).has_point(position)
+
+
+func _cursor_position() -> Vector2:
+	var viewport: Viewport = get_viewport()
+	if viewport == null:
+		return global_position
+	return get_global_mouse_position()
 
 
 func _on_balance_changed(_balance: int) -> void:
@@ -131,6 +218,6 @@ func _refresh_case_overlay() -> void:
 
 # Cased items freeze kinematically; drag lifecycle controls freeze directly.
 func _refresh_freeze() -> void:
-	if _dragging:
+	if _held_token != null:
 		return
 	set_deferred("freeze", not is_owned() and not can_be_owned())

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -331,3 +331,92 @@ func test_save_round_trip_preserves_live_ball_placement() -> void:
 		0.01,
 		"reloaded ball item must run the same effect as before the save",
 	)
+
+
+# --- Scenario 7 (SH-245): press-drag-release on rack drives full input pipeline -
+
+
+func test_real_press_drag_release_on_rack_spawns_live_ball_with_item_art() -> void:
+	# Drives the actual InputEventMouseButton path on the rack token: press,
+	# move, release. Asserts the released live ball lands at the release position
+	# AND wears the item's authored art (SH-244).
+	_manager.take("training_ball")
+	await get_tree().process_frame
+	var displayed: Array[String] = _rack.get_displayed_keys()
+	assert_eq(displayed, ["training_ball"], "precondition: rack shows the token")
+
+	# Resolve the slot's click area and feed it a mouse-down event.
+	var slot: Node2D = _find_slot_for_key("training_ball")
+	assert_not_null(slot, "rack slot exists for the owned key")
+	var click_area: Area2D = slot.get_node("ClickArea")
+	var press := InputEventMouseButton.new()
+	press.button_index = MOUSE_BUTTON_LEFT
+	press.pressed = true
+	click_area.input_event.emit(get_viewport(), press, 0)
+
+	assert_true(_drag.is_dragging(), "press on the rack token starts the held-token gesture")
+	assert_false(
+		_manager.is_on_court("training_ball"),
+		"press alone must not introduce the ball (SH-245)",
+	)
+
+	# Simulate cursor motion across a window so release velocity is non-zero.
+	_drag._cursor_samples.clear()
+	_drag._cursor_samples.append({"time": 0.0, "position": Vector2.ZERO})
+	_drag._cursor_samples.append({"time": 0.04, "position": Vector2(200, 0)})
+
+	# Release over the court. Drive the actual mouse-button-up path through _input.
+	for ball in _all_balls_under_host():
+		ball.queue_free()
+	await get_tree().process_frame
+	var release := InputEventMouseButton.new()
+	release.button_index = MOUSE_BUTTON_LEFT
+	release.pressed = false
+	_drag._input(release)
+
+	assert_false(_drag.is_dragging(), "release ends the gesture")
+	assert_true(_manager.is_on_court("training_ball"), "release over court activates the item")
+	var ball: Ball = _reconciler.get_ball_for_key("training_ball")
+	assert_not_null(ball, "reconciler should own the live ball after release")
+	assert_true(ball.has_item_art(), "live ball must render the item's authored art (SH-244)")
+
+
+# --- Scenario 8 (SH-247): real press on a live Ball flips into mid-rally grab --
+
+
+func test_real_press_on_live_ball_starts_mid_rally_grab_and_release_reinstates() -> void:
+	_manager.take("training_ball")
+	_manager.activate("training_ball")
+	var live: Ball = _reconciler.get_ball_for_key("training_ball")
+	assert_not_null(live, "precondition: live ball exists")
+	assert_true(live.input_pickable, "live ball must be input_pickable so a press routes through")
+
+	# Drive a real press through the Ball's input_event signal.
+	var press := InputEventMouseButton.new()
+	press.button_index = MOUSE_BUTTON_LEFT
+	press.pressed = true
+	live.input_event.emit(get_viewport(), press, 0)
+
+	assert_true(_drag.is_dragging(), "press on a live ball flips into drag mode (SH-247)")
+	await get_tree().process_frame
+	assert_false(
+		is_instance_valid(live),
+		"the live ball is freed during the hold; held token takes over the cursor",
+	)
+
+	# Release over the court reinstates a live ball at the cursor.
+	var court_point := Vector2(50, -25)
+	var released: bool = _drag.attempt_release(court_point)
+	assert_true(released)
+
+	var reinstated: Ball = _reconciler.get_ball_for_key("training_ball")
+	assert_not_null(reinstated, "court release should reinstate a Ball via the reconciler")
+	assert_eq(reinstated.global_position, court_point)
+	assert_true(reinstated.has_item_art(), "reinstated ball preserves the item's art (SH-244)")
+
+
+func _find_slot_for_key(item_key: String) -> Node2D:
+	for child in _rack.slot_container.get_children():
+		if child is Node2D and child.get_meta(&"item_key", "") == item_key:
+			return child
+	return null

--- a/tests/integration/test_shop_arrivals_inactive.gd
+++ b/tests/integration/test_shop_arrivals_inactive.gd
@@ -52,8 +52,12 @@ func _shop_item(item_key: String) -> ShopItem:
 
 
 func _take_from_shop(shop_item: ShopItem) -> void:
-	# Emit the signal directly to avoid physics-frame timing in tests.
-	_shop.shop_area.body_exited.emit(shop_item)
+	# Drive the diegetic drag-as-purchase path: press, then release outside the
+	# shop bounds. attempt_release accepts a release position so we can hit-test
+	# against the shop area without depending on real cursor placement.
+	shop_item.start_drag()
+	var outside: Vector2 = _shop.shop_area.global_position + Vector2(10000, 0)
+	shop_item.attempt_release(outside)
 
 
 # --- ball rack arrivals ----------------------------------------------------

--- a/tests/integration/test_shop_drag_drop.gd
+++ b/tests/integration/test_shop_drag_drop.gd
@@ -112,7 +112,112 @@ func test_each_shop_item_responds_to_input_event_signal() -> void:
 		assert_ne(item.get_last_input_frame(), before, "input_event not wired for %s" % item.name)
 
 
+# --- diegetic drag-as-purchase ---
+func test_press_on_shop_item_starts_held_token_without_purchase() -> void:
+	var item: ShopItem = _shop_item("grip_tape")
+	var balance_before: int = _item_manager.get_friendship_point_balance()
+
+	item.start_drag()
+
+	assert_true(item.is_dragging(), "press on an affordable item starts the held-token gesture")
+	assert_not_null(item.get_held_token(), "held token spawned on press")
+	assert_eq(_item_manager.get_level("grip_tape"), 0, "purchase has not fired yet")
+	assert_eq(
+		_item_manager.get_friendship_point_balance(),
+		balance_before,
+		"FP balance unchanged until release outside the shop",
+	)
+
+
+func test_release_inside_shop_cancels_purchase() -> void:
+	var item: ShopItem = _shop_item("grip_tape")
+	item.start_drag()
+	var balance_before: int = _item_manager.get_friendship_point_balance()
+
+	item.attempt_release(_shop.shop_area.global_position)
+
+	assert_false(item.is_dragging(), "release ends the gesture")
+	assert_eq(_item_manager.get_level("grip_tape"), 0, "release inside shop must not purchase")
+	assert_eq(
+		_item_manager.get_friendship_point_balance(),
+		balance_before,
+		"release inside shop must not debit FP",
+	)
+
+
+func test_release_outside_shop_purchases_and_debits_balance() -> void:
+	var item: ShopItem = _shop_item("grip_tape")
+	var balance_before: int = _item_manager.get_friendship_point_balance()
+	var cost: int = GripTape.base_cost
+	item.start_drag()
+
+	var outside: Vector2 = _shop.shop_area.global_position + Vector2(10000, 0)
+	item.attempt_release(outside)
+
+	assert_eq(
+		_item_manager.get_level("grip_tape"), 1, "release outside shop completes the purchase"
+	)
+	assert_eq(
+		_item_manager.get_friendship_point_balance(),
+		balance_before - cost,
+		"FP balance debits at release time",
+	)
+
+
+func test_real_press_on_shop_item_starts_drag_and_release_outside_purchases() -> void:
+	# Drives InputEventMouseButton through the shop item's input_event signal.
+	# Press starts the held token; release outside the shop bounds completes the
+	# purchase (SH-246) and lands the item inactive on the matching rack.
+	var item: ShopItem = _shop_item("grip_tape")
+	var balance_before: int = _item_manager.get_friendship_point_balance()
+	var cost: int = GripTape.base_cost
+	var viewport: Viewport = item.get_viewport()
+
+	var press := InputEventMouseButton.new()
+	press.button_index = MOUSE_BUTTON_LEFT
+	press.pressed = true
+	item.input_event.emit(viewport, press, 0)
+
+	assert_true(item.is_dragging(), "press starts the held-token gesture")
+	assert_eq(_item_manager.get_level("grip_tape"), 0, "press alone must not purchase")
+
+	# Release outside shop bounds: drive attempt_release directly (the _input
+	# branch reads cursor position from the viewport, which is not deterministic
+	# under headless tests).
+	var outside: Vector2 = _shop.shop_area.global_position + Vector2(10000, 0)
+	item.attempt_release(outside)
+
+	assert_false(item.is_dragging(), "release ends the gesture")
+	assert_eq(
+		_item_manager.get_level("grip_tape"),
+		1,
+		"release outside shop completes the purchase (one purchase event)",
+	)
+	assert_eq(
+		_item_manager.get_friendship_point_balance(),
+		balance_before - cost,
+		"FP balance debits exactly once at release time",
+	)
+	assert_false(
+		_item_manager.is_on_court("grip_tape"),
+		"purchased equipment lands inactive on the rack, not on the player",
+	)
+
+
+func test_unaffordable_item_cannot_start_drag() -> void:
+	_item_manager._progression.friendship_point_balance = 0
+	var item: ShopItem = _shop_item("grip_tape")
+
+	var ok: bool = item.start_drag()
+
+	assert_false(ok, "unaffordable items reject the drag-out gesture")
+	assert_false(item.is_dragging(), "no held token when unaffordable")
+
+
 # --- helpers ---
 func _drag_item_out_of_shop_area(item: ShopItem) -> void:
-	# Emit the signal directly to avoid physics-frame timing in tests.
-	_shop.shop_area.body_exited.emit(item)
+	# Drive the diegetic drag-as-purchase path: press, then release outside the
+	# shop bounds. The position is well outside the shop area's collision rect.
+	item.start_drag()
+	var outside: Vector2 = _shop.shop_area.global_position + Vector2(10000, 0)
+	item.attempt_release(outside)

--- a/tests/unit/items/test_ball_drag_controller.gd
+++ b/tests/unit/items/test_ball_drag_controller.gd
@@ -75,7 +75,7 @@ func _permanent_balls() -> Array:
 	return result
 
 
-func test_grab_from_rack_spawns_held_token_and_activates_item() -> void:
+func test_grab_from_rack_spawns_held_token_without_activating_item() -> void:
 	_manager.take("ball_alpha")
 	assert_false(_manager.is_on_court("ball_alpha"), "precondition: item is on the rack")
 
@@ -83,10 +83,38 @@ func test_grab_from_rack_spawns_held_token_and_activates_item() -> void:
 	assert_true(ok)
 	assert_true(_drag.is_dragging(), "drag controller should be mid-gesture after rack pickup")
 	assert_eq(_drag.get_held_key(), "ball_alpha")
-	assert_true(
+	# SH-245: a press alone must not introduce the ball; activation is deferred to
+	# release-over-court so a click-without-movement leaves the rack untouched.
+	assert_false(
 		_manager.is_on_court("ball_alpha"),
-		"picking up a rack token should activate the item so the rack marks the slot spent",
+		"rack pickup is press-hold-release; activation only fires at release over court",
 	)
+
+
+func test_click_on_rack_without_movement_does_not_introduce_ball() -> void:
+	# SH-245 regression guard: press, then immediately release at the same rack position.
+	# The held token must clear and no ball should land on the court.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
+
+	# Release over the rack drop target with zero cursor movement.
+	var rack_position: Vector2 = _drop_target.global_position
+	var released: bool = _drag.attempt_release(rack_position)
+
+	assert_true(released)
+	assert_false(_drag.is_dragging(), "held token cleared on release")
+	assert_false(
+		_manager.is_on_court("ball_alpha"),
+		"no movement, no court release: the item must not be activated",
+	)
+	assert_null(
+		_reconciler.get_ball_for_key("ball_alpha"),
+		"a click-without-movement must not spawn a live ball",
+	)
+	assert_eq(_permanent_balls().size(), 0, "no permanent Ball instance should land on the court")
 
 
 func test_rack_pickup_fails_when_item_unowned() -> void:
@@ -160,9 +188,15 @@ func test_release_far_outside_court_clamps_to_bounds() -> void:
 	assert_eq(ball.global_position, Vector2(600, 400), "spawn clamps to court bounds")
 
 
-func test_release_over_rack_returns_owned_ball_to_rack_and_stops_effects() -> void:
+func test_release_over_rack_returns_a_court_ball_to_the_rack() -> void:
+	# Grabbing a live ball that was already on court and releasing over the rack
+	# must deactivate the item so the rack regrows the token.
 	_manager.take("ball_alpha")
-	_drag.grab_from_rack("ball_alpha")
+	_manager.activate("ball_alpha")
+	assert_true(_manager.is_on_court("ball_alpha"), "precondition: item is on court")
+
+	_drag.grab_live_ball("ball_alpha", false)
+	await get_tree().process_frame
 	var over_rack := _drop_target.global_position
 
 	var released: bool = _drag.attempt_release(over_rack)

--- a/tests/unit/shop/test_shop_item.gd
+++ b/tests/unit/shop/test_shop_item.gd
@@ -93,3 +93,47 @@ class TestShopItemArt:
 
 	func test_configure_stores_item_definition() -> void:
 		assert_eq(_item.item_definition, GripTape)
+
+
+class TestShopItemInputRelease:
+	extends GutTest
+
+	var _item: ShopItem
+	var _item_manager: Node
+
+	func before_each() -> void:
+		_item_manager = ItemFactory.create_manager(self)
+		_item_manager._progression.friendship_point_balance = 1000
+		var definition: ItemDefinition = _item_manager.items[0]
+		_item = ShopItemScene.instantiate()
+		_item._item_manager = _item_manager
+		add_child_autofree(_item)
+		_item.configure(_item_manager, definition)
+
+	func test_mouse_button_release_event_resolves_active_drag() -> void:
+		_item.start_drag()
+		assert_true(_item.is_dragging(), "precondition: drag is active")
+
+		var event := InputEventMouseButton.new()
+		event.button_index = MOUSE_BUTTON_LEFT
+		event.pressed = false
+		_item._input(event)
+
+		assert_false(_item.is_dragging(), "mouse-up should resolve the active drag")
+
+	func test_mouse_button_release_event_ignored_when_not_dragging() -> void:
+		var event := InputEventMouseButton.new()
+		event.button_index = MOUSE_BUTTON_LEFT
+		event.pressed = false
+		_item._input(event)
+
+		assert_false(_item.is_dragging(), "no drag started by stray release event")
+
+	func test_non_left_button_release_does_not_end_drag() -> void:
+		_item.start_drag()
+		var event := InputEventMouseButton.new()
+		event.button_index = MOUSE_BUTTON_RIGHT
+		event.pressed = false
+		_item._input(event)
+
+		assert_true(_item.is_dragging(), "right-button release must not end the gesture")


### PR DESCRIPTION
The first attempt at SH-218 treated rack press as the whole interaction; the equip loop fell apart on Josh's hands-on ride. This rebuild makes press-hold-release the single shape across rack tokens, live rally balls, and shop items.

Rack press spawns a held token and waits. Activation only fires when the player releases over the court, so a click without movement leaves the rack untouched. Live balls now accept input and route the press into the same drag controller, so mid-rally grabs work for any reconciler-tracked ball. The reconciler forwards the item's authored art onto its live ball, so the visual the player held is the visual that lands. The shop follows the same model: pressing an item starts a held-token drag, releasing outside the shop bounds completes the purchase, releasing inside cancels. Unaffordable items reject the gesture.

Closes SH-244, SH-245, SH-246, SH-247.