### PR TITLE
docs(SH-277): MC profile for the protagonist

### DIFF
--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -20,7 +20,7 @@ They lost someone close to them. Recently enough that it is not healed, long eno
 
 The bright world is that structure. The garden, the stall, the rally that climbs through its tiers, the friend at the counter with their head tilted toward the play. The protagonist did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
 
-They are rarely embodied in the bright world. The world is built around their quiet presence at its centre rather than their figure; the racquet moves, the counter climbs, the friend watches, and the protagonist is the gravity the rest of it orbits. In the quieter world they are on screen, observed fly-on-the-wall in a small ordinary moment with a partner. That is where the body lives.
+They are visible throughout. Drawn like any other character, on the left of the court with a racquet, holding the gravity of the world they built. Their Construction-render is who the player connects to across the bright world. Their Reality-render is the same person in their actual life, plainer, observed fly-on-the-wall in a small ordinary moment with a partner. The contrast lives in the register-switch, not in their presence on the page.
 
 ---
 
@@ -42,15 +42,15 @@ The structure holds because they choose it, again and again, not because anythin
 
 ---
 
-## In the bright world
+## In Construction
 
-The protagonist is a presence more than a figure. The court frames them on the left; the racquet moves; the head turns toward the stall when the rally allows it. The art's first job is to make the player feel the centre of the world is them, before a single line of dialogue.
+The court frames them on the left. The racquet moves; the head turns toward the stall when the rally allows it; the body carries the rally's tempo. Drawn young and full and helping, the way the bright world renders the rest of its cast. The figure on the court is the player's anchor in the bright world; the rendering choices that hold for the cast hold for the protagonist too.
 
-When something is harder to look at, the camera does not look at them. The world holds the feeling instead: the light in the garden, the friend's posture, the ball in the air.
+When the moment is harder to look at, the camera can hold elsewhere: the light in the garden, the friend's posture, the ball in the air. The protagonist stays in the frame; the attention of the frame moves around them.
 
-## In the quieter world
+## In Reality
 
-The protagonist is on screen. A small moment with a partner in an ordinary place: a kitchen, a bus stop, the corner of a shop. Observed fly-on-the-wall, neither dramatised nor explained. Mid-30s, a little softer than they once were, gentle in posture. The artist's first quieter-world deliverable will set the rest of their physical specifics; everything else here defers to that read.
+The same person at their actual age. A small moment with a partner in an ordinary place: a kitchen, a bus stop, the corner of a shop. Observed fly-on-the-wall, neither dramatised nor explained. Mid-30s, a little softer than they once were, gentle in posture. The first Reality deliverable will set the rest of their physical specifics; everything else here defers to that read.
 
 ---
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -33,12 +33,22 @@ The pull is the urge to do the destructive thing when nothing forces it. To jump
 It surfaces in places the artist and animator can feel for, not script:
 
 - The cliffhanger leap to the next venue. The player triggers it; the world thins on the brink of something else; the choice to fall is theirs.
-- The locked gate at the back of the garden. The protagonist tries it. It does not open. They turn back. (The gate opens at the call; the cliff is on the other side. The champ leaves the key.)
+- The locked gate at the back of the garden. The protagonist tries it. It does not open. They turn back. (The gate opens later, after Reconstruction: the sister hands them the key from the photo album's hidden compartment once it has filled enough; they unlock the gate; they walk to the cliff on the other side.)
 - The ball about to roll out of the play area. The moment the protagonist could let it go.
 - The pause before serving in a long rally. The awareness, held inside the breath, that they could stop.
 - The edges of the play area where their gaze drifts past it.
 
 The structure holds because they choose it, again and again, not because anything forces it on them. That is the load-bearing piece. Hold it as a quiet undercurrent in posture and timing; let the choice be the visible thing.
+
+---
+
+## Becoming the champ
+
+A second layer underneath the structure. It sits next to the void, not under it.
+
+Across Construction the protagonist is climbing toward the championship, and the obsession pulls in two directions at once. They want to become the champion of the world they built: the title, the record, the spot at the top of the climb. They also want to become the champ inside that world, a friend now drawn as the partner at the final venue. The same word does both jobs and the protagonist does not separate them. Winning the title and reaching the friend are one motion to them, even though the world cannot grant the second.
+
+The doubled pull is what makes the championship win land the way it does. Both meanings are satisfied at the same beat and neither was the thing the protagonist actually needed. Hold this as quiet weight in how they treat the climb: not triumph, not desperation, a steadiness that knows what it is reaching for and does not yet know it is reaching past it.
 
 ---
 
@@ -59,6 +69,16 @@ The same person at their actual age. A small moment with a partner in an ordinar
 They love the game. They love the friend at the stall. They reach for the partners they reach for: Martha first, because she was reliably kind and asks nothing of them yet; others, harder, later.
 
 The structure was built around what they love. The grief and the void are real; so is the love, and it is the reason the structure stands. The protagonist is not surviving in the garden. They are living there. Quietly, partially, on the days they can; that is still living.
+
+---
+
+## The call
+
+At the cliff, with the key spent and the gate open behind them, the protagonist sees the shopkeeper on a bench dedicated to the friend. The bench is a few steps away. The protagonist could close that distance silently. They do not.
+
+They take out their phone and dial. The number they finally have is the number they have been climbing toward the whole climb, surfacing across Reconstruction in places it should not be, becoming a phone number across the player's eyes. The shopkeeper's phone rings on the bench beside them; they turn at the sound, see the protagonist, pick up. Both of them hold their phones across the small distance between path and bench.
+
+The dial bridges intention, not space. Chosen presence rather than a closing of distance. The few steps between path and bench are easy; the choice to be reached, and to reach, is the part that took the whole game. After the call the protagonist crosses, sits beside the shopkeeper on the bench. The call ends there.
 
 ---
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -18,7 +18,7 @@ Not a tragic figure, not melodramatic, not a person in collapse. Someone who bui
 
 They lost someone close to them. Recently enough that it is not healed, long enough that they have built a structure around it.
 
-Construction is that structure. The garden, the stall, the rally that climbs through its tiers, the friend at the counter with their head tilted toward the play. The protagonist did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
+Construction is that structure. The garden, the stall, the rally, the friend at the counter with their head tilted toward the play. The protagonist did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
 
 They are visible throughout. Drawn like any other character, on the left of the court with a racquet, holding the gravity of the world they built. Their Construction-render is who the player connects to across Construction. Their Reality-render is the same person in their actual life, plainer, observed fly-on-the-wall in a small ordinary moment with a partner. The contrast lives in the register-switch, not in their presence on the page.
 
@@ -26,25 +26,25 @@ They are visible throughout. Drawn like any other character, on the left of the 
 
 ## The call of the void
 
-There is a layer underneath the structure that should never be named in the game and should never be named in the artist-facing bible. It belongs here, in the room where the people working on the protagonist meet, because without it the character flattens.
+A layer underneath the structure. It is here, not in the bible, because without it the character flattens.
 
-The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. To let the ball roll past instead of returning it. The structure the protagonist built holds against the loss; it also holds against this. The two are related and distinct. Grief is what they are sheltering from. The void is what they are resisting.
+The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. The structure the protagonist built holds against the loss; it also holds against this. The two are related and distinct. Grief is what they are sheltering from. The void is what they are resisting.
 
 It surfaces in places the artist and animator can feel for, not script:
 
-- The cliffhanger leap to the next venue. The player triggers it; the world fades on the brink of something else; the choice to fall is theirs.
-- The locked gate, visible but unreachable. The protagonist could try; they don't.
+- The cliffhanger leap to the next venue. The player triggers it; the world thins on the brink of something else; the choice to fall is theirs.
+- The locked gate at the back of the garden. The protagonist tries it. It does not open. They turn back. (The gate opens at the call; the cliff is on the other side. The champ leaves the key.)
 - The ball about to roll out of the play area. The moment the protagonist could let it go.
 - The pause before serving in a long rally. The awareness, held inside the breath, that they could stop.
 - The edges of the play area where their gaze drifts past it.
 
-The structure holds because they choose it, again and again, not because anything forces it on them. That is the load-bearing piece. Hold it as a quiet undercurrent in posture and timing; do not narrate it, do not name it, do not let it tip into theme.
+The structure holds because they choose it, again and again, not because anything forces it on them. That is the load-bearing piece. Hold it as a quiet undercurrent in posture and timing; let the choice be the visible thing.
 
 ---
 
 ## In Construction
 
-The court frames them on the left. The racquet moves; the head turns toward the stall when the rally allows it; the body carries the rally's tempo. Drawn young and full and helping, the way Construction renders the rest of its cast. The figure on the court is the player's anchor in Construction; the rendering choices that hold for the cast hold for the protagonist too.
+The court frames them on the left. The racquet moves; the head turns toward the stall when the rally allows it; the body carries the rally's tempo. Drawn young and full and present, the way Construction renders the rest of its cast. The figure on the court is the player's anchor in Construction; the rendering choices that hold for the cast hold for the protagonist too.
 
 When the moment is harder to look at, the camera can hold elsewhere: the light in the garden, the friend's posture, the ball in the air. The protagonist stays in the frame; the attention of the frame moves around them.
 
@@ -61,9 +61,5 @@ They love the game. They love the friend at the stall. They reach for the partne
 The structure was built around what they love. The grief and the void are real; so is the love, and it is the reason the structure stands. The protagonist is not surviving in the garden. They are living there. Quietly, partially, on the days they can; that is still living.
 
 ---
-
-## A note on growth
-
-This is the first cut. It captures the basic, the loss, the call-of-the-void layer, and the bright-world / quieter-world split. It does not yet carry voice, motion language, gesture vocabulary, or the relationships with each partner in turn. Those land here as the work that needs them lands.
 
 The artist world bible holds the world. This document holds the person at its centre. When the two disagree, the bible is canon for the world and this document is canon for them.

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -1,0 +1,71 @@
+# The protagonist
+
+The person whose game this is. Mid-30s, androgynous, agender, a little softer than they once were. They picked up a racquet a long time ago and never quite put it down. The garden is theirs. The rally is theirs. The quiet at the centre of it is theirs too.
+
+This document is the starting point of the main-character profile. It carries what is canon now and the interior layer artists, animators, and writers need to hold them without flattening them. It will grow.
+
+---
+
+## The basic
+
+Androgynous, agender, mid-30s. Less athletic than they used to be. The body has settled into a shape that still knows the game but no longer chases it: a slight rounding at the shoulders, a slight ease in the hips, weight a touch lower than the racquet's old line wanted it. Gentle with themselves; gentle in posture. They stand the way someone stands who has nothing to prove to the room.
+
+The racquet has been in their hand for years. It is the constant that equipment hangs off; it is also the constant they hang off. The grip is worn where their grip is. They hold it without thinking about holding it.
+
+Not a tragic figure, not melodramatic, not a person in collapse. Someone who built a place where they could keep playing.
+
+---
+
+## What they lost
+
+They lost someone close to them. Recently enough that it is not healed, long enough that they have built a structure around it.
+
+The bright world is that structure. The garden, the stall, the rally that climbs through its tiers, the friend at the counter with their head tilted toward the play. The protagonist did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
+
+They are rarely embodied in the bright world. The world is built around their quiet presence at its centre rather than their figure; the racquet moves, the counter climbs, the friend watches, and the protagonist is the gravity the rest of it orbits. In the quieter world they are on screen, observed fly-on-the-wall in a small ordinary moment with a partner. That is where the body lives.
+
+---
+
+## The call of the void
+
+There is a layer underneath the structure that should never be named in the game and should never be named in the artist-facing bible. It belongs here, in the room where the people working on the protagonist meet, because without it the character flattens.
+
+The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. To let the ball roll past instead of returning it. The structure the protagonist built holds against the loss; it also holds against this. The two are related and distinct. Grief is what they are sheltering from. The void is what they are resisting.
+
+It surfaces in places the artist and animator can feel for, not script:
+
+- The cliffhanger leap to the next venue. The player triggers it; the world fades on the brink of something else; the choice to fall is theirs.
+- The locked gate, visible but unreachable. The protagonist could try; they don't.
+- The ball about to roll out of the play area. The moment the protagonist could let it go.
+- The pause before serving in a long rally. The awareness, held inside the breath, that they could stop.
+- The edges of the play area where their gaze drifts past it.
+
+The structure holds because they choose it, again and again, not because anything forces it on them. That is the load-bearing piece. Hold it as a quiet undercurrent in posture and timing; do not narrate it, do not name it, do not let it tip into theme.
+
+---
+
+## In the bright world
+
+The protagonist is a presence more than a figure. The court frames them on the left; the racquet moves; the head turns toward the stall when the rally allows it. The art's first job is to make the player feel the centre of the world is them, before a single line of dialogue.
+
+When something is harder to look at, the camera does not look at them. The world holds the feeling instead: the light in the garden, the friend's posture, the ball in the air.
+
+## In the quieter world
+
+The protagonist is on screen. A small moment with a partner in an ordinary place: a kitchen, a bus stop, the corner of a shop. Observed fly-on-the-wall, neither dramatised nor explained. Mid-30s, a little softer than they once were, gentle in posture. The artist's first quieter-world deliverable will set the rest of their physical specifics; everything else here defers to that read.
+
+---
+
+## What they love
+
+They love the game. They love the friend at the stall. They reach for the partners they reach for: Martha first, because she was reliably kind and asks nothing of them yet; others, harder, later.
+
+Warmth is the thing the structure was built around. The grief and the void are real, and the warmth is real too, and the warmth is the reason the structure stands. The protagonist is not surviving in the garden. They are living there. Quietly, partially, on the days they can; that is still living.
+
+---
+
+## A note on growth
+
+This is the first cut. It captures the basic, the loss, the call-of-the-void layer, and the bright-world / quieter-world split. It does not yet carry voice, motion language, gesture vocabulary, or the relationships with each partner in turn. Those land here as the work that needs them lands.
+
+The artist world bible holds the world. This document holds the person at its centre. When the two disagree, the bible is canon for the world and this document is canon for them.

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -18,9 +18,9 @@ Not a tragic figure, not melodramatic, not a person in collapse. Someone who bui
 
 They lost someone close to them. Recently enough that it is not healed, long enough that they have built a structure around it.
 
-The bright world is that structure. The garden, the stall, the rally that climbs through its tiers, the friend at the counter with their head tilted toward the play. The protagonist did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
+Construction is that structure. The garden, the stall, the rally that climbs through its tiers, the friend at the counter with their head tilted toward the play. The protagonist did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
 
-They are visible throughout. Drawn like any other character, on the left of the court with a racquet, holding the gravity of the world they built. Their Construction-render is who the player connects to across the bright world. Their Reality-render is the same person in their actual life, plainer, observed fly-on-the-wall in a small ordinary moment with a partner. The contrast lives in the register-switch, not in their presence on the page.
+They are visible throughout. Drawn like any other character, on the left of the court with a racquet, holding the gravity of the world they built. Their Construction-render is who the player connects to across Construction. Their Reality-render is the same person in their actual life, plainer, observed fly-on-the-wall in a small ordinary moment with a partner. The contrast lives in the register-switch, not in their presence on the page.
 
 ---
 
@@ -44,7 +44,7 @@ The structure holds because they choose it, again and again, not because anythin
 
 ## In Construction
 
-The court frames them on the left. The racquet moves; the head turns toward the stall when the rally allows it; the body carries the rally's tempo. Drawn young and full and helping, the way the bright world renders the rest of its cast. The figure on the court is the player's anchor in the bright world; the rendering choices that hold for the cast hold for the protagonist too.
+The court frames them on the left. The racquet moves; the head turns toward the stall when the rally allows it; the body carries the rally's tempo. Drawn young and full and helping, the way Construction renders the rest of its cast. The figure on the court is the player's anchor in Construction; the rendering choices that hold for the cast hold for the protagonist too.
 
 When the moment is harder to look at, the camera can hold elsewhere: the light in the garden, the friend's posture, the ball in the air. The protagonist stays in the frame; the attention of the frame moves around them.
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -58,7 +58,7 @@ The same person at their actual age. A small moment with a partner in an ordinar
 
 They love the game. They love the friend at the stall. They reach for the partners they reach for: Martha first, because she was reliably kind and asks nothing of them yet; others, harder, later.
 
-Warmth is the thing the structure was built around. The grief and the void are real, and the warmth is real too, and the warmth is the reason the structure stands. The protagonist is not surviving in the garden. They are living there. Quietly, partially, on the days they can; that is still living.
+The structure was built around what they love. The grief and the void are real; so is the love, and it is the reason the structure stands. The protagonist is not surviving in the garden. They are living there. Quietly, partially, on the days they can; that is still living.
 
 ---
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -52,6 +52,20 @@ The doubled pull is what makes the championship win land the way it does. Both m
 
 ---
 
+## The unnamed number
+
+A third interior layer, sitting alongside the void and the becoming-champ pull.
+
+The protagonist's phone is a period device, late 90s or early 2000s, a flip or a candy-bar. The shopkeeper's number is sitting in the call log or the contacts list, unnamed. They either deleted the contact, never saved the name, or the device just holds digits without labels. They scroll past it sometimes. They know whose it is and they do not know whose it is, in the way a person can hold a thing in two halves at once.
+
+The player has the phone throughout the game. They can dial the unnamed number from Construction onward. It never connects; the shopkeeper has withdrawn and is not picking up. The unanswered ring is the player-facing manifestation of the protagonist's reach without contact.
+
+Across Reconstruction the digits surface in Reality where they should not be: written on the back of a found photo, etched on the closed shop's sign, scrawled in the workshop, half-spoken by a coach mid-rally. Each fragment tightens the recognition that the unnamed contact is the shopkeeper's number. By late Reconstruction the protagonist knows whose it is.
+
+The dial at the cliff is the moment the name finally attaches. Two acts at once: chosen presence, and the contact in their phone becoming a person they have called.
+
+---
+
 ## In Construction
 
 The court frames them on the left. The racquet moves; the head turns toward the stall when the rally allows it; the body carries the rally's tempo. Drawn young and full and present, the way Construction renders the rest of its cast. The figure on the court is the player's anchor in Construction; the rendering choices that hold for the cast hold for the protagonist too.
@@ -74,11 +88,15 @@ The structure was built around what they love. The grief and the void are real; 
 
 ## The call
 
-At the cliff, with the key spent and the gate open behind them, the protagonist sees the shopkeeper on a bench dedicated to the friend. The bench is a few steps away. The protagonist could close that distance silently. They do not.
+The key arrives through the sister. Across Reconstruction she holds the half-filled photo album, with a hidden compartment that opens once the album fills enough. When the work is done, she takes the key out and hands it to the protagonist. They walk back to the garden, unlock the one locked gate at the back, and step through to the cliff in Reality.
 
-They take out their phone and dial. The number they finally have is the number they have been climbing toward the whole climb, surfacing across Reconstruction in places it should not be, becoming a phone number across the player's eyes. The shopkeeper's phone rings on the bench beside them; they turn at the sound, see the protagonist, pick up. Both of them hold their phones across the small distance between path and bench.
+The whole of Reconstruction has been shadowed by dread. The shopkeeper has been missing since the break; calls to the unnamed number have not connected; the protagonist has been afraid the friend's path has been followed. Arriving at the cliff carries that fear: a bench dedicated to the friend, a place to find the worst.
 
-The dial bridges intention, not space. Chosen presence rather than a closing of distance. The few steps between path and bench are easy; the choice to be reached, and to reach, is the part that took the whole game. After the call the protagonist crosses, sits beside the shopkeeper on the bench. The call ends there.
+The shopkeeper is on the bench, alive. The dread inverts. The fear was wrong; they are still here, withdrawn, refusing calls, but here.
+
+The bench is a few steps away. The protagonist could close that distance silently. They do not. They take out their phone and dial the unnamed number, the digits whole in their head now from all the surfaced fragments. The shopkeeper's phone rings beside them on the bench; they could ignore it the way they have been ignoring all the others. They do not. They look up at the sound, see the protagonist, pick up. Both of them hold their phones across the small distance between path and bench.
+
+The dial bridges intention, not space. Chosen presence rather than a closing of distance. Two acts at once: choosing to reach, and finally attaching the name to the number that has been sitting unnamed in the protagonist's phone the whole game. The few steps between path and bench are easy; the choice to be reached, and to reach, is the part that took the whole game. After the call the protagonist crosses, sits beside the shopkeeper on the bench. The call ends there.
 
 ---
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -1,7 +1,5 @@
 # The protagonist
 
-The person whose game this is. Mid-30s, androgynous, agender, a little softer than they once were. They picked up a racquet a long time ago and never quite put it down. The garden is theirs. The rally is theirs. The quiet at the centre of it is theirs too.
-
 This document is the starting point of the main-character profile. It carries what is canon now and the interior layer artists, animators, and writers need to hold them without flattening them. It will grow.
 
 ---

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -100,4 +100,10 @@ The dial bridges intention, not space. Chosen presence rather than a closing of 
 
 ---
 
+## Credits over the rally
+
+Credits roll over a rally. The protagonist on the left of the court, the shopkeeper on the right, the ball moving between them. The first rally the two of them have ever played. The championship spot at the top of Construction held a substitute for the whole game; the actual person stands in it now, and the daily thing the protagonist did alone is finally done together. The rally is the proof. Hold the figures the way the rest of Construction holds them: full, present, drawn with the same care given to every coach-partner across the climb. Let the volley carry its own tempo; the credits sit on top of it without interrupting.
+
+---
+
 The artist world bible holds the world. This document holds the person at its centre. When the two disagree, the bible is canon for the world and this document is canon for them.

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -20,7 +20,7 @@ They lost someone close to them. Recently enough that it is not healed, long eno
 
 Construction is that structure. The garden, the stall, the rally, the friend at the counter with their head tilted toward the play. The protagonist did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
 
-They are visible throughout. Drawn like any other character, on the left of the court with a racquet, holding the gravity of the world they built. Their Construction-render is who the player connects to across Construction. Their Reality-render is the same person in their actual life, plainer, observed fly-on-the-wall in a small ordinary moment with a partner. The contrast lives in the register-switch, not in their presence on the page.
+They are visible throughout. Drawn like any other character, on the left of the court with a racquet, holding the gravity of the world they built. Their Construction-render is who the player connects to across Construction. Their Reality-render is the same person in their actual life, plainer, observed fly-on-the-wall in a small ordinary moment with a partner. The contrast lives in the style-switch, not in their presence on the page.
 
 ---
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -8,7 +8,7 @@ This document is the starting point of the main-character profile. It carries wh
 
 ## The basic
 
-Androgynous, agender, mid-30s. Less athletic than they used to be. The body has settled into a shape that still knows the game but no longer chases it: a slight rounding at the shoulders, a slight ease in the hips, weight a touch lower than the racquet's old line wanted it. Gentle with themselves; gentle in posture. They stand the way someone stands who has nothing to prove to the room.
+Androgynous, agender, mid-30s. Less athletic than they used to be. The body has settled into a shape that still knows the game but no longer chases it. They stand the way someone stands who has nothing to prove to the room.
 
 The racquet has been in their hand for years. It is the constant that equipment hangs off; it is also the constant they hang off. The grip is worn where their grip is. They hold it without thinking about holding it.
 


### PR DESCRIPTION
First-cut main-character profile, separate from the artist world bible. Captures the basic protagonist canon plus the call-of-the-void motif as an interior layer. The doc is positioned to grow into the full character profile.

Closes SH-277.