### PR TITLE
docs: warmer-Wales hometown + credits-over-rally beat

### DIFF
--- a/designs/concept/00-three-styles.md
+++ b/designs/concept/00-three-styles.md
@@ -1,4 +1,4 @@
-# The Three Registers
+# The Three Styles
 
 The high-level structure of Volley as a game. This doc carries the architecture; per-arc docs in this folder carry the detail.
 
@@ -10,7 +10,7 @@ This is a working set of docs. Refinement passes follow.
 - `01-construction.md`: the bright world, the cast, the shopkeeper psychology, the tournament structure, the champ, the rally and the count.
 - `02-cracks-and-break.md`: the wall thinning and the wall coming down.
 - `03-reconstruction.md`: the long arc after the break, the bidirectional carry, the reconciliation mechanic.
-- `04-reality.md`: the second register; the hometown, the cast in Reality, the photo book, the cliff.
+- `04-reality.md`: the second style; the hometown, the cast in Reality, the photo book, the cliff.
 - `05-postgame.md`: the call, the seashell, what the bright world becomes after.
 
 The earlier narrative pass at `designs/02-alpha/01-world-and-narrative.md` is raw material for these docs. Pieces that work are kept; pieces that do not are reframed or dropped. The picked-up section below names the deltas.
@@ -23,40 +23,40 @@ What the player does not know yet: the world record is a phone number. The shopk
 
 The bright world is a construction the protagonist is actively maintaining. It takes energy to keep. The warmth in it is real; the pretense is the rendering. The game is the arc of that pretense thinning, the wall coming down, and the protagonist learning to live without it.
 
-## The three registers
+## The three styles
 
 **Construction.** The bright world. Saturated, full, helping. Volleyball lives here; the count is the engine; the world record is the goal. The protagonist's pretense actively maintained against a loss they have not yet been able to face. Detail in `01-construction.md`.
 
-**Reality.** A complete second register. Visually distinct from Construction: gold-hour, weighted, plainer, characters at their actual ages. Story-driven; layered scenes the player walks into. One place, the protagonist's hometown, geographically static with content added across the arc. Detail in `04-reality.md`.
+**Reality.** A complete second style. Visually distinct from Construction: gold-hour, weighted, plainer, characters at their actual ages. Story-driven; layered scenes the player walks into. One place, the protagonist's hometown, geographically static with content added across the arc. Detail in `04-reality.md`.
 
-**Reconstruction.** The arc. The long phase after the break in which the wall stays down and the player can travel between Construction and Reality at will. Not a third visual register; a meta-state of free travel and bidirectional carry. Reconciliation lives inside Reconstruction as the actions the player takes. Detail in `03-reconstruction.md`.
+**Reconstruction.** The arc. The long phase after the break in which the wall stays down and the player can travel between Construction and Reality at will. Not a third visual style; a meta-state of free travel and bidirectional carry. Reconciliation lives inside Reconstruction as the actions the player takes. Detail in `03-reconstruction.md`.
 
 ## The five movements at a glance
 
 1. **Construction.** The pretense actively maintained. The rally climbs toward the record. The count is visible; the goal is named in dialogue. (Detail: `01-construction.md`.)
 2. **Cracks.** Reality leaks into the construction in small atmospheric ways. Each crack is dismissible; the cumulative pressure matters. (Detail: `02-cracks-and-break.md`.)
 3. **The break.** The wall comes down once. Cumulative cracks plus a singular rupture. The player is pulled into Reality involuntarily for the first time. (Detail: `02-cracks-and-break.md`.)
-4. **Reconstruction.** The long arc. Free travel between registers; bidirectional carry; reconciliation actions accumulate; the cliff visit closes the arc. (Detail: `03-reconstruction.md`.)
+4. **Reconstruction.** The long arc. Free travel between styles; bidirectional carry; reconciliation actions accumulate; the cliff visit closes the arc. (Detail: `03-reconstruction.md`.)
 5. **The call.** Reaching the world record means dialling the shopkeeper. Peace is the call made. (Detail: `05-postgame.md`.)
 
 After the call: postgame, with the champ gone and a seashell in their place.
 
-## Cross-register principles
+## Cross-style principles
 
-These principles bind the registers together; the per-arc docs should not contradict them.
+These principles bind the styles together; the per-arc docs should not contradict them.
 
 - **Everyone is real.** The supporting cast in Construction is the real cast from the protagonist's life, rendered young / vibrant / helping. The same people exist in Reality at their actual ages. Two asset sets per character that appears in both. Exception: the champ (Construction-only; their reality is the cliff).
 - **The hook is in dialogue, not HUD.** The world record is named by a character (probably the friend at the stall) in the first session. The number is on a HUD; the meaning is not.
 - **Cracks are tonal, not concrete.** A real-world object literally appearing in Construction reads as a flag the player can point at. A colour shift or a beat in a partner's posture is harder to name and easier to absorb. Concrete leakage breaks the deniability the cumulative shape needs.
-- **Reconstruction is not a third visual register.** The two registers stay distinct. Reconstruction's signal is the carry, plus a gradual weathering of Construction's saturation, plus play-level differentiators (score hidden in Construction, champ dialogue softens, audio shifts).
+- **Reconstruction is not a third visual style.** The two styles stay distinct. Reconstruction's signal is the carry, plus a gradual weathering of Construction's saturation, plus play-level differentiators (score hidden in Construction, champ dialogue softens, audio shifts).
 - **Reality is finite hand-crafted content.** One place, built once, with iterative additions across Reconstruction. Reality cannot be procedural; the team builds each scene.
 
 ## What this teaches each surface
 
-- **Artist world bible**: two asset sets per character that appears in both registers (champ is the exception). Reconstruction's visual signal is the carry plus weathering, not a third render. Cracks are tonal and atmospheric; do not draw concrete reality-leaks.
+- **Artist world bible**: two asset sets per character that appears in both styles (champ is the exception). Reconstruction's visual signal is the carry plus weathering, not a third render. Cracks are tonal and atmospheric; do not draw concrete reality-leaks.
 - **MC profile**: the protagonist's reconciliation arc is the spine of their interior life. The call-of-the-void layer the profile already names becomes legible as the resistance to crossing into Reality. The cliff is where that resistance is met head-on.
 - **Tech-context**: the rally tooling holds Construction. Reality's tooling is its own thing: layered scene-state, contextual interactions, dialogue, descriptive prose, the present-and-attentive puzzle shape, the bidirectional carry. SH-279 is the right place to spike this.
-- **Audio (SH-281)**: a register per phase. Construction is synthetic / bright / energetic; Break is abstract synth, harsh, minimalist; Reality is acoustic with bustle and wind; Reconstruction is synth and acoustic in conversation, escalating to full orchestra by the end.
+- **Audio (SH-281)**: a style per phase. Construction is synthetic / bright / energetic; Break is abstract synth, harsh, minimalist; Reality is acoustic with bustle and wind; Reconstruction is synth and acoustic in conversation, escalating to full orchestra by the end.
 
 ## What this teaches the production
 
@@ -106,8 +106,8 @@ From `05-postgame.md`:
 
 ## What this unblocks
 
-- The artist world bible can name the three registers and the five movements, with content fills proceeding once the open questions on action count, crack pacing, and the encounter shape are answered.
+- The artist world bible can name the three styles and the five movements, with content fills proceeding once the open questions on action count, crack pacing, and the encounter shape are answered.
 - SH-279 (tech spike on reality gameplay) absorbs the hometown structure, the layered-scene puzzle shape, and the bidirectional carry.
-- SH-281 (audio direction) drafts the music register per phase.
+- SH-281 (audio direction) drafts the music style per phase.
 - Future content tickets live downstream of these per-arc docs reaching consensus.
 - The MC profile can deepen with the call-of-the-void resistance mapped onto the cliff's chosen-acceptance shape.

--- a/designs/concept/01-construction.md
+++ b/designs/concept/01-construction.md
@@ -1,6 +1,6 @@
 # Construction
 
-The bright world. The pretense the protagonist is actively maintaining. This doc carries Construction's detail; high-level architecture lives in `00-three-registers.md`.
+The bright world. The pretense the protagonist is actively maintaining. This doc carries Construction's detail; high-level architecture lives in `00-three-styles.md`.
 
 ## What Construction is
 
@@ -16,7 +16,7 @@ The cast splits into two groups. The supporting cast are real people from the pr
 
 ### Supporting cast
 
-- **The protagonist.** Drawn like any other character; the player needs to see them to connect to them. Construction-render and Reality-render, same shape as everyone else. The Construction-render is what the player connects to throughout the bright world; the Reality-render is the protagonist as they actually are. The two stay distinct; the protagonist's image does not transform across the arc. The player gets the contrast by switching registers.
+- **The protagonist.** Drawn like any other character; the player needs to see them to connect to them. Construction-render and Reality-render, same shape as everyone else. The Construction-render is what the player connects to throughout the bright world; the Reality-render is the protagonist as they actually are. The two stay distinct; the protagonist's image does not transform across the arc. The player gets the contrast by switching styles.
 - **The shopkeeper / friend at the stall.** The warmth at the centre of the venue, in Construction. In reality, this is someone the protagonist has pushed away. Same person, two renders. The shopkeeper leaves the construction at the break (`02-cracks-and-break.md`) and returns at the call as the final partner on the right side of the court (`05-postgame.md`). (See "Why the shopkeeper is at the stall" below.)
 - **Martha and the partners.** Real people the protagonist knew, summoned into the bright world as the protagonist's coaches and training partners. Each has a real-world counterpart the player can meet during Reconstruction. (See "The coaches" below.)
 - **The tinkerer.** Real person, the shopkeeper's younger sister. Holds the photo book in Reality (`04-reality.md`).

--- a/designs/concept/02-cracks-and-break.md
+++ b/designs/concept/02-cracks-and-break.md
@@ -1,6 +1,6 @@
 # Cracks and the Break
 
-The wall thinning, then the wall coming down. This doc carries both phases together because they are one continuous beat. High-level architecture in `00-three-registers.md`; what follows here is the detail.
+The wall thinning, then the wall coming down. This doc carries both phases together because they are one continuous beat. High-level architecture in `00-three-styles.md`; what follows here is the detail.
 
 ## Cracks
 

--- a/designs/concept/03-reconstruction.md
+++ b/designs/concept/03-reconstruction.md
@@ -1,16 +1,16 @@
 # Reconstruction
 
-The arc. The long phase between the break and the cliff. The wall stays down; the player can travel between Construction and Reality at will. The protagonist is reconstructing their view of the world. High-level architecture in `00-three-registers.md`.
+The arc. The long phase between the break and the cliff. The wall stays down; the player can travel between Construction and Reality at will. The protagonist is reconstructing their view of the world. High-level architecture in `00-three-styles.md`.
 
 ## What Reconstruction is
 
-Reconstruction is not a third visual register. The two registers stay distinct: Construction (`01-construction.md`) is still vibrant; Reality (`04-reality.md`) is still gold-hour. Reconstruction is the meta-state in which the player has access to both and can carry across.
+Reconstruction is not a third visual style. The two styles stay distinct: Construction (`01-construction.md`) is still vibrant; Reality (`04-reality.md`) is still gold-hour. Reconstruction is the meta-state in which the player has access to both and can carry across.
 
 Reconstruction's Construction is missing its warm centre. The shopkeeper left at the break (`02-cracks-and-break.md`); the shop is closed; the stall is empty. The bright world has been hollowed out where it used to be warmest. The protagonist rallies on without them. The shopkeeper exists only in Reality during this arc, reachable through the reconciliation mechanic, until the call returns them to the construction (`05-postgame.md`).
 
 Reconstruction must also FEEL different to play, not only look different in the carry. Construction was driven by a visible count climbing toward the championship; if Reconstruction is just more of the same with the cap raised in stages, it will feel like Construction with extra steps. Three changes mark Reconstruction at the play level:
 
-- **The score is hidden in Construction.** In Construction, the count climbs visibly; the player chases the number. In Reconstruction, the number disappears from the rally. The player rallies without knowing how close they are to the call. The number can still be checked, but only by visiting somewhere in Reality (the sister's, the closed shop, the cliff). The score migrates from Construction to Reality. The player has to leave the rally to know how close they are; that is the exact register-shift Reconstruction wants to feel like.
+- **The score is hidden in Construction.** In Construction, the count climbs visibly; the player chases the number. In Reconstruction, the number disappears from the rally. The player rallies without knowing how close they are to the call. The number can still be checked, but only by visiting somewhere in Reality (the sister's, the closed shop, the cliff). The score migrates from Construction to Reality. The player has to leave the rally to know how close they are; that is the exact style-shift Reconstruction wants to feel like.
 - **The champ's dialogue softens gradually.** In Construction, the champ's lines are sharp, pushing, the friend's old habit of not letting the protagonist coast. Across Reconstruction the lines soften beat by beat, until late in the arc the champ sounds like a friend again. The shift is in what gets said and how, not in a stat. The player notices the change through the dialogue alone.
 - **Audio shifts.** The construction's bright synthetic music thins and acoustic instruments arrive, with the balance moving toward fuller arrangement by late Reconstruction. Full direction in SH-281.
 
@@ -21,7 +21,7 @@ The carry is what Reconstruction enables. Bidirectional and selective. Not anyth
 - **Constructs into Reality.** Specific Construction items, characters, or memories can be brought into Reality and used in specific reconciliation scenes. The construction is what the protagonist built to keep going; in Reconstruction, the things they built turn out to be useful in the world they were avoiding. Which constructs are carry-able and which are not is a narrative decision per content beat, not an open mechanic.
 - **Reality into Construction.** Specific real-world acknowledgements feed back into the rally. New venues unlock; coaches gain new lines; the bright world acknowledges what it had been hiding from. Hints for Reality's next reconciliation surface in Construction. Same gate: which acknowledgements bridge back is a curated narrative call.
 
-The visual signal of Reconstruction is the act of crossing, plus the persistent presence of one register's elements when the player is in the other. The bridge itself is the new affordance.
+The visual signal of Reconstruction is the act of crossing, plus the persistent presence of one style's elements when the player is in the other. The bridge itself is the new affordance.
 
 As the carry accumulates, the bright world ages with the player. Saturation drops a notch; line weight thickens; compositions hold longer pauses. The construction does not visually rebuild; it weathers.
 

--- a/designs/concept/04-reality.md
+++ b/designs/concept/04-reality.md
@@ -1,6 +1,6 @@
 # Reality
 
-The second register. Visually distinct from Construction, mechanically a different game, story-driven. The protagonist's hometown, geographically static, with content added across Reconstruction. Reachable only voluntarily once Reconstruction begins (`03-reconstruction.md`).
+The second style. Visually distinct from Construction, mechanically a different game, story-driven. The protagonist's hometown, geographically static, with content added across Reconstruction. Reachable only voluntarily once Reconstruction begins (`03-reconstruction.md`).
 
 ## The place
 
@@ -18,7 +18,7 @@ Reality is interaction-driven, not rally-driven. The player walks into a scene, 
 
 ## The cast in Reality
 
-Reality holds the real-world version of every cross-register character. Each is at their actual age, in their actual life, plainer than their Construction-render. The player meets them across Reconstruction.
+Reality holds the real-world version of every cross-style character. Each is at their actual age, in their actual life, plainer than their Construction-render. The player meets them across Reconstruction.
 
 - **The sister**: the tinkerer's real-world counterpart. The shopkeeper's younger sister. Less weighted by the death than the shopkeeper. Holds the photo book (see below). One of the first reachable people in Reality.
 - **Martha and the partners (in Reality)**: the cashier at the actual newsagent; the others as they actually are. Not coaches here, just people the protagonist knew.

--- a/designs/concept/04-reality.md
+++ b/designs/concept/04-reality.md
@@ -4,7 +4,7 @@ The second register. Visually distinct from Construction, mechanically a differe
 
 ## The place
 
-Reality is one place: the protagonist's hometown. A small coastal town, British-seaside-meets-southern-Spain. Terraced houses next to whitewashed walls; a high street that smells of both rain and citrus; light shifting between northern grey and Mediterranean glare. Ordinary, lived-in.
+Reality is one place: the protagonist's hometown. A small coastal town on the Welsh and Cornish coast in an imagined warmer climate. Painted terraces in seaside colours, the palette of Tenby and Aberaeron: pinks, yellows, sea-greens, sky-blues. Whitewashed walls. Palm trees in places. A high street that smells of rain and citrus. Mediterranean light on a British coastline. Faded grandeur with sun on it. Ordinary, lived-in.
 
 The place is geographically static. The map does not grow; the town stays the size it was when the player first walked through it at the break. What changes is what is in it. Across Reconstruction, things are added: people the player can meet, objects that were not there before, conversations that open as the protagonist is ready for them. The same hometown, revealed in passes.
 

--- a/designs/concept/05-postgame.md
+++ b/designs/concept/05-postgame.md
@@ -20,6 +20,12 @@ This is the postgame opening, and it is not a transition. The player never leave
 
 The call is the ending. The warmth in Construction is now available without the pretense; the protagonist can be in their hometown, with the people who are actually there, and the rally is something they do, with the right person, in a world that no longer has to be a wall.
 
+## Credits
+
+Credits roll over the rally. The first one between the MC and the shopkeeper, the championship spot occupied by the actual person, racquet in their hand, the ball going back and forth. The substitute is gone; the right side of the court holds the friend the protagonist had been reaching for the whole time. The names scroll over the play. The rally keeps going.
+
+The image is the proof: the daily thing the protagonist did alone is finally done together.
+
 ## Postgame
 
 Postgame is rallying with the shopkeeper. They take the right side of the court that used to be the championship spot, the same spot the champ once held. The construction is at last what the protagonist was always reaching for: themselves on the left, the shopkeeper on the right, the rally going.

--- a/designs/concept/05-postgame.md
+++ b/designs/concept/05-postgame.md
@@ -1,6 +1,6 @@
 # The Call and Postgame
 
-The ending and what comes after. High-level architecture in `00-three-registers.md`.
+The ending and what comes after. High-level architecture in `00-three-styles.md`.
 
 ## The call
 


### PR DESCRIPTION
Two narrative-canon followups for the merged spike concept docs.

`04-reality.md`'s hometown paragraph leads with the Welsh / Cornish painted-terrace palette (Tenby and Aberaeron) under Mediterranean light on a British coastline, replacing the prior framing-by-contrast wording.

`05-postgame.md` gains a Credits subsection: credits roll over the first rally between MC and shopkeeper, championship spot finally occupied by the actual person.