### PR TITLE
docs: restructure MC profile around the protagonist's arc

### DIFF
--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -8,7 +8,7 @@ When this document and the bible disagree, the bible is canon for the world and 
 
 ## Who they are
 
-Androgynous, agender, mid-30s. Less athletic than they used to be. The body has settled into a shape that still knows the game but no longer chases it. They stand the way someone stands who has nothing to prove to the room.
+Androgynous, agender, mid-30s. Their body still knows the game; the chasing is over. Stands the way someone stands who has nothing to prove to the room.
 
 The racquet has been in their hand for years. It is the constant that equipment hangs off; it is also the constant they hang off. The grip is worn where their grip is. They hold it without thinking about holding it.
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -62,7 +62,7 @@ The album fills as the protagonist works. The shopkeeper's younger sister has he
 
 A layer underneath the structure. It sits next to the grief and the becoming-champ pull, not under them.
 
-The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. The cliff is the specific shape of this for them: the place the friend died, the place the protagonist did not go that day. The structure holds against the loss; it also holds against this. The two are related and distinct. Grief is what they are sheltering from. The void is what they are resisting.
+The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. The cliff is the specific shape of this for them: the place the friend died, the place the protagonist did not go that day. The structure holds them present in the loss; it also holds them present alongside this. Grief is what they are sheltering from. The void is what they live alongside, daily.
 
 It surfaces in places the artist and animator can feel for, not script:
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -84,9 +84,9 @@ A bench sits at the cliff edge, dedicated to the friend who died. The shopkeeper
 
 Recognition lands. The unnamed number in the phone, the world record they reached, the digits the championship match resolved on, the person on the bench: all the same number, held unnamed all along, only now legible. The connection forms in the seeing.
 
-The bench is a few steps away. The protagonist could close that distance silently. They do not. They take out their phone and dial the number, knowing now whose it is. The shopkeeper's phone rings beside them on the bench; they could ignore it the way they have been ignoring all the others. They do not. They look up at the sound, see the protagonist, pick up. Both of them hold their phones across the small distance between path and bench.
+The shopkeeper is right there. The protagonist could walk up silently. They do not. They take out their phone and dial the number, knowing now whose it is. The shopkeeper's phone rings on the bench beside them; they could ignore it the way they have been ignoring all the others. They do not. They look up at the sound, see the protagonist, pick up. Both of them hold their phones, the call open between them.
 
-The dial bridges intention, not space. Chosen presence rather than a closing of distance. Two acts at once: choosing to reach, and finally attaching the name to the number that has sat unnamed in the protagonist's phone the whole game. The few steps between path and bench are easy; the choice to be reached, and to reach, is the part that took the whole game.
+The dial bridges intention, not space. Chosen presence rather than a quiet approach. Two acts at once: choosing to reach, and finally attaching the name to the number that has sat unnamed in the protagonist's phone the whole game. The years between them were what was hard; the choice to be reached, and to reach, is the part that took the whole game.
 
 The call ends. The protagonist crosses, sits beside the shopkeeper on the bench. Credits roll over the rally that follows: the protagonist on the left, the shopkeeper on the right, the championship spot held by the actual person at last. The daily thing the protagonist did alone is finally done together.
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -1,10 +1,12 @@
 # The protagonist
 
-This document is the starting point of the main-character profile. It carries what is canon now and the interior layer artists, animators, and writers need to hold them without flattening them. It will grow.
+The artist world bible at `designs/01-prototype/artist-world-bible.md` holds the world and the role. The structural arc lives across `designs/concept/`, beginning at `00-three-styles.md`. This document holds the person at the centre of both: who they are, what they carry, how they move through Part 1 and Part 2, and the interior weight underneath.
+
+When this document and the bible disagree, the bible is canon for the world and this document is canon for them.
 
 ---
 
-## The basic
+## Who they are
 
 Androgynous, agender, mid-30s. Less athletic than they used to be. The body has settled into a shape that still knows the game but no longer chases it. They stand the way someone stands who has nothing to prove to the room.
 
@@ -14,96 +16,84 @@ Not a tragic figure, not melodramatic, not a person in collapse. Someone who bui
 
 ---
 
-## What they lost
+## What they lost, what they built
 
-They lost someone close to them. Recently enough that it is not healed, long enough that they have built a structure around it.
+They lost a friend years ago in something reckless at the cliff. The shopkeeper was there. The protagonist was not. That asymmetry has sat between them ever since. Recently enough that it is not healed, long enough that they have built a structure around it.
 
-Construction is that structure. The garden, the stall, the rally, the friend at the counter with their head tilted toward the play. The protagonist did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
+Construction is that structure. The garden, the stall, the rally, the friend at the counter with their head tilted toward the play. They did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
 
-They are visible throughout. Drawn like any other character, on the left of the court with a racquet, holding the gravity of the world they built. Their Construction-render is who the player connects to across Construction. Their Reality-render is the same person in their actual life, plainer, observed fly-on-the-wall in a small ordinary moment with a partner. The contrast lives in the style-switch, not in their presence on the page.
+The structure was built around what they love. The love is real; so is the grief. The protagonist is not surviving in the garden. They are living there. Quietly, partially, on the days they can; that is still living.
+
+---
+
+## How the styles render them
+
+In Construction the court frames them on the left. The racquet moves; the head turns toward the stall when the rally allows it; the body carries the rally's tempo. Drawn young and full and present, the way Construction renders the rest of its cast. The figure on the court is the player's anchor; the rendering choices that hold for the cast hold for the protagonist too. When a moment is harder to look at, the camera can hold elsewhere: the light in the garden, the friend's posture, the ball in the air. The protagonist stays in the frame; the attention of the frame moves around them.
+
+In Reality the same person at their actual age. A small moment with a partner in an ordinary place: a kitchen, a bus stop, the corner of a shop. Observed fly-on-the-wall, neither dramatised nor explained. Mid-30s, a little softer than they once were, gentle in posture. The first Reality deliverable will set the rest of their physical specifics; everything else here defers to that read.
+
+---
+
+## Part 1: the climb
+
+Across Construction the protagonist is climbing toward the championship, and the obsession pulls in two directions at once. They want to become the champion of the world they built: the title, the record, the spot at the top of the climb. They also want to become the champ inside that world, the friend now drawn as the partner at the final venue. The same word does both jobs and the protagonist does not separate them. Winning the title and reaching the friend are one motion to them, even though the world cannot grant the second.
+
+Hold this as quiet weight in how they treat the climb: not triumph, not desperation, a steadiness that knows what it is reaching for and does not yet know it is reaching past it.
+
+The doubled pull is what makes the championship win land the way it does. Both meanings are satisfied at the same beat and neither was the thing the protagonist actually needed. The win is the break. The construct cannot hold itself together once its central goal has been reached and proved meaningless.
+
+At the win the count completes; the digits land; the protagonist sees them, and they look weirdly familiar. The number has been sitting in their phone the whole game. The recognition does not quite land yet.
+
+---
+
+## Part 2: the dread, the search, the unnamed number
+
+Reconstruction runs on dread. The shopkeeper went missing at the break and the protagonist has been afraid the friend's path has been followed. The driving force is the search for what happened, where they have gone, whether it is too late. The work is the search-for-confirmation, all of it shadowed by the fear that the confirmation will be terrible.
+
+The phone is theirs to hold the whole game. The shopkeeper's number sits in the call log or the contacts list, unnamed: deleted, never saved, or held by the device as digits without labels. They scroll past it sometimes. They know whose it is and they do not know whose it is, in the way a person can hold a thing in two halves at once.
+
+The player has the phone throughout. They can dial the unnamed number from Construction onward. It never connects. The shopkeeper has withdrawn and is not picking up. The unanswered ring is the player-facing weight of the protagonist's reach without contact.
+
+Across Reconstruction the digits surface in Reality where they should not be: written on the back of a found photo, etched on the closed shop's sign, scrawled in the workshop, half-spoken by a coach mid-rally, mentioned by the sister as an area code. Each fragment tightens the recognition. By late Reconstruction the protagonist knows whose it is. The almost-dial recurs across the arc: hand-to-pocket after a coach's memory, the phone out after a heavy photo find, a draft message left open and never sent, a voicemail attempt that hangs up before saying anything. None connect.
+
+The album fills as the protagonist works. The shopkeeper's younger sister has held the half-filled book the whole time; finding the scattered photos is the protagonist's work. When it fills enough the hidden compartment opens. The key is inside. The sister hands it to them.
 
 ---
 
 ## The call of the void
 
-A layer underneath the structure. It is here, not in the bible, because without it the character flattens.
+A layer underneath the structure. It sits next to the grief and the becoming-champ pull, not under them.
 
-The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. The structure the protagonist built holds against the loss; it also holds against this. The two are related and distinct. Grief is what they are sheltering from. The void is what they are resisting.
+The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. The structure holds against the loss; it also holds against this. The two are related and distinct. Grief is what they are sheltering from. The void is what they are resisting.
 
 It surfaces in places the artist and animator can feel for, not script:
 
 - The cliffhanger leap to the next venue. The player triggers it; the world thins on the brink of something else; the choice to fall is theirs.
-- The locked gate at the back of the garden. The protagonist tries it. It does not open. They turn back. (The gate opens later, after Reconstruction: the sister hands them the key from the photo album's hidden compartment once it has filled enough; they unlock the gate; they walk to the cliff on the other side.)
+- The locked gate at the back of the garden. The protagonist tries it. It does not open. They turn back.
 - The ball about to roll out of the play area. The moment the protagonist could let it go.
 - The pause before serving in a long rally. The awareness, held inside the breath, that they could stop.
 - The edges of the play area where their gaze drifts past it.
 
-The structure holds because they choose it, again and again, not because anything forces it on them. That is the load-bearing piece. Hold it as a quiet undercurrent in posture and timing; let the choice be the visible thing.
+The structure holds because they choose it, again and again. Hold this as a quiet undercurrent in posture and timing; let the choice be the visible thing.
 
 ---
 
-## Becoming the champ
+## The cliff and the call
 
-A second layer underneath the structure. It sits next to the void, not under it.
+The protagonist returns to the garden with the key from the album. They walk to the locked gate at the back, unlock it, step through to the cliff in Reality.
 
-Across Construction the protagonist is climbing toward the championship, and the obsession pulls in two directions at once. They want to become the champion of the world they built: the title, the record, the spot at the top of the climb. They also want to become the champ inside that world, a friend now drawn as the partner at the final venue. The same word does both jobs and the protagonist does not separate them. Winning the title and reaching the friend are one motion to them, even though the world cannot grant the second.
-
-The doubled pull is what makes the championship win land the way it does. Both meanings are satisfied at the same beat and neither was the thing the protagonist actually needed. Hold this as quiet weight in how they treat the climb: not triumph, not desperation, a steadiness that knows what it is reaching for and does not yet know it is reaching past it.
-
----
-
-## The unnamed number
-
-A third interior layer, sitting alongside the void and the becoming-champ pull.
-
-The protagonist's phone is a period device, late 90s or early 2000s, a flip or a candy-bar. The shopkeeper's number is sitting in the call log or the contacts list, unnamed. They either deleted the contact, never saved the name, or the device just holds digits without labels. They scroll past it sometimes. They know whose it is and they do not know whose it is, in the way a person can hold a thing in two halves at once.
-
-The player has the phone throughout the game. They can dial the unnamed number from Construction onward. It never connects; the shopkeeper has withdrawn and is not picking up. The unanswered ring is the player-facing manifestation of the protagonist's reach without contact.
-
-Across Reconstruction the digits surface in Reality where they should not be: written on the back of a found photo, etched on the closed shop's sign, scrawled in the workshop, half-spoken by a coach mid-rally. Each fragment tightens the recognition that the unnamed contact is the shopkeeper's number. By late Reconstruction the protagonist knows whose it is.
-
-The dial at the cliff is the moment the name finally attaches. Two acts at once: chosen presence, and the contact in their phone becoming a person they have called.
-
----
-
-## In Construction
-
-The court frames them on the left. The racquet moves; the head turns toward the stall when the rally allows it; the body carries the rally's tempo. Drawn young and full and present, the way Construction renders the rest of its cast. The figure on the court is the player's anchor in Construction; the rendering choices that hold for the cast hold for the protagonist too.
-
-When the moment is harder to look at, the camera can hold elsewhere: the light in the garden, the friend's posture, the ball in the air. The protagonist stays in the frame; the attention of the frame moves around them.
-
-## In Reality
-
-The same person at their actual age. A small moment with a partner in an ordinary place: a kitchen, a bus stop, the corner of a shop. Observed fly-on-the-wall, neither dramatised nor explained. Mid-30s, a little softer than they once were, gentle in posture. The first Reality deliverable will set the rest of their physical specifics; everything else here defers to that read.
-
----
-
-## What they love
-
-They love the game. They love the friend at the stall. They reach for the partners they reach for: Martha first, because she was reliably kind and asks nothing of them yet; others, harder, later.
-
-The structure was built around what they love. The grief and the void are real; so is the love, and it is the reason the structure stands. The protagonist is not surviving in the garden. They are living there. Quietly, partially, on the days they can; that is still living.
-
----
-
-## The call
-
-The key arrives through the sister. Across Reconstruction she holds the half-filled photo album, with a hidden compartment that opens once the album fills enough. When the work is done, she takes the key out and hands it to the protagonist. They walk back to the garden, unlock the one locked gate at the back, and step through to the cliff in Reality.
-
-The whole of Reconstruction has been shadowed by dread. The shopkeeper has been missing since the break; calls to the unnamed number have not connected; the protagonist has been afraid the friend's path has been followed. Arriving at the cliff carries that fear: a bench dedicated to the friend, a place to find the worst.
-
-The shopkeeper is on the bench, alive. The dread inverts. The fear was wrong; they are still here, withdrawn, refusing calls, but here.
+A bench sits at the cliff edge, dedicated to the friend who died. The shopkeeper is on the bench, alive. The dread inverts to relief. The fear was wrong; they are still here, withdrawn, refusing calls, but here.
 
 The bench is a few steps away. The protagonist could close that distance silently. They do not. They take out their phone and dial the unnamed number, the digits whole in their head now from all the surfaced fragments. The shopkeeper's phone rings beside them on the bench; they could ignore it the way they have been ignoring all the others. They do not. They look up at the sound, see the protagonist, pick up. Both of them hold their phones across the small distance between path and bench.
 
-The dial bridges intention, not space. Chosen presence rather than a closing of distance. Two acts at once: choosing to reach, and finally attaching the name to the number that has been sitting unnamed in the protagonist's phone the whole game. The few steps between path and bench are easy; the choice to be reached, and to reach, is the part that took the whole game. After the call the protagonist crosses, sits beside the shopkeeper on the bench. The call ends there.
+The dial bridges intention, not space. Chosen presence rather than a closing of distance. Two acts at once: choosing to reach, and finally attaching the name to the number that has been sitting unnamed in the protagonist's phone the whole game. The few steps between path and bench are easy; the choice to be reached, and to reach, is the part that took the whole game.
+
+The call ends. The protagonist crosses, sits beside the shopkeeper on the bench. Credits roll over the rally that follows: the protagonist on the left, the shopkeeper on the right, the championship spot held by the actual person at last. The daily thing the protagonist did alone is finally done together.
 
 ---
 
-## Credits over the rally
+## Postgame
 
-Credits roll over a rally. The protagonist on the left of the court, the shopkeeper on the right, the ball moving between them. The first rally the two of them have ever played. The championship spot at the top of Construction held a substitute for the whole game; the actual person stands in it now, and the daily thing the protagonist did alone is finally done together. The rally is the proof. Hold the figures the way the rest of Construction holds them: full, present, drawn with the same care given to every coach-partner across the climb. Let the volley carry its own tempo; the credits sit on top of it without interrupting.
+Rallying with the shopkeeper, on the right side of the court that used to be the championship spot. The cliff stays returnable through the now-unlocked gate; a place to sit, look at the sea, listen.
 
----
-
-The artist world bible holds the world. This document holds the person at its centre. When the two disagree, the bible is canon for the world and this document is canon for them.
+Construction has its centre back, as the actual relationship rather than the substitute. The protagonist still loves the game. They still love the friend at the stall. The structure still stands; the difference is that the person it was built around is in it now.

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -18,7 +18,7 @@ Not a tragic figure, not melodramatic, not a person in collapse. Someone who bui
 
 ## What they lost, what they built
 
-They lost a friend years ago in something reckless at the cliff. The shopkeeper was there. The protagonist was not. That asymmetry has sat between them ever since. Recently enough that it is not healed, long enough that they have built a structure around it.
+They lost a friend years ago in a cliff-jumping accident. Cliff jumping was a normalised activity in the friend group, dangerous and routine for them, until it wasn't. The shopkeeper was there that day, jumping with the friend. The protagonist was not. Whether they ever went jumping with the group, or always declined, is a question the profile does not answer. The asymmetry of that day has sat between them ever since: one survivor on the cliff, one survivor who was elsewhere. Recently enough that it is not healed, long enough that they have built a structure around it.
 
 Construction is that structure. The garden, the stall, the rally, the friend at the counter with their head tilted toward the play. They did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held. The hiding is the by-product. The holding is the point.
 
@@ -64,7 +64,7 @@ The album fills as the protagonist works. The shopkeeper's younger sister has he
 
 A layer underneath the structure. It sits next to the grief and the becoming-champ pull, not under them.
 
-The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. The structure holds against the loss; it also holds against this. The two are related and distinct. Grief is what they are sheltering from. The void is what they are resisting.
+The pull is the urge to do the destructive thing when nothing forces it. To jump from the bridge. To swerve into traffic. The cliff is the specific shape of this for them: the place the friend died, the place the protagonist did not go that day. The structure holds against the loss; it also holds against this. The two are related and distinct. Grief is what they are sheltering from. The void is what they are resisting.
 
 It surfaces in places the artist and animator can feel for, not script:
 

--- a/designs/characters/protagonist.md
+++ b/designs/characters/protagonist.md
@@ -42,7 +42,7 @@ Hold this as quiet weight in how they treat the climb: not triumph, not desperat
 
 The doubled pull is what makes the championship win land the way it does. Both meanings are satisfied at the same beat and neither was the thing the protagonist actually needed. The win is the break. The construct cannot hold itself together once its central goal has been reached and proved meaningless.
 
-At the win the count completes; the digits land; the protagonist sees them, and they look weirdly familiar. The number has been sitting in their phone the whole game. The recognition does not quite land yet.
+At the win the count completes; the digits land; the protagonist sees them, and they look weirdly familiar. The number has been sitting in their phone the whole game. The connection does not form. The digits stay digits.
 
 ---
 
@@ -50,11 +50,9 @@ At the win the count completes; the digits land; the protagonist sees them, and 
 
 Reconstruction runs on dread. The shopkeeper went missing at the break and the protagonist has been afraid the friend's path has been followed. The driving force is the search for what happened, where they have gone, whether it is too late. The work is the search-for-confirmation, all of it shadowed by the fear that the confirmation will be terrible.
 
-The phone is theirs to hold the whole game. The shopkeeper's number sits in the call log or the contacts list, unnamed: deleted, never saved, or held by the device as digits without labels. They scroll past it sometimes. They know whose it is and they do not know whose it is, in the way a person can hold a thing in two halves at once.
+The phone is theirs to hold the whole game. A number sits in the call log or the contacts list, unnamed: deleted, never saved, or held by the device as digits without labels. They scroll past it sometimes. They carry it without naming it.
 
-The player has the phone throughout. They can dial the unnamed number from Construction onward. It never connects. The shopkeeper has withdrawn and is not picking up. The unanswered ring is the player-facing weight of the protagonist's reach without contact.
-
-Across Reconstruction the digits surface in Reality where they should not be: written on the back of a found photo, etched on the closed shop's sign, scrawled in the workshop, half-spoken by a coach mid-rally, mentioned by the sister as an area code. Each fragment tightens the recognition. By late Reconstruction the protagonist knows whose it is. The almost-dial recurs across the arc: hand-to-pocket after a coach's memory, the phone out after a heavy photo find, a draft message left open and never sent, a voicemail attempt that hangs up before saying anything. None connect.
+The player has the phone throughout. They can dial the unnamed number from Construction onward. It never connects. The unanswered ring is the player-facing weight of the protagonist's reach without contact. The protagonist does not know whose number it is. The number stays unnamed across Reconstruction, dialable, never picked up. The reveal is held until the cliff.
 
 The album fills as the protagonist works. The shopkeeper's younger sister has held the half-filled book the whole time; finding the scattered photos is the protagonist's work. When it fills enough the hidden compartment opens. The key is inside. The sister hands it to them.
 
@@ -84,9 +82,11 @@ The protagonist returns to the garden with the key from the album. They walk to 
 
 A bench sits at the cliff edge, dedicated to the friend who died. The shopkeeper is on the bench, alive. The dread inverts to relief. The fear was wrong; they are still here, withdrawn, refusing calls, but here.
 
-The bench is a few steps away. The protagonist could close that distance silently. They do not. They take out their phone and dial the unnamed number, the digits whole in their head now from all the surfaced fragments. The shopkeeper's phone rings beside them on the bench; they could ignore it the way they have been ignoring all the others. They do not. They look up at the sound, see the protagonist, pick up. Both of them hold their phones across the small distance between path and bench.
+Recognition lands. The unnamed number in the phone, the world record they reached, the digits the championship match resolved on, the person on the bench: all the same number, held unnamed all along, only now legible. The connection forms in the seeing.
 
-The dial bridges intention, not space. Chosen presence rather than a closing of distance. Two acts at once: choosing to reach, and finally attaching the name to the number that has been sitting unnamed in the protagonist's phone the whole game. The few steps between path and bench are easy; the choice to be reached, and to reach, is the part that took the whole game.
+The bench is a few steps away. The protagonist could close that distance silently. They do not. They take out their phone and dial the number, knowing now whose it is. The shopkeeper's phone rings beside them on the bench; they could ignore it the way they have been ignoring all the others. They do not. They look up at the sound, see the protagonist, pick up. Both of them hold their phones across the small distance between path and bench.
+
+The dial bridges intention, not space. Chosen presence rather than a closing of distance. Two acts at once: choosing to reach, and finally attaching the name to the number that has sat unnamed in the protagonist's phone the whole game. The few steps between path and bench are easy; the choice to be reached, and to reach, is the part that took the whole game.
 
 The call ends. The protagonist crosses, sits beside the shopkeeper on the bench. Credits roll over the rally that follows: the protagonist on the left, the shopkeeper on the right, the championship spot held by the actual person at last. The daily thing the protagonist did alone is finally done together.
 


### PR DESCRIPTION
Reorders sections so the doc walks the protagonist through the game in the order a player meets them. Folds three accreted interior-layer sections into their arc beats, integrates the credits coda, trims redundant restatements. Roughly net-flat on word count.

Part of Mission Page One's restructure round, working from the locked narrative canon. Companion PRs land alongside for the bible, spike concept docs, and tech-context.