### PR TITLE
docs: restructure concept docs against locked canon

### DIFF
--- a/designs/concept/00-three-styles.md
+++ b/designs/concept/00-three-styles.md
@@ -47,7 +47,7 @@ The two acts use the two styles in different proportion. Part 1 is mostly Constr
 
 These bind the styles together. The per-arc docs do not contradict them.
 
-**Everyone is real.** The supporting cast in Construction is the real cast from the protagonist's life, rendered young, vibrant, helping. The same people exist in Reality at their actual ages. Two asset sets per cross-style character. The exception is the champ: Construction-only, the dead friend rendered as the championship final, no Reality counterpart.
+**Everyone is real.** The supporting cast in Construction is the real cast from the protagonist's life, rendered young, vibrant, present. The same people exist in Reality at their actual ages. Two asset sets per cross-style character. The exception is the champ: Construction-only, the dead friend rendered as the championship final, no Reality counterpart.
 
 **The hook is in dialogue, not HUD.** The world record is named by a character in the first session. The number is on a HUD; the meaning is not.
 

--- a/designs/concept/00-three-styles.md
+++ b/designs/concept/00-three-styles.md
@@ -7,7 +7,7 @@ This is a working set of docs. Refinement passes follow.
 ## Map
 
 - This doc: the game's overall shape and how the three styles fit together.
-- `01-construction.md`: Part 1. The bright world, the tournament, the cast, the rally, the count.
+- `01-construction.md`: Part 1. The vibrant world, the tournament, the cast, the rally, the count.
 - `02-cracks-and-break.md`: cracks across Part 1, the championship win that lands wrong, the involuntary walk through the hometown.
 - `03-reconstruction.md`: Part 2. Dread, the photo album, the sister, the unnamed number, the search.
 - `04-reality.md`: Reality as a style. Visual register, audio register, the structural shape of a Reality scene.
@@ -17,7 +17,7 @@ This is a working set of docs. Refinement passes follow.
 
 Volley holds two worlds. The player meets the first as the world. The second arrives later and is the one that was always there.
 
-**Construction** is the bright one. A garden in late afternoon, a stall against the inside wall, a racquet on the left, a friend's head turned toward the play. Saturated colour, generous light. Volleyball lives here and only here. The protagonist built it and keeps it tending. The warmth in it is real; the rendering is the pretense.
+**Construction** is the vibrant one. A garden in late afternoon, a stall against the inside wall, a racquet on the left, a friend's head turned toward the play. Saturated colour, generous light. Tennis lives here and only here. The protagonist built it and keeps it tending. The warmth in it is real; the rendering is the pretense.
 
 **Reality** is the protagonist's actual hometown. A small coastal town on the Welsh and Cornish coast in an imagined warmer climate: painted terraces in seaside colours, whitewashed walls, palm trees in places, Mediterranean light on a British coastline. The same people live here at their actual ages. One of them, the friend from the stall, has been pushed away. Reality is gold-hour, weighted, plainer.
 

--- a/designs/concept/00-three-styles.md
+++ b/designs/concept/00-three-styles.md
@@ -85,7 +85,7 @@ From `01-construction.md`: the encounter shape per round. Partner unlock cadence
 
 From `02-cracks-and-break.md`: crack pacing across idle play. Tonal-vs-meta crack mix. How the cracks behave during the championship attempt itself.
 
-From `03-reconstruction.md`: photo count across Part 2. Per-photo scene shape. How the unnamed-number recognition surfaces in Construction without breaking the no-concrete-leakage rule. Cliff-trigger gate.
+From `03-reconstruction.md`: photo count across Part 2. Per-photo scene shape. Cliff-trigger gate. Bridge unlock signal after the break.
 
 From `04-reality.md`: per-scene state persistence. The interaction surface vocabulary. How dialogue layers across return visits.
 

--- a/designs/concept/00-three-styles.md
+++ b/designs/concept/00-three-styles.md
@@ -1,113 +1,92 @@
 # The Three Styles
 
-The high-level structure of Volley as a game. This doc carries the architecture; per-arc docs in this folder carry the detail.
+The high-level architecture of Volley as a game. This doc carries the shape and how the three styles relate; per-arc docs in this folder carry the detail.
 
 This is a working set of docs. Refinement passes follow.
 
 ## Map
 
-- This doc: the game's overall shape and the synthesis index.
-- `01-construction.md`: the bright world, the cast, the shopkeeper psychology, the tournament structure, the champ, the rally and the count.
-- `02-cracks-and-break.md`: the wall thinning and the wall coming down.
-- `03-reconstruction.md`: the long arc after the break, the bidirectional carry, the reconciliation mechanic.
-- `04-reality.md`: the second style; the hometown, the cast in Reality, the photo book, the cliff.
-- `05-postgame.md`: the call, the seashell, what the bright world becomes after.
+- This doc: the game's overall shape and how the three styles fit together.
+- `01-construction.md`: Part 1. The bright world, the tournament, the cast, the rally, the count.
+- `02-cracks-and-break.md`: cracks across Part 1, the championship win that lands wrong, the involuntary walk through the hometown.
+- `03-reconstruction.md`: Part 2. Dread, the photo album, the sister, the unnamed number, the search.
+- `04-reality.md`: Reality as a style. Visual register, audio register, the structural shape of a Reality scene.
+- `05-postgame.md`: the cliff, the call, the credits, the postgame rally.
 
-The earlier narrative pass at `designs/02-alpha/01-world-and-narrative.md` is raw material for these docs. Pieces that work are kept; pieces that do not are reframed or dropped. The picked-up section below names the deltas.
+## Two worlds, one game
 
-## What the game is
+Volley holds two worlds. The player meets the first as the world. The second arrives later and is the one that was always there.
 
-The protagonist holds a racquet. Their stated goal is to beat the world volley record. Friends help them along the way. The count climbs, the rally tiers climb with it, the friends keep showing up. The hook arrives in the friend's voice in the first session, not on a HUD; the count gives a number, the friend gives the number meaning.
+**Construction** is the bright one. A garden in late afternoon, a stall against the inside wall, a racquet on the left, a friend's head turned toward the play. Saturated colour, generous light. Volleyball lives here and only here. The protagonist built it and keeps it tending. The warmth in it is real; the rendering is the pretense.
 
-What the player does not know yet: the world record is a phone number. The shopkeeper's. Every volley counts toward dialling someone the protagonist could reach but won't. The construction is a coping shape; reaching the record means making the call.
+**Reality** is the protagonist's actual hometown. A small coastal town on the Welsh and Cornish coast in an imagined warmer climate: painted terraces in seaside colours, whitewashed walls, palm trees in places, Mediterranean light on a British coastline. The same people live here at their actual ages. One of them, the friend from the stall, has been pushed away. Reality is gold-hour, weighted, plainer.
 
-The bright world is a construction the protagonist is actively maintaining. It takes energy to keep. The warmth in it is real; the pretense is the rendering. The game is the arc of that pretense thinning, the wall coming down, and the protagonist learning to live without it.
+The player learns Construction is a construct only as the climb cracks open. The garden the player has been rallying in is the protagonist's memory of their actual garden in Reality, sprucing it up. Constructed garden and real garden remain separate places.
 
-## The three styles
+## The garden is the meeting point
 
-**Construction.** The bright world. Saturated, full, helping. Volleyball lives here; the count is the engine; the world record is the goal. The protagonist's pretense actively maintained against a loss they have not yet been able to face. Detail in `01-construction.md`.
+The garden is the one venue where Construction and Reality overlap. Other Construction venues are purely fantastic, with no Reality counterpart. The garden's out-of-place-out-of-time feel comes from being the one venue grounded in the real hometown.
 
-**Reality.** A complete second style. Visually distinct from Construction: gold-hour, weighted, plainer, characters at their actual ages. Story-driven; layered scenes the player walks into. One place, the protagonist's hometown, geographically static with content added across the arc. Detail in `04-reality.md`.
+The title carries the weight. Literal place. Tended thing. Where things grow: rally, obsession, memory. Pre-Fall innocence preserved. Walled enclosure.
 
-**Reconstruction.** The arc. The long phase after the break in which the wall stays down and the player can travel between Construction and Reality at will. Not a third visual style; a meta-state of free travel and bidirectional carry. Reconciliation lives inside Reconstruction as the actions the player takes. Detail in `03-reconstruction.md`.
+## One locked gate
 
-## The five movements at a glance
+There is one locked gate in the whole game. In the garden. Walking through it transitions to Reality. The cliff is on the other side. The gate opens once, late, when the sister hands over the key.
 
-1. **Construction.** The pretense actively maintained. The rally climbs toward the record. The count is visible; the goal is named in dialogue. (Detail: `01-construction.md`.)
-2. **Cracks.** Reality leaks into the construction in small atmospheric ways. Each crack is dismissible; the cumulative pressure matters. (Detail: `02-cracks-and-break.md`.)
-3. **The break.** The wall comes down once. Cumulative cracks plus a singular rupture. The player is pulled into Reality involuntarily for the first time. (Detail: `02-cracks-and-break.md`.)
-4. **Reconstruction.** The long arc. Free travel between styles; bidirectional carry; reconciliation actions accumulate; the cliff visit closes the arc. (Detail: `03-reconstruction.md`.)
-5. **The call.** Reaching the world record means dialling the shopkeeper. Peace is the call made. (Detail: `05-postgame.md`.)
+## The two-act spine
 
-After the call: postgame, with the champ gone and a seashell in their place.
+Volley is shaped in two acts.
+
+**Part 1 is Construction.** The protagonist climbs the volley world ladder. Each main venue hosts one round; coach-partners train them in mechanics that compose into the kit; the championship sits at the top. The stated goal is the world record. The cracks accumulate. The win arrives. The win lands wrong.
+
+**Part 2 is Reconstruction.** The construct cannot hold itself together once its central goal has been achieved and proved meaningless. The shopkeeper is missing. The protagonist searches Reality for traces of where they went, fearing the worst, while the player carries a phone with the unnamed number that never connects. The album fills, a key falls out, the gate opens, the cliff is on the other side.
+
+The two acts use the two styles in different proportion. Part 1 is mostly Construction, with Reality leaking in through cracks. Part 2 lives in both, with Reality carrying the search and Construction holding the rally that surfaces what the protagonist is searching for.
 
 ## Cross-style principles
 
-These principles bind the styles together; the per-arc docs should not contradict them.
+These bind the styles together. The per-arc docs do not contradict them.
 
-- **Everyone is real.** The supporting cast in Construction is the real cast from the protagonist's life, rendered young / vibrant / helping. The same people exist in Reality at their actual ages. Two asset sets per character that appears in both. Exception: the champ (Construction-only; their reality is the cliff).
-- **The hook is in dialogue, not HUD.** The world record is named by a character (probably the friend at the stall) in the first session. The number is on a HUD; the meaning is not.
-- **Cracks are tonal, not concrete.** A real-world object literally appearing in Construction reads as a flag the player can point at. A colour shift or a beat in a partner's posture is harder to name and easier to absorb. Concrete leakage breaks the deniability the cumulative shape needs.
-- **Reconstruction is not a third visual style.** The two styles stay distinct. Reconstruction's signal is the carry, plus a gradual weathering of Construction's saturation, plus play-level differentiators (score hidden in Construction, champ dialogue softens, audio shifts).
-- **Reality is finite hand-crafted content.** One place, built once, with iterative additions across Reconstruction. Reality cannot be procedural; the team builds each scene.
+**Everyone is real.** The supporting cast in Construction is the real cast from the protagonist's life, rendered young, vibrant, helping. The same people exist in Reality at their actual ages. Two asset sets per cross-style character. The exception is the champ: Construction-only, the dead friend rendered as the championship final, no Reality counterpart.
+
+**The hook is in dialogue, not HUD.** The world record is named by a character in the first session. The number is on a HUD; the meaning is not.
+
+**Cracks are tonal and meta-contextual, never concrete.** A real-world object literally appearing inside Construction reads as a flag the player can point at. A flicker in the venue light, a music cue that skips, a UI element that blinks the wrong colour, a loading screen that says something it should not: these are easier to absorb and harder to name. Concrete leakage breaks the deniability the cumulative shape needs.
+
+**The unnamed number is load-bearing across both acts.** The shopkeeper's number sits in the protagonist's phone, unnamed. The player has full control of the phone throughout Construction, Reconstruction, and the cliff. Dialling never connects until the final beat. The unanswered ring is the player-facing weight of the protagonist's reach without contact.
+
+**Reality is finite hand-crafted content.** The hometown is built once with iterative additions across Part 2. Reality cannot be procedural; the team builds each scene.
+
+**The period is pre-smartphone.** Late 90s or early 2000s as a tonal range. Phones flip or candy-bar or land-line. Numbers held in heads or written on paper. The unnamed-number mechanic depends on the period.
 
 ## What this teaches each surface
 
-- **Artist world bible**: two asset sets per character that appears in both styles (champ is the exception). Reconstruction's visual signal is the carry plus weathering, not a third render. Cracks are tonal and atmospheric; do not draw concrete reality-leaks.
-- **MC profile**: the protagonist's reconciliation arc is the spine of their interior life. The call-of-the-void layer the profile already names becomes legible as the resistance to crossing into Reality. The cliff is where that resistance is met head-on.
-- **Tech-context**: the rally tooling holds Construction. Reality's tooling is its own thing: layered scene-state, contextual interactions, dialogue, descriptive prose, the present-and-attentive puzzle shape, the bidirectional carry. SH-279 is the right place to spike this.
-- **Audio (SH-281)**: a style per phase. Construction is synthetic / bright / energetic; Break is abstract synth, harsh, minimalist; Reality is acoustic with bustle and wind; Reconstruction is synth and acoustic in conversation, escalating to full orchestra by the end.
+The artist world bible holds the visual canon and the cast. The concept docs hold the structural spine. The character docs hold interior life. The audio direction (SH-281) holds the music arc. SH-279 holds the Reality gameplay tooling.
+
+Each cross-style character has two asset sets. The champ is the exception. Cracks are tonal and atmospheric; concrete reality-leaks are out. Reality is hand-crafted scene content, gated by photos. The photo album and the unnamed number are the load-bearing mechanics of Part 2.
 
 ## What this teaches the production
 
-- Construction's content scales (procedural rally, item economy, partner system).
-- Reality's content does not. The hometown is built once with iterative additions across Reconstruction. The cliff is a separate location built once. Finite hand-crafted content.
-- Reconstruction's length is a budget knob: more reconciliation actions means longer arc but more content to build.
-- Idle pacing means the cracks need to escalate slowly enough that month-long players see them as cumulative rather than clustered around early sessions.
-- The cast doubles in Reconstruction (each supporting-cast character with a Reality-side asset). Worth bounding the partner count early.
+Construction's content scales: procedural rally, item economy, partner system, tournament rounds. Reality's content does not: the hometown is built once with iterative additions; the cliff is a separate location built once.
 
-## What we are picking up from the prior narrative pass
+Idle pacing means the cracks need to escalate slowly enough that month-long players read them as cumulative rather than clustered around early sessions.
 
-Strong keeps from `designs/02-alpha/01-world-and-narrative.md`:
+The cast doubles in Part 2 (each cross-style character with a Reality-side asset). Worth bounding the partner count early.
 
-- The world record is the shopkeeper's phone number. The hook resolves into the call.
-- Peace is the call made.
-- The shopkeeper is the friend who got pushed away. Same person as the friend at the stall. Two renders.
-- The champ is the dead friend. Construction only. Returns as a partner once the cliff is faced.
-- The hometown is the reality place. Coastal, British-seaside-meets-southern-Spain.
+## Prototype scope
 
-Reframings:
-
-- The shopkeeper's role in the death has shifted from "tried to help after" to "involved but not responsible." Something else caused it; the shopkeeper was present, entangled, a daily reminder of the failure. This sharpens why the protagonist blocks them out and why the call is hard.
-- The post-break mechanic in the prior doc was badge activation (slotting narrative items into milestone badges). The new architecture replaces this with the bidirectional carry. Badge activation may persist as one expression of the carry inside Construction, or be dropped entirely. SH-279 will decide.
-- The narrative doc framed the post-break phase as a single arc through denial-to-acceptance. The new architecture splits it into Reconstruction (the arc) and Reconciliation (the actions inside it).
+Per SH-275, the prototype delivers Part 1's first venue: the garden. Martha as the coach, one mechanic she teaches, one round match. Part 2 and the cliff are post-prototype.
 
 ## Open questions (synthesis index)
 
-The questions live in their respective per-arc docs; this is the index.
+The questions live in the per-arc docs; this is the index.
 
-From `01-construction.md`:
-- Gym-leader / encounter shape. The "leaders as metaphors" framing reads as too on-the-nose (close to Omori). Currently being reworked: a venue-tied encounter involving the partner, off the main flow, in a shared themed battle space.
-- Partner unlock cadence inside the gym-leader-vs-partner shape.
+From `01-construction.md`: the encounter shape per round. Partner unlock cadence. Mechanic-per-coach specifics. Round-match win condition.
 
-From `02-cracks-and-break.md`:
-- Crack pacing. Cracks tied to count milestones, playtime, story flags, or a combination?
-- Cracks as deniable in an idle context. Burst-player vs all-night-grinder pacing.
+From `02-cracks-and-break.md`: crack pacing across idle play. Tonal-vs-meta crack mix. How the cracks behave during the championship attempt itself.
 
-From `03-reconstruction.md`:
-- Reconciliation action count. 4–6 or 5–7?
-- Action shape. Memory faced, character encountered, small task, or varying?
-- Bridge unlock signal. UI affordance, character moment, music shift?
-- Cliff trigger. What unlocks the cliff dip late in Reconstruction?
-- Visual language of the carry.
+From `03-reconstruction.md`: photo count across Part 2. Per-photo scene shape. How the unnamed-number recognition surfaces in Construction without breaking the no-concrete-leakage rule. Cliff-trigger gate.
 
-From `05-postgame.md`:
-- Reality cycling post-call. After the call, does the game continue, close, or open into a Regret-style alt-perspective?
+From `04-reality.md`: per-scene state persistence. The interaction surface vocabulary. How dialogue layers across return visits.
 
-## What this unblocks
-
-- The artist world bible can name the three styles and the five movements, with content fills proceeding once the open questions on action count, crack pacing, and the encounter shape are answered.
-- SH-279 (tech spike on reality gameplay) absorbs the hometown structure, the layered-scene puzzle shape, and the bidirectional carry.
-- SH-281 (audio direction) drafts the music style per phase.
-- Future content tickets live downstream of these per-arc docs reaching consensus.
-- The MC profile can deepen with the call-of-the-void resistance mapped onto the cliff's chosen-acceptance shape.
+From `05-postgame.md`: what Construction looks like in postgame with the championship spot occupied by the shopkeeper. Whether the cliff becomes a returnable place after the call.

--- a/designs/concept/01-construction.md
+++ b/designs/concept/01-construction.md
@@ -1,100 +1,108 @@
 # Construction
 
-The bright world. The pretense the protagonist is actively maintaining. This doc carries Construction's detail; high-level architecture lives in `00-three-styles.md`.
+Part 1. The bright world the protagonist is actively maintaining, the tournament shape the climb takes, and the rally that drives it. High-level architecture lives in `00-three-styles.md`; the cracks and the win that breaks Construction live in `02-cracks-and-break.md`.
 
 ## What Construction is
 
-The garden, the stall, the racquet, the rally. Saturated colour, generous light, surfaces that gleam, shadows held warm. Characters drawn young and full and helping. Volleyball lives here and only here. The structure is a tournament: the protagonist is climbing the volley world ladder toward the championship.
+The garden, the stall, the racquet, the rally. Saturated colour, generous light, surfaces that gleam, shadows held warm. Characters drawn young and full and helping. Volleyball lives here and only here.
 
-Construction is a coping shape. Spiritfarer is the closest playable precedent: "We've only created a playground and framework for you to deal with your own emotions" (Nicolas Guérin, Thunder Lotus). The bright world is honest about being a defence. The warmth in it was always real; the pretense is the rendering, not the warmth itself.
+Construction is the structure the protagonist built to keep going. The warmth in it was always real; the rendering is the pretense. They did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held.
 
 The artist's hardest job lives here. Construction must be straight-up enjoyable as an idle pong game for the player who never thinks about the narrative. The cracks come later (`02-cracks-and-break.md`); if they arrive before the player has good reason to want the rally to keep going, they have nothing to crack.
 
+## The hook
+
+The protagonist holds a racquet. The first session opens in the friend's voice at the stall: chase the world volley record. The count climbs. The friend gives the number meaning.
+
+What the player does not know yet: the world record is a phone number. The shopkeeper's. Every rally is the protagonist's unconscious reach. The count climbing is the protagonist almost-dialling without admitting they want to. The bright world's whole engine is the substitute relationship being maintained against the day the real one becomes possible.
+
 ## The cast
 
-The cast splits into two groups. The supporting cast are real people from the protagonist's life, rendered in the bright world. The player will see two asset sets for each: a Construction-side rendering (young, vibrant, helping) and a Reality-side rendering (their actual age, plainer, in their actual life). The opposing cast is just one person: the champ, the dead friend, who sits at the top of the tournament ladder.
+The cast splits into two groups. The supporting cast are real people from the protagonist's life, rendered in Construction. The player will see two asset sets for each: a Construction-render (young, vibrant, helping) and a Reality-render (their actual age, plainer, in their actual life). The opposing cast is one person: the champ, who sits at the top of the tournament ladder.
 
 ### Supporting cast
 
-- **The protagonist.** Drawn like any other character; the player needs to see them to connect to them. Construction-render and Reality-render, same shape as everyone else. The Construction-render is what the player connects to throughout the bright world; the Reality-render is the protagonist as they actually are. The two stay distinct; the protagonist's image does not transform across the arc. The player gets the contrast by switching styles.
-- **The shopkeeper / friend at the stall.** The warmth at the centre of the venue, in Construction. In reality, this is someone the protagonist has pushed away. Same person, two renders. The shopkeeper leaves the construction at the break (`02-cracks-and-break.md`) and returns at the call as the final partner on the right side of the court (`05-postgame.md`). (See "Why the shopkeeper is at the stall" below.)
-- **Martha and the partners.** Real people the protagonist knew, summoned into the bright world as the protagonist's coaches and training partners. Each has a real-world counterpart the player can meet during Reconstruction. (See "The coaches" below.)
-- **The tinkerer.** Real person, the shopkeeper's younger sister. Holds the photo book in Reality (`04-reality.md`).
+**The protagonist.** Drawn like any other character. The player needs to see them to connect to them. Construction-render and Reality-render, same shape as everyone else. The Construction-render is who the player connects to throughout Part 1. The two stay distinct; the protagonist's image does not transform across the arc. The contrast lives in the style-switch.
+
+**The shopkeeper / friend at the stall.** Behind the counter of the small wooden stall in the garden. The warm centre of the venue. In Reality, the same person is alive in the hometown, withdrawn, the one the protagonist pushed away. The shopkeeper was at the cliff when the friend died; the protagonist was not. Their relationship is the load-bearing emotional shape of the game.
+
+**Martha and the partners.** Real people the protagonist knew, summoned into Construction as coach-partners. Each has a Reality-render at their actual age in their actual life. Lineage rule: each partner is named for a character from a science-fiction author's work.
+
+**The tinkerer.** The sister's Construction render. Workshop in another corner of the garden. The sister herself lives in Reality (`04-reality.md` for the register, `03-reconstruction.md` for her role with the photo album).
 
 ### Opposing cast
 
-- **The champ.** The dead friend. The championship final. Someone the protagonist looks up to, never a rival; the player the protagonist always admired. No real-world counterpart in person; their reality is the cliff (`04-reality.md`).
+**The champ.** The dead friend, rendered into Construction as the championship final. Someone the protagonist looks up to, never a rival. No Reality counterpart; their reality is the cliff. The champ exits at the end of Part 1.
 
 ## Why the shopkeeper is at the stall
 
 The shopkeeper was there when the friend died. The protagonist was not.
 
-That asymmetry is the wedge. The friend did something reckless, alone except for the shopkeeper, who witnessed it and could not save them. The shopkeeper carries the memory; the protagonist carries the absence. Their grief is not shared in the same direction. Talking to the shopkeeper would mean hearing what happened, and naming where the protagonist was instead. The protagonist pushes them away because the shopkeeper IS the failure of presence, made daily and visible. Not as judgment, the shopkeeper did not cause it; as mirror.
+That asymmetry is the wedge. The friend did something reckless, alone except for the shopkeeper, who witnessed it and could not save them. The shopkeeper carries the memory; the protagonist carries the absence. Talking to the shopkeeper would mean hearing what happened, and naming where the protagonist was instead. The protagonist pushes them away because the shopkeeper IS the failure of presence, made daily and visible. Not as judgment, the shopkeeper did not cause it; as mirror.
 
 The shopkeeper's tries to help after the death were partly their own grief reaching for connection. They got pushed away because the protagonist could not bear what their presence pointed at.
 
-The protagonist's mind cannot let them go either. The shopkeeper is the only one who knows; the only one who could understand. The construction's compromise is precise: keep the shopkeeper present, warm, available; have the relationship that does not require admitting where the protagonist was when the friend died. The friend at the stall, attentive without intruding, is the relationship the protagonist wants AND the relationship they cannot have in reality, rendered as the version they can hold.
+The protagonist's mind cannot let them go either. The shopkeeper is the only one who knows; the only one who could understand. Construction's compromise is precise: keep the shopkeeper present, warm, available; have the relationship that does not require admitting where the protagonist was when the friend died. The friend at the stall, attentive without intruding, is the relationship the protagonist wants AND the relationship they cannot have in Reality, rendered as the version they can hold.
 
-This is why the world record IS the shopkeeper's phone number. Every rally is the protagonist's unconscious reach. The count climbing is the protagonist almost-dialling without admitting they want to. The bright world's whole engine is the substitute relationship being maintained against the day the real one becomes possible.
-
-It is why the championship sits structurally as the final wall. Reaching the champ means reaching the dead friend, which means facing what happened, which means facing the shopkeeper, which means facing where the protagonist was instead.
-
-It is why the call is the ending (`05-postgame.md`). Once the protagonist has faced the cliff (the place they should have been) and reconciled the absence, there is nothing left between them and the shopkeeper. The shared knowledge has been waiting all along.
+This is why the world record IS the shopkeeper's phone number. Every rally is the unconscious reach. Reaching the championship means reaching past the substitute toward the actual call.
 
 ## The tournament
 
-The bright world is shaped as a volley tournament. The protagonist is climbing the ladder; the championship is the world record; the world record is the shopkeeper's phone number. Reaching it means making the call.
+The bright world is shaped as a volley tournament. The protagonist is climbing the ladder; the championship is the world record; the world record is the shopkeeper's phone number.
 
-The structure: each main venue hosts one round of the tournament. The player rallies in that venue with their coach (a partner) until they qualify; then they enter the round, where the coach takes the other side and the player faces them in the round's match. Win the round, advance.
+Each main venue hosts one round. The player rallies in that venue with a coach until they qualify; then they enter the round, where the coach takes the other side and the player faces them in the round's match. Win the round, advance.
 
-Round matches happen in a shared themed battle space, off the main rally flow. The player attempts each round when ready. Win unlocks: the next venue, the next coach, the next mechanic, the next round.
+Round matches happen in a shared themed battle space, off the main rally flow. The player attempts each round when ready. Win unlocks the next venue, the next coach, the next mechanic, the next round.
 
 The championship is the final round, against the champ.
 
 ### The coaches
 
-Each partner is a coach who trains the protagonist in a specific mechanic. The training happens through the rally: the partner is on the right side of the court, and as you rally with them, the mechanic they hold becomes available to you. By qualifying for their round, you have learned what they teach.
+Each partner is a coach who trains the protagonist in a specific mechanic. The training happens through the rally. The partner is on the right side of the court, and as the player rallies with them, the mechanic they hold becomes available. By qualifying for their round, the player has learned what they teach.
 
-Then they take the other side for the round match. The encounter is the test of what they taught you. Master-and-pupil shape. Their mechanic, plus everything you learned from earlier coaches, is in your kit; the round is where you prove you can use it under pressure.
+Then the partner takes the other side for the round match. The encounter is the test of what they taught. Master-and-pupil shape. Their mechanic, plus everything learned from earlier coaches, is in the kit; the round is where the player proves they can use it under pressure.
 
 Each milestone should feel interesting and different from the others. Mechanics compose: by the championship the player has a stack of techniques, each tied to a person who taught them. The kit accumulates with the cast.
 
-Concrete shape of the mechanics is downstream design (one mechanic per coach, each distinct, all working together). What this doc commits is the shape: coach trains the protagonist via the rally, then becomes the opponent in the round, with the mechanic they taught at the centre of that match.
+Concrete mechanics are downstream design. What this doc commits is the shape: coach trains the protagonist via the rally, then becomes the opponent in the round, with the mechanic they taught at the centre of that match.
 
 ### The champ as the championship
 
-The champ is the final coach the protagonist had: the friend they used to play with, who was the best at the game and pushed the protagonist to be better. In the construction, the champ holds the championship spot, a person the protagonist looks up to, never a rival.
+The champ is the final coach the protagonist had: the friend they used to play with, the best at the game, the one who pushed the protagonist to be better. In Construction, the champ holds the championship spot, someone the protagonist looks up to.
 
-In Construction, the protagonist climbs the rounds, learning each coach's mechanic, and eventually qualifies for the championship. The championship match is unwinnable. The wall is exactly there. The break (`02-cracks-and-break.md`) is what happens when the player has been at the championship long enough that the construction can no longer hold them against the impossibility.
-
-Late in Reconstruction, after the cliff visit, the champ shifts. They become recruitable as a partner; the player can put them on the court like any other. The rallies are different with them; they were always the player they admired. The path to the call opens once the champ is a partner the player can rally with, not a championship match they cannot win.
-
-After the call, the champ is gone (`05-postgame.md`).
+The protagonist climbs every round, learning each coach's mechanic, until they qualify for the championship. The match is winnable. The break beat (`02-cracks-and-break.md`) lives in what the win turns out to mean.
 
 ## The rally and the count
 
 The rally is the engine of Construction. Pong-shape court (described in the artist world bible's court section), protagonist on the left with a racquet, coach on the right. The count climbs as long as the rally holds. Items and effects layer on top.
 
-In Construction, the count is visible. The current round's qualifying count gates the next round; the championship's qualifying count is the world record. The champ holds the championship; the player can qualify for the championship match but cannot win it.
+In Construction, the count is visible. The current round's qualifying count gates the next round; the championship's qualifying count is the world record.
 
-In Reconstruction, the count is hidden in Construction. The number can still be checked, but only by visiting somewhere in Reality. See `03-reconstruction.md` for the mechanics.
+In Part 2 the count behaves differently; see `03-reconstruction.md`.
+
+## The unnamed number, in Construction
+
+The shopkeeper's number sits in the protagonist's phone the whole game, unnamed. Period-correct for a flip or candy-bar device. The player has full control of the phone throughout. Dialling never connects.
+
+In Construction, the number is just digits in a contacts list. The protagonist scrolls past it sometimes. The player can dial it any time and hear the unanswered ring. Nothing in Construction tells the player whose number it is. The recognition is held back for Part 2 (`03-reconstruction.md`).
 
 ## Prototype scope
 
-Per SH-275 (define prototype venue scope), the prototype delivers one venue: the garden. That maps to one round of the tournament: Martha as the coach, one mechanic she teaches, one round match in the shared themed battle space. The championship and the rest of the rounds unfold across alpha and beta.
+Per SH-275, the prototype delivers one venue: the garden. That maps to one round of the tournament: Martha as the coach, one mechanic she teaches, one round match in the shared themed battle space. The championship and the rest of the rounds unfold across alpha and beta.
 
-The prototype's job is to land the championship-shape: the protagonist meets a coach, learns from them, qualifies for a round, plays the round match, wins, and gets the felt sense that this is the path. The other rounds are content fills against a structure the prototype proves out.
+The prototype's job is to land the championship-shape: meet a coach, learn from them, qualify for a round, play the round match, win, and feel that this is the path.
 
 ## Open questions
 
 - **Mechanic shape.** What specifically does each coach teach? Concrete pong mechanics like top-spin, lob, smash, drop-shot, defensive dig: or something different? The space is open; what matters is each is interesting, different, and composable.
-- **Round match format.** Pong with items and effects active, 1v1, no partner on court. What's the win condition? First-to-N points? Reach a count threshold against the coach's pressure? Survive a number of returns? Affects the felt difference between rally-mode and match-mode.
+- **Round match format.** Pong with items and effects active, 1v1, no partner on court. What is the win condition? First-to-N points? Reach a count threshold against the coach's pressure? Survive a number of returns?
 - **Tournament round count for the full game.** SH-275 will name venues. One round per venue means tournament length tracks venue count.
-- **Drop-out behaviour.** If the player loses a round, what happens? Re-attempt? Train more? Affects pacing.
+- **Drop-out behaviour.** If the player loses a round, what happens? Re-attempt? Train more?
+- **Encounter shape per round.** The round-match staging needs sharpening; the gym-leader framing reads close to Omori and is being reworked toward something venue-specific.
 
 ## Production notes
 
-- The cast doubles in scope. Protagonist + shopkeeper + tinkerer + 4-6 partners (each in two renders, plus their teaching mechanic), plus the champ (one render, plus their championship match). Worth bounding the partner count early.
-- Construction's content scales (procedural rally, item economy, partner system, tournament rounds). This is the part of Volley that has long-tail content runway.
-- Round matches reuse one battle court re-themed per venue; production-tight versus building unique battle venues.
-- The count's behaviour shifts between Construction and Reconstruction (visible vs hidden); this is one of Construction's load-bearing mechanics. The hidden-count move in Reconstruction is described in `03-reconstruction.md`.
+- The cast doubles in scope. Protagonist plus shopkeeper plus sister plus four to six partners (each in two renders, plus their teaching mechanic), plus the champ in one render with their championship match. Worth bounding the partner count early.
+- Construction's content scales: procedural rally, item economy, partner system, tournament rounds. This is the part of Volley with long-tail content runway.
+- Round matches reuse one battle court re-themed per venue: production-tight versus building unique battle venues.
+- The count's behaviour shifts between Construction and Part 2 (visible vs hidden). See `03-reconstruction.md`.

--- a/designs/concept/01-construction.md
+++ b/designs/concept/01-construction.md
@@ -14,7 +14,7 @@ The artist's hardest job lives here. Construction must be straight-up enjoyable 
 
 The protagonist holds a racquet. The first session opens in the friend's voice at the stall: chase the world volley record. The count climbs. The friend gives the number meaning.
 
-What the player does not know yet: the world record is a phone number. The shopkeeper's. Every rally is the protagonist's unconscious reach. The count climbing is the protagonist almost-dialling without admitting they want to. The bright world's whole engine is the substitute relationship being maintained against the day the real one becomes possible.
+What the player does not know yet: the world record is a phone number. The shopkeeper's. Every rally is the protagonist's unconscious reach. The bright world's whole engine is the substitute relationship being maintained against the day the real one becomes possible.
 
 ## The cast
 

--- a/designs/concept/01-construction.md
+++ b/designs/concept/01-construction.md
@@ -24,7 +24,7 @@ The cast splits into two groups. The supporting cast are real people from the pr
 
 **The protagonist.** Drawn like any other character. The player needs to see them to connect to them. Construction-render and Reality-render, same shape as everyone else. The Construction-render is who the player connects to throughout Part 1. The two stay distinct; the protagonist's image does not transform across the arc. The contrast lives in the style-switch.
 
-**The shopkeeper / friend at the stall.** Behind the counter of the small wooden stall in the garden. The warm centre of the venue. In Reality, the same person is alive in the hometown, withdrawn, the one the protagonist pushed away. The shopkeeper was at the cliff when the friend died; the protagonist was not. Their relationship is the load-bearing emotional shape of the game.
+**The shopkeeper / friend at the stall.** Behind the counter of the small wooden stall in the garden. The warm centre of the venue. In Reality, the same person is alive in the hometown, withdrawn, the one the protagonist pushed away. The shopkeeper was cliff-jumping with the friend the day they died; the protagonist was not there. Their relationship is the load-bearing emotional shape of the game.
 
 **Martha and the partners.** Real people the protagonist knew, summoned into Construction as coach-partners. Each has a Reality-render at their actual age in their actual life. Lineage rule: each partner is named for a character from a science-fiction author's work.
 
@@ -36,11 +36,11 @@ The cast splits into two groups. The supporting cast are real people from the pr
 
 ## Why the shopkeeper is at the stall
 
-The shopkeeper was there when the friend died. The protagonist was not.
+The shopkeeper was on the cliff with the friend the day they jumped. The protagonist was not.
 
-That asymmetry is the wedge. The friend did something reckless, alone except for the shopkeeper, who witnessed it and could not save them. The shopkeeper carries the memory; the protagonist carries the absence. Talking to the shopkeeper would mean hearing what happened, and naming where the protagonist was instead. The protagonist pushes them away because the shopkeeper IS the failure of presence, made daily and visible. Not as judgment, the shopkeeper did not cause it; as mirror.
+That asymmetry is the wedge. Cliff jumping was a normalised activity in the friend group: dangerous, but routine for them, until it wasn't. The shopkeeper was up there too, doing the same thing, and walked away. The friend did not. The shopkeeper carries the memory and the survival; the protagonist carries the absence and the not-being-there. Talking to the shopkeeper would mean hearing what happened, and naming where the protagonist was instead. The protagonist pushes them away because the shopkeeper IS the failure of presence, made daily and visible. Not as judgment, the shopkeeper did not cause it; as mirror, and as the survivor whose survival the protagonist cannot quite hold beside the friend's death.
 
-The shopkeeper's tries to help after the death were partly their own grief reaching for connection. They got pushed away because the protagonist could not bear what their presence pointed at.
+The shopkeeper's tries to help after the death were partly their own grief reaching for connection, the survivor's reach. They got pushed away because the protagonist could not bear what their presence pointed at.
 
 The protagonist's mind cannot let them go either. The shopkeeper is the only one who knows; the only one who could understand. Construction's compromise is precise: keep the shopkeeper present, warm, available; have the relationship that does not require admitting where the protagonist was when the friend died. The friend at the stall, attentive without intruding, is the relationship the protagonist wants AND the relationship they cannot have in Reality, rendered as the version they can hold.
 

--- a/designs/concept/01-construction.md
+++ b/designs/concept/01-construction.md
@@ -1,10 +1,10 @@
 # Construction
 
-Part 1. The bright world the protagonist is actively maintaining, the tournament shape the climb takes, and the rally that drives it. High-level architecture lives in `00-three-styles.md`; the cracks and the win that breaks Construction live in `02-cracks-and-break.md`.
+Part 1. The vibrant world the protagonist is actively maintaining, the tournament shape the climb takes, and the rally that drives it. High-level architecture lives in `00-three-styles.md`; the cracks and the win that breaks Construction live in `02-cracks-and-break.md`.
 
 ## What Construction is
 
-The garden, the stall, the racquet, the rally. Saturated colour, generous light, surfaces that gleam, shadows held warm. Characters drawn young and full, present. Volleyball lives here and only here.
+The garden, the stall, the racquet, the rally. Saturated colour, generous light, surfaces that gleam, shadows held warm. Characters drawn young and full, present. Tennis lives here and only here.
 
 Construction is the structure the protagonist built to keep going. The warmth in it was always real; the rendering is the pretense. They did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held.
 
@@ -14,7 +14,7 @@ The artist's hardest job lives here. Construction must be straight-up enjoyable 
 
 The protagonist holds a racquet. The first session opens in the friend's voice at the stall: chase the world volley record. The count climbs. The friend gives the number meaning.
 
-What the player does not know yet: the world record is a phone number. The shopkeeper's. Every rally is the protagonist's unconscious reach. The bright world's whole engine is the substitute relationship being maintained against the day the real one becomes possible.
+What the player does not know yet: the world record is a phone number. The shopkeeper's. Every rally is the protagonist's unconscious reach. The vibrant world's whole engine is the substitute relationship being maintained against the day the real one becomes possible.
 
 ## The cast
 
@@ -48,7 +48,7 @@ This is why the world record IS the shopkeeper's phone number. Every rally is th
 
 ## The tournament
 
-The bright world is shaped as a volley tournament. The protagonist is climbing the ladder; the championship is the world record; the world record is the shopkeeper's phone number.
+The vibrant world is shaped as a volley tournament. The protagonist is climbing the ladder; the championship is the world record; the world record is the shopkeeper's phone number.
 
 Each main venue hosts one round. The player rallies in that venue with a coach until they qualify; then they enter the round, where the coach takes the other side and the player faces them in the round's match. Win the round, advance.
 

--- a/designs/concept/01-construction.md
+++ b/designs/concept/01-construction.md
@@ -4,7 +4,7 @@ Part 1. The bright world the protagonist is actively maintaining, the tournament
 
 ## What Construction is
 
-The garden, the stall, the racquet, the rally. Saturated colour, generous light, surfaces that gleam, shadows held warm. Characters drawn young and full and helping. Volleyball lives here and only here.
+The garden, the stall, the racquet, the rally. Saturated colour, generous light, surfaces that gleam, shadows held warm. Characters drawn young and full, present. Volleyball lives here and only here.
 
 Construction is the structure the protagonist built to keep going. The warmth in it was always real; the rendering is the pretense. They did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held.
 
@@ -18,7 +18,7 @@ What the player does not know yet: the world record is a phone number. The shopk
 
 ## The cast
 
-The cast splits into two groups. The supporting cast are real people from the protagonist's life, rendered in Construction. The player will see two asset sets for each: a Construction-render (young, vibrant, helping) and a Reality-render (their actual age, plainer, in their actual life). The opposing cast is one person: the champ, who sits at the top of the tournament ladder.
+The cast splits into two groups. The supporting cast are real people from the protagonist's life, rendered in Construction. The player will see two asset sets for each: a Construction-render (young, vibrant, present) and a Reality-render (their actual age, plainer, in their actual life). The opposing cast is one person: the champ, who sits at the top of the tournament ladder.
 
 ### Supporting cast
 

--- a/designs/concept/02-cracks-and-break.md
+++ b/designs/concept/02-cracks-and-break.md
@@ -28,7 +28,7 @@ The win feels off. Like real-world achievement that turns out not to fix the thi
 
 The win IS the break. The construct cannot hold itself together once its central goal has been achieved and proved meaningless. Cumulative cracks have been preparing the player to read what just happened; the win is the singular moment that makes the prior cracks legible as a chord rather than as noise.
 
-At the moment of the win, the count completes. The digits land. The protagonist sees them and they look weirdly familiar. They match the unnamed number in the phone. The recognition does not fully land yet.
+At the moment of the win, the count completes. The digits land. The protagonist sees them, vaguely familiar, and the connection does not form. The number stays unnamed in their phone. Recognition is held until the cliff.
 
 ## After the win: the walk through Reality
 

--- a/designs/concept/02-cracks-and-break.md
+++ b/designs/concept/02-cracks-and-break.md
@@ -1,49 +1,49 @@
 # Cracks and the Break
 
-The wall thinning, then the wall coming down. This doc carries both phases together because they are one continuous beat. High-level architecture in `00-three-styles.md`; what follows here is the detail.
+The wall thinning across Part 1, the championship win that lands wrong, and the involuntary first walk through the hometown. These three beats are one continuous shape and live in one doc. High-level architecture in `00-three-styles.md`; Construction's detail in `01-construction.md`; Part 2 picks up in `03-reconstruction.md`.
 
 ## Cracks
 
-Reality leaks into the construction. Each leak is dismissible on its own. Their cumulative pressure is what matters.
+Reality leaks into Construction in small atmospheric ways across Part 1. Each leak is dismissible on its own. The cumulative pressure is what matters.
 
-Cracks earn dismissibility from prior generosity (Pattern 1 in `designs/research/game-structure-references.md`). The construction has to land as genuinely fun before a single crack works. Spec Ops's first heat shimmer arrives roughly three hours in, after the player has settled into a competent-soldier rhythm; Doki Doki's first poem night arrives after hours of dating-sim warmth; Inscryption's first scrybe-room break arrives once the player has earned the deck. Volley's idle pacing scales these numbers up, but the principle holds.
+Cracks earn their dismissibility from prior generosity. Construction has to land as genuinely fun before a single crack works. Spec Ops's first heat shimmer arrives roughly three hours in, after the player has settled into a competent-soldier rhythm; Doki Doki's first poem night arrives after hours of dating-sim warmth; Inscryption's first scrybe-room break arrives once the player has earned the deck. Volley's idle pacing scales these numbers up; the principle holds.
 
 ### Two kinds of crack
 
-Cracks come in two flavours. Both are intentional and authored; neither is bug-shaped. Both are dismissible.
+**Tonal cracks.** Inside Construction's fiction. A flicker in the venue light. A partner's tilt held a beat too long. A colour cooling at the edge of the frame. A moment of sound that does not match the venue. Atmospheric oddness; the player notices and lets it pass.
 
-**Tonal cracks.** Inside the construction's fiction. A flicker in the venue light, a partner's tilt held a beat too long, a colour cooling at the edge of the frame, a moment of sound that does not match the venue. These read as atmospheric oddness; the player notices and lets it pass.
+**Meta-contextual cracks.** Outside the fiction, in the surfaces around it. After Spec Ops's loading-screen taunts and dialogue-degradation, Doki Doki's interface glitches, Inscryption's desktop-frame breaks. Construction is itself a thing the player is interfacing with; that interface can crack. A music cue that skips. A UI element that blinks the wrong colour. A loading screen that says something it should not. A pause-menu wording that shifts.
 
-**Meta-contextual cracks.** Outside the construction's fiction, in the surfaces around it. After Spec Ops's loading-screen taunts and dialogue-degradation, Doki Doki's interface glitches, Inscryption's desktop-frame breaks. The construction is itself a thing the player is interfacing with; that interface can crack. A music cue that skips. A UI element that blinks the wrong colour. A loading screen that says something it should not. A pause menu where one option's wording shifts. The player half-notices, half-dismisses.
+Both kinds are authored. Both are deniable. The mix is what makes the cumulative weight feel woven rather than singular: tonal cracks live in the world; meta cracks live in the player's interaction with the game.
 
-Both kinds are authored, both are deniable. The mix is what makes the cumulative weight feel woven rather than singular: tonal cracks live in the world, meta cracks live in the player's interaction with the game. Together they signal that something larger is wrong, on multiple surfaces, none of which alone is enough to call.
+Concrete leakage stays out. A real-world object literally appearing on the rack reads as a flag the player can point at; the deniability the cumulative shape needs collapses.
 
-NEVER concrete leakage inside the construction's fiction (a real-world object literally appearing on the rack). That reads as a flag the player can point at; deniability collapses.
+## The championship win
 
-## The break
+The protagonist climbs every round. The obsession with becoming champ deepens. The word does double work: become the champion (win the title) and become the champ (the dead friend rendered as the final). Both pulls live in one motion; the protagonist does not separate them.
 
-The break is the wall coming down. Spec Ops is the structural exemplar: cumulative cracks across seven chapters, then chapter eight is the singular moment that makes the prior cracks legible as a chord rather than as noise. Volley's break is both. The cracks pile up, dismissible. Then one moment is the rupture, and from there reality is in the player's life whether they wanted it or not.
+The player wins the championship. They do beat the champ.
 
-The break's mechanical signature: the player is pulled into Reality involuntarily for the first time. The dip is forced. They walk through the protagonist's hometown. They see the people behind the partners. Martha is the cashier at the actual newsagent. The cliff is somewhere in this geography but not yet visited.
+The win feels off. Like real-world achievement that turns out not to fix the thing it was supposed to fix. Both pulls of becoming-champ are satisfied at the same beat and neither was the thing the protagonist actually needed.
 
-The shopkeeper is not there in the break walk. Some excuse: the shop has a sign on the door (closing hours, "back later", a notice about something), the lights are off, the door is locked. The shopkeeper's face-to-face is held back for the call (`05-postgame.md`). The break shows the player Reality but not the conversation that lives at its centre.
+The win IS the break. The construct cannot hold itself together once its central goal has been achieved and proved meaningless. Cumulative cracks have been preparing the player to read what just happened; the win is the singular moment that makes the prior cracks legible as a chord rather than as noise.
 
-The break ends and the player is back in Construction, but the wall does not go up again. The construction has lost its warm centre: the shop is closed; the friend at the stall is gone. The shopkeeper exists only in Reality from here. Reconstruction begins (`03-reconstruction.md`).
+At the moment of the win, the count completes. The digits land. The protagonist sees them and they look weirdly familiar. They match the unnamed number in the phone. The recognition does not fully land yet.
 
-## The break and the championship
+## After the win: the walk through Reality
 
-The break is what happens after the protagonist has attempted the championship and failed. The attempt is signalled to the player as one shot. The whole climb has been training; the championship is the test; the player thinks they have one chance and they take it.
+The player is pulled into Reality involuntarily for the first time. The protagonist walks through the hometown. Sees the people behind the partners. Martha at the actual newsagent. The others in their actual lives, plainer.
 
-The match is unwinnable. The champ holds the championship; the protagonist has done all the right work and still cannot pass. The break follows immediately. The construction can no longer hold the protagonist against this impossibility, and the wall comes down.
+They discover the shopkeeper is missing. The shop is empty. The door is locked, lights off, a notice on the door. Family worried. The person the protagonist was reaching for without admitting it has actually disappeared.
 
-This shape gives the championship attempt the structural weight that the break needs: the player feels the moment of trying and failing, not the slog of repeated attempts. One attempt, one failure, the wall down. The cumulative cracks have been preparing the player to read what just happened.
+The champ exits at this point. They do not appear in Part 2.
 
-The relationship to the cracks: the cracks have been thinning the wall throughout. The championship attempt is the singular moment that the cracks finally render as legible. Cumulative pressure plus singular rupture, in one beat.
+The break ends. The player is back in Construction, but Construction has lost its warm centre: the shop is closed; the friend at the stall is gone. End of Part 1. Part 2 begins (`03-reconstruction.md`).
 
 ## Open questions
 
-- **Crack pacing.** Cracks tied to count milestones, playtime, story flags, or a combination? Idle players play in spurts over months; cracks that gate on count alone reward grinders.
-- **Cracks as deniable in an idle context.** Idle games are played in short sessions over months. A cumulative crack pattern has to work for both the burst-player and the all-night-grinder. The pattern's pacing across real time vs in-game time is open.
-- **Cracks during a championship attempt.** Should cracks intensify or behave differently while the player is in the championship match itself? The match is where the construction's pressure is highest; that may be where the cracks land hardest.
-- **Tonal vs meta crack mix.** What proportion of each kind of crack across the arc? Meta-contextual cracks are higher-leverage but also higher-impact when they land; over-using them risks signalling too early.
-- **Replay attempts.** The match is signalled as one-shot, but if the player loses and can press play again on the championship, what happens? Possibilities: the championship is structurally one-shot (no replay button); the championship can be re-entered but always loses with diminishing diegetic effect; or the failed attempt is what triggers the break and the championship is not visitable again until reconstruction.
+- **Crack pacing.** Cracks tied to count milestones, playtime, story flags, or a combination? Idle players play in spurts over months; cracks gated on count alone reward grinders.
+- **Cracks as deniable in an idle context.** A cumulative crack pattern has to work for both the burst-player and the all-night-grinder. The pacing across real time vs in-game time is open.
+- **Cracks during the championship attempt.** Should cracks intensify or behave differently during the championship match itself? The match is where the construct's pressure is highest.
+- **Tonal vs meta crack mix.** What proportion across the arc? Meta-contextual cracks are higher-leverage and higher-impact when they land; over-using them risks signalling too early.
+- **The walk through the hometown as the player's first Reality.** How the style-switch is staged, how navigation works in this short forced beat, how it differs from the freer Reality movement of Part 2.

--- a/designs/concept/03-reconstruction.md
+++ b/designs/concept/03-reconstruction.md
@@ -1,56 +1,83 @@
 # Reconstruction
 
-The arc. The long phase between the break and the cliff. The wall stays down; the player can travel between Construction and Reality at will. The protagonist is reconstructing their view of the world. High-level architecture in `00-three-styles.md`.
+Part 2. The arc after the break: dread, the search, the photo album, the unnamed number that almost-dials, the key that opens the gate. High-level architecture in `00-three-styles.md`; the break that opens it in `02-cracks-and-break.md`; Reality as a style in `04-reality.md`; the cliff and the call in `05-postgame.md`.
 
-## What Reconstruction is
+## What Part 2 is
 
-Reconstruction is not a third visual style. The two styles stay distinct: Construction (`01-construction.md`) is still vibrant; Reality (`04-reality.md`) is still gold-hour. Reconstruction is the meta-state in which the player has access to both and can carry across.
+The shopkeeper is missing. The shop is closed. The friend the protagonist was reaching for without admitting it has actually disappeared.
 
-Reconstruction's Construction is missing its warm centre. The shopkeeper left at the break (`02-cracks-and-break.md`); the shop is closed; the stall is empty. The bright world has been hollowed out where it used to be warmest. The protagonist rallies on without them. The shopkeeper exists only in Reality during this arc, reachable through the reconciliation mechanic, until the call returns them to the construction (`05-postgame.md`).
+The protagonist's belief, and the player's: the shopkeeper followed the friend's path. Did something reckless. Is gone. The unnamed number does not connect, and that no-answer is the player-facing weight of the protagonist's ineffectual reach.
 
-Reconstruction must also FEEL different to play, not only look different in the carry. Construction was driven by a visible count climbing toward the championship; if Reconstruction is just more of the same with the cap raised in stages, it will feel like Construction with extra steps. Three changes mark Reconstruction at the play level:
+The driving force is the search. Not "find the shopkeeper" generically: find out what they did, where they went, whether it is too late. The whole arc is the search-for-confirmation, shadowed by the fear that the confirmation will be terrible.
 
-- **The score is hidden in Construction.** In Construction, the count climbs visibly; the player chases the number. In Reconstruction, the number disappears from the rally. The player rallies without knowing how close they are to the call. The number can still be checked, but only by visiting somewhere in Reality (the sister's, the closed shop, the cliff). The score migrates from Construction to Reality. The player has to leave the rally to know how close they are; that is the exact style-shift Reconstruction wants to feel like.
-- **The champ's dialogue softens gradually.** In Construction, the champ's lines are sharp, pushing, the friend's old habit of not letting the protagonist coast. Across Reconstruction the lines soften beat by beat, until late in the arc the champ sounds like a friend again. The shift is in what gets said and how, not in a stat. The player notices the change through the dialogue alone.
-- **Audio shifts.** The construction's bright synthetic music thins and acoustic instruments arrive, with the balance moving toward fuller arrangement by late Reconstruction. Full direction in SH-281.
+This is the act-2 dread. It runs the length of Reconstruction. It inverts at the cliff (`05-postgame.md`).
 
-## The bidirectional carry
+## Where the work happens
 
-The carry is what Reconstruction enables. Bidirectional and selective. Not anything-and-everything: that would open infinite interactions and demand combinatorial content. Each carry is hand-curated for its narrative function.
+Part 2 lives in both styles. Reality carries the search. Construction holds the rally that surfaces what the search needs.
 
-- **Constructs into Reality.** Specific Construction items, characters, or memories can be brought into Reality and used in specific reconciliation scenes. The construction is what the protagonist built to keep going; in Reconstruction, the things they built turn out to be useful in the world they were avoiding. Which constructs are carry-able and which are not is a narrative decision per content beat, not an open mechanic.
-- **Reality into Construction.** Specific real-world acknowledgements feed back into the rally. New venues unlock; coaches gain new lines; the bright world acknowledges what it had been hiding from. Hints for Reality's next reconciliation surface in Construction. Same gate: which acknowledgements bridge back is a curated narrative call.
+Construction in Part 2 is missing its warm centre. The shopkeeper has left the stall; the shop is closed in Reality and unstaffed in Construction. The protagonist rallies on without them. The bright world has been hollowed out where it used to be warmest.
 
-The visual signal of Reconstruction is the act of crossing, plus the persistent presence of one style's elements when the player is in the other. The bridge itself is the new affordance.
+Construction must also feel different to play, not only look hollowed. Three play-level changes mark Part 2:
 
-As the carry accumulates, the bright world ages with the player. Saturation drops a notch; line weight thickens; compositions hold longer pauses. The construction does not visually rebuild; it weathers.
+- **The score is hidden in Construction.** The count climbed visibly through Part 1; in Part 2 the number disappears from the rally HUD. The player rallies without seeing how the digits are filling. The number can be checked, but only in Reality (the sister's, the closed shop, the cliff once unlocked). The score migrates from Construction to Reality. Leaving the rally to know how close they are is the exact style-shift Part 2 wants to feel like.
+- **Coaches' lines reach back.** Each coach who keeps showing up in Construction carries memories of the shopkeeper into the rally between points. Their lines soften, lengthen, surface what they remember. The shift is in dialogue, not in stat.
+- **Audio shifts.** Construction's bright synthetic music thins; acoustic instruments arrive; the balance moves toward fuller arrangement by late Part 2. Full direction in SH-281.
 
-## Reconciliation
+## The photo album
 
-Reconciliation is what the player DOES inside Reconstruction. It is the mechanic that takes the player from the break to the call.
+The album is the spine of Part 2.
 
-The mechanic is the photo book. The sister has the book, but not all of the photos. Some are scattered: lost in the wind off the sea years ago, tucked into other people's drawers, pinned to a noticeboard somewhere. The protagonist begins by sitting with the sister and the book, then goes to find the rest. Each scattered photo found is a reconciliation action: a place to visit, a person to ask, a small attentive thing to do. Each one returned to the book completes a part of the protagonist's history that the shopkeeper kept and the protagonist could not.
+The sister has the album. It is half-filled. There is a hidden compartment at the back that does not open until enough pages are filled.
 
-The full mechanic and the photo arc live in Reality (`04-reality.md`). Reconstruction is the arc-shape; the photo book is the verb.
+Each rally in Construction surfaces a memory. Each memory becomes a photo, or unlocks one already in the album. Each photo points to a place in Reality the shopkeeper might be, or left a trace of. Coaches share their own memories of the shopkeeper as the protagonist rallies with them. The volley is the search done sideways.
 
-Each found photo compounds: the wall thins; the champ's dialogue softens; new venues unlock; the bright world ages. The cumulative effect is the protagonist getting closer to the cliff (where the last photo lives), closer to the champ becoming a partner, closer to the call.
+The found photos compound. Pages fill. The hidden compartment gets closer to opening. The search closes in.
 
-By the end of Reconstruction, the protagonist has reconciled the event and reconstructed their view. The two land together.
+The photo album mechanic is the protagonist saying: someone has been keeping this. The shopkeeper kept the history because the protagonist could not. The sister holds the album because she is not entangled in the absence the way the shopkeeper is.
 
-## The cliff
+## The sister
 
-Late in Reconstruction, the protagonist visits the cliff where the friend died. The cliff is a Reality place; full description in `04-reality.md`. Structurally: it is the chosen-acceptance bookend to the break (forced acceptance) and the location of the last scattered photo. After the visit, the champ shifts from wall to partner; the path to the call opens.
+Less weighted by the death than the shopkeeper. The bridge. She holds the album and the protagonist's first reachable Reality character after the break.
+
+Sitting with her and turning the pages of what is there is the first reconciliation moment. After that, the protagonist goes to find the rest. She receives each found photo. She mentions things in passing as the album fills: an area code she half-remembers, the way her brother used to leave the shop door, what was on the radio that morning.
+
+She is the most-visited Reality character. Her scene supports many returns.
+
+## The unnamed number deepens
+
+Across Part 2 the recognition surfaces in Reality. The digits start showing up in places the protagonist visits. Written on the back of a found photo. Etched on the closed shop's sign. Scrawled on a workbench in the workshop. A coach absent-mindedly says a couple of digits while rallying. The sister mentions an area code.
+
+By late Part 2, the protagonist knows the unnamed contact is the shopkeeper. The number is whole in their head from all the recovered fragments, even as it sits unlabelled in the phone.
+
+### Almost-dials
+
+The player can dial the unnamed number any time. It does not connect. The shopkeeper has withdrawn and is not picking up.
+
+The protagonist almost-dials in specific reconciliation beats: takes the phone out after a heavy photo find, hand-to-pocket after a coach's memory, a draft message left open and never sent, a voicemail attempt that hangs up before saying anything. Each almost-dial is the player-facing weight of the reach without contact.
+
+These almost-dial moments are authored beats threaded through the search, not a uniform mechanic. The phone control stays with the player throughout; the almost-dials are what the protagonist does on their own.
+
+## The key, the gate
+
+The album fills. The hidden compartment opens. The key is inside.
+
+The sister hands it over.
+
+The protagonist returns to the first venue, the garden, with the key in hand. The locked gate at the back of the garden is the one locked gate in the whole game. They walk to it. They unlock it. They walk through to Reality.
+
+The cliff is on the other side. What happens there lives in `05-postgame.md`.
 
 ## Open questions
 
-- **Photo count.** How many scattered photos across Reconstruction? Idle pacing argues 4–6; narrative arc argues 5–7. The answer affects content scope and pacing.
-- **Per-photo scene shape.** Each found photo is a hand-crafted scene. Variety across them: a place to visit, a person to ask, an item to find, a moment to witness. Mix and pacing are open.
-- **Bridge unlock signal.** Reconstruction begins immediately after the break. What does the player see/feel that marks the bridge as available? A UI affordance? A character moment? A shift in the music?
-- **Cliff trigger.** The cliff carries the last photo. Does the cliff unlock when N other photos are found, when a specific photo is found, or via a different gate?
-- **Visual language of the carry.** When the player carries a construct into Reality, what does that look like on screen? An item icon that persists? A character who walks alongside? A note that surfaces in dialogue? Affects the tech-context and the artist's job.
+- **Photo count.** How many photos across Part 2? Idle pacing argues four to six; narrative arc argues five to seven. Affects content scope and pacing.
+- **Per-photo scene shape.** Each found photo is a hand-crafted Reality scene. Variety: a place to visit, a person to ask, an item to find, a moment to witness. Mix and pacing are open.
+- **How recognition surfaces in Construction without breaking the no-concrete-leakage rule.** The number fragments belong in Reality; Construction holds the rally and the coaches' memories. The cracks-style discipline still applies in Part 2.
+- **Cliff-trigger gate.** The hidden compartment opens when the album fills enough. What counts as enough: photo count, specific photo, or a different gate?
+- **Bridge unlock signal.** What does the player see or feel that marks the bridge between Construction and Reality as available, after the break?
 
 ## Production notes
 
-- The photo book and the scattered-photo mechanic are the spine of Reconstruction. SH-279 (tech spike on reality gameplay) absorbs the tooling.
-- Each reconciliation action is a hand-crafted Reality scene. Photo count = scene count. Bound the scope at SH-275 venue scope and Reconstruction length together.
-- The carry's selectivity is a production discipline, not just a narrative one: each carry-able is one entry in a curated list, not an open category.
+- The photo album and the scattered-photos mechanic are the spine of Part 2. SH-279 (tech spike on Reality gameplay) absorbs the tooling.
+- Each found photo is a hand-crafted Reality scene. Photo count equals scene count. Bound the scope at SH-275 venue scope and Part 2 length together.
+- The cast doubles in Part 2 (each cross-style character with a Reality-side asset). Worth bounding the partner count early.

--- a/designs/concept/03-reconstruction.md
+++ b/designs/concept/03-reconstruction.md
@@ -16,7 +16,7 @@ This is the act-2 dread. It runs the length of Reconstruction. It inverts at the
 
 Part 2 lives in both styles. Reality carries the search. Construction holds the rally that surfaces what the search needs.
 
-Construction in Part 2 is missing its warm centre. The shopkeeper has left the stall; the shop is closed in Reality and unstaffed in Construction. The protagonist rallies on without them. The bright world has been hollowed out where it used to be warmest.
+Construction in Part 2 is missing its warm centre. The shopkeeper has left the stall; the shop is closed in Reality and unstaffed in Construction. The protagonist rallies on without them. The vibrant world has been hollowed out where it used to be warmest.
 
 Construction must also feel different to play, not only look hollowed. Three play-level changes mark Part 2:
 

--- a/designs/concept/03-reconstruction.md
+++ b/designs/concept/03-reconstruction.md
@@ -1,6 +1,6 @@
 # Reconstruction
 
-Part 2. The arc after the break: dread, the search, the photo album, the unnamed number that almost-dials, the key that opens the gate. High-level architecture in `00-three-styles.md`; the break that opens it in `02-cracks-and-break.md`; Reality as a style in `04-reality.md`; the cliff and the call in `05-postgame.md`.
+Part 2. The arc after the break: dread, the search, the photo album, the unnamed number that never connects, the key that opens the gate. High-level architecture in `00-three-styles.md`; the break that opens it in `02-cracks-and-break.md`; Reality as a style in `04-reality.md`; the cliff and the call in `05-postgame.md`.
 
 ## What Part 2 is
 
@@ -40,23 +40,17 @@ The photo album mechanic is the protagonist saying: someone has been keeping thi
 
 Less weighted by the death than the shopkeeper. The bridge. She holds the album and the protagonist's first reachable Reality character after the break.
 
-Sitting with her and turning the pages of what is there is the first reconciliation moment. After that, the protagonist goes to find the rest. She receives each found photo. She mentions things in passing as the album fills: an area code she half-remembers, the way her brother used to leave the shop door, what was on the radio that morning.
+Sitting with her and turning the pages of what is there is the first reconciliation moment. After that, the protagonist goes to find the rest. She receives each found photo. She mentions things in passing as the album fills: the way her brother used to leave the shop door, what was on the radio that morning, a song he played too loud.
 
 She is the most-visited Reality character. Her scene supports many returns.
 
-## The unnamed number deepens
+## The unnamed number, in Part 2
 
-Across Part 2 the recognition surfaces in Reality. The digits start showing up in places the protagonist visits. Written on the back of a found photo. Etched on the closed shop's sign. Scrawled on a workbench in the workshop. A coach absent-mindedly says a couple of digits while rallying. The sister mentions an area code.
+The number sits in the phone the same way it sat through Part 1. Unnamed. Dialable. Never picked up.
 
-By late Part 2, the protagonist knows the unnamed contact is the shopkeeper. The number is whole in their head from all the recovered fragments, even as it sits unlabelled in the phone.
+The player can dial it any time. The ring goes unanswered. The shopkeeper has withdrawn and is not picking the phone up for anyone. That no-answer is the player-facing weight of the protagonist's reach across the whole act.
 
-### Almost-dials
-
-The player can dial the unnamed number any time. It does not connect. The shopkeeper has withdrawn and is not picking up.
-
-The protagonist almost-dials in specific reconciliation beats: takes the phone out after a heavy photo find, hand-to-pocket after a coach's memory, a draft message left open and never sent, a voicemail attempt that hangs up before saying anything. Each almost-dial is the player-facing weight of the reach without contact.
-
-These almost-dial moments are authored beats threaded through the search, not a uniform mechanic. The phone control stays with the player throughout; the almost-dials are what the protagonist does on their own.
+The number stays unnamed all the way through Reconstruction. No fragments surface on found photos. No digits get half-spoken by a coach mid-rally. No area code from the sister. Recognition is held back for the cliff (`05-postgame.md`); Part 2's job is the search and the dread, not the dawning.
 
 ## The key, the gate
 
@@ -72,7 +66,6 @@ The cliff is on the other side. What happens there lives in `05-postgame.md`.
 
 - **Photo count.** How many photos across Part 2? Idle pacing argues four to six; narrative arc argues five to seven. Affects content scope and pacing.
 - **Per-photo scene shape.** Each found photo is a hand-crafted Reality scene. Variety: a place to visit, a person to ask, an item to find, a moment to witness. Mix and pacing are open.
-- **How recognition surfaces in Construction without breaking the no-concrete-leakage rule.** The number fragments belong in Reality; Construction holds the rally and the coaches' memories. The cracks-style discipline still applies in Part 2.
 - **Cliff-trigger gate.** The hidden compartment opens when the album fills enough. What counts as enough: photo count, specific photo, or a different gate?
 - **Bridge unlock signal.** What does the player see or feel that marks the bridge between Construction and Reality as available, after the break?
 

--- a/designs/concept/03-reconstruction.md
+++ b/designs/concept/03-reconstruction.md
@@ -6,7 +6,7 @@ Part 2. The arc after the break: dread, the search, the photo album, the unnamed
 
 The shopkeeper is missing. The shop is closed. The friend the protagonist was reaching for without admitting it has actually disappeared.
 
-The protagonist's belief, and the player's: the shopkeeper followed the friend's path. Did something reckless. Is gone. The unnamed number does not connect, and that no-answer is the player-facing weight of the protagonist's ineffectual reach.
+The protagonist's belief, and the player's: the shopkeeper followed the friend's path. Went back to the cliff. Is gone. Cliff jumping was the friend group's normal until the day it wasn't, and the shopkeeper survived once already; the fear is that surviving once was the limit. The unnamed number does not connect, and that no-answer is the player-facing weight of the protagonist's ineffectual reach.
 
 The driving force is the search. Not "find the shopkeeper" generically: find out what they did, where they went, whether it is too late. The whole arc is the search-for-confirmation, shadowed by the fear that the confirmation will be terrible.
 

--- a/designs/concept/04-reality.md
+++ b/designs/concept/04-reality.md
@@ -44,7 +44,7 @@ Reality holds the real-world version of every cross-style character. Each is at 
 
 **The protagonist.** Reality-render of the MC. Older, gentler, less athletic than their Construction-render. Same character, real version.
 
-The champ is Construction-only. No Reality counterpart. Their reality is the cliff (`05-postgame.md`).
+The champ is Construction-only. No Reality counterpart. Their reality is the cliff (`05-postgame.md`): the place the friend group used to jump from, the place the friend died, the place the shopkeeper went back to.
 
 ## Period
 
@@ -54,5 +54,5 @@ Late 90s or early 2000s as a tonal range. Pre-smartphone. Phones flip or candy-b
 
 - Reality is finite hand-crafted content. The hometown is built once with iterative additions across Part 2.
 - The sister is the most-visited Reality character (she holds the photo album). Her scene supports many returns.
-- The cliff is a separate location built once. Used at the chosen-acceptance moment and re-enterable through the unlocked gate after the call (`05-postgame.md`).
+- The cliff is a separate location built once. The same cliff the friend group used as a jumping spot, the same edge the friend went off, the bench at the top dedicated to them. Used at the chosen-acceptance moment and re-enterable through the unlocked gate after the call (`05-postgame.md`).
 - Specific Reality tooling (interaction surfaces, scene state, dialogue, navigation) belongs to SH-279.

--- a/designs/concept/04-reality.md
+++ b/designs/concept/04-reality.md
@@ -40,7 +40,7 @@ Reality holds the real-world version of every cross-style character. Each is at 
 
 **Martha and the partners.** The cashier at the actual newsagent; the others as they actually are. Not coaches here, just people the protagonist knew.
 
-**The shopkeeper.** Present in Reality from the break onward. Not approachable directly until the cliff. The almost-dial mechanic with the unnamed number is the player-facing weight of their absence; detail in `03-reconstruction.md`. The cliff meeting and the call are in `05-postgame.md`.
+**The shopkeeper.** Present in Reality from the break onward. Not approachable directly until the cliff. The unnamed number that never connects is the player-facing weight of their absence; detail in `03-reconstruction.md`. The cliff meeting and the call are in `05-postgame.md`.
 
 **The protagonist.** Reality-render of the MC. Older, gentler, less athletic than their Construction-render. Same character, real version.
 

--- a/designs/concept/04-reality.md
+++ b/designs/concept/04-reality.md
@@ -1,64 +1,58 @@
 # Reality
 
-The second style. Visually distinct from Construction, mechanically a different game, story-driven. The protagonist's hometown, geographically static, with content added across Reconstruction. Reachable only voluntarily once Reconstruction begins (`03-reconstruction.md`).
+The second style. Reality as a register: how it looks, how it sounds, the shape of a Reality scene. High-level architecture in `00-three-styles.md`. The break that introduces Reality lives in `02-cracks-and-break.md`. The Part 2 work that happens inside Reality (photo album, sister, search) lives in `03-reconstruction.md`. The cliff and the call live in `05-postgame.md`.
 
 ## The place
 
-Reality is one place: the protagonist's hometown. A small coastal town on the Welsh and Cornish coast in an imagined warmer climate. Painted terraces in seaside colours, the palette of Tenby and Aberaeron: pinks, yellows, sea-greens, sky-blues. Whitewashed walls. Palm trees in places. A high street that smells of rain and citrus. Mediterranean light on a British coastline. Faded grandeur with sun on it. Ordinary, lived-in.
+Reality is one place: the protagonist's hometown. A small coastal town on the Welsh and Cornish coast in an imagined warmer climate. Painted terraces in seaside colours, the palette of Tenby and Aberaeron: pinks, yellows, sea-greens, sky-blues. Whitewashed walls. Palm trees in places. A high street that smells of rain and citrus. Mediterranean light on a British coastline. Faded grandeur with sun on it. Ordinary, lived-in. Pulls from real reference points; sits on no map.
 
-The place is geographically static. The map does not grow; the town stays the size it was when the player first walked through it at the break. What changes is what is in it. Across Reconstruction, things are added: people the player can meet, objects that were not there before, conversations that open as the protagonist is ready for them. The same hometown, revealed in passes.
+The map is geographically static. The hometown does not grow; the town stays the size it was when the player first walked through it at the break. What changes is what is in it. Across Part 2, things are added: people who become reachable, objects that were not there before, conversations that open as the protagonist is ready for them. The same hometown, revealed in passes.
 
-## Tone and texture
+## Visual register
 
-Reality's tone is gold-hour, weighted, story-driven. Characters at their real ages. Less vibrant, less full, deliberately unconstructed. Spiritfarer, Lake, Omori's Faraway Town are the tonal touchstones. Loss is acknowledged; the prose breathes; the rally is not the engine here. The pull of Reality is its honesty; the player ends up wanting it.
+Gold-hour. Weighted. Plainer than Construction. The light is slant afternoon rather than full midday; the shadows lengthen; the air carries dust. Saturation drops a notch from Construction; line weight thickens; compositions hold longer pauses.
 
-## The puzzle shape
+Characters are at their actual ages. Less vibrant, less full, deliberately unconstructed. The Six Marks still apply (per the artist world bible's section B); their expression here is plainer warmth, specific detail without gleam, breathing posture without performance.
 
-Reality is interaction-driven, not rally-driven. The player walks into a scene, does small attentive things, leaves. Specific puzzle mechanics (interaction surfaces, scene state, dialogue layering) are downstream game-design work and live in SH-279. The structure-level commit here is: it is not pong; it is not inventory recombination; it is being present in a room and finding what wants to happen.
+The pull of Reality is its honesty. The player ends up wanting it.
+
+Touchstones: Spiritfarer's quieter moments, Lake, Omori's Faraway Town. Loss is acknowledged; the prose breathes; the rally is not the engine here.
+
+## Audio register
+
+Reality is acoustic. Bustle, wind instruments, rooms with people in them. Where Construction is bright synthetic music with a melodic chip-tone heritage, Reality is the air outside that synth.
+
+Across Part 2, the two styles converse in the soundtrack: synth and acoustic in tension, the weight moving toward fuller arrangement by late Part 2. At the cliff, the music thins. At the credits, full orchestra reaches for both wonder and weight. Synthesis. Full direction in SH-281.
+
+## The shape of a scene
+
+Reality is interaction-driven, not rally-driven. The player walks into a scene, does small attentive things, leaves. Each scene is hand-crafted: layered state, contextual interactions, dialogue, descriptive prose, the present-and-attentive puzzle shape.
+
+The structure-level commit: not pong; not inventory recombination; being present in a room and finding what wants to happen. Specific puzzle mechanics (interaction surfaces, scene state, dialogue layering) are downstream game-design work and live in SH-279.
+
+Scenes are gated by photos. Each found photo opens a Reality scene; finding the photo and the corresponding scene compounds the trail. The mechanic itself is in `03-reconstruction.md`; what matters here is the register: scenes are hand-built, return-supporting, layered with state across visits.
 
 ## The cast in Reality
 
-Reality holds the real-world version of every cross-style character. Each is at their actual age, in their actual life, plainer than their Construction-render. The player meets them across Reconstruction.
+Reality holds the real-world version of every cross-style character. Each is at their actual age, in their actual life, plainer than their Construction-render. The player meets them across Part 2.
 
-- **The sister**: the tinkerer's real-world counterpart. The shopkeeper's younger sister. Less weighted by the death than the shopkeeper. Holds the photo book (see below). One of the first reachable people in Reality.
-- **Martha and the partners (in Reality)**: the cashier at the actual newsagent; the others as they actually are. Not coaches here, just people the protagonist knew.
-- **The shopkeeper**: present in Reality from the break onward. Not approachable directly until late in Reconstruction; reachable through the sister and the photo-book arc, then through the call (`05-postgame.md`).
-- **The protagonist**: Reality-render of the MC. Older, gentler, less athletic than their Construction-render. Same character, real version.
+**The sister.** The tinkerer's real-world counterpart. The shopkeeper's younger sister. Less weighted by the death than the shopkeeper. Holds the photo album. The bridge. One of the first reachable people in Reality. Detail in `03-reconstruction.md`.
 
-## The photo book and the scattered photos
+**Martha and the partners.** The cashier at the actual newsagent; the others as they actually are. Not coaches here, just people the protagonist knew.
 
-The sister has the photo book, but not all of the photos. Some are still inside; some are scattered: lost in the wind off the sea years ago, tucked into other people's drawers, pinned to a noticeboard somewhere, taped to the back of an old radio in the workshop. The book is incomplete by design.
+**The shopkeeper.** Present in Reality from the break onward. Not approachable directly until the cliff. The almost-dial mechanic with the unnamed number is the player-facing weight of their absence; detail in `03-reconstruction.md`. The cliff meeting and the call are in `05-postgame.md`.
 
-The photo book IS the reconciliation mechanic. Sitting with the sister and turning the pages of what she has is the first reconciliation moment. After that, the protagonist goes to find the rest. Each scattered photo is a reconciliation action: a place to visit, a person to ask, a small attentive thing to do. Each one returned to the book completes a part of the protagonist's history that the shopkeeper kept and the protagonist could not.
+**The protagonist.** Reality-render of the MC. Older, gentler, less athletic than their Construction-render. Same character, real version.
 
-Once the book fills, the path to the shopkeeper opens. The book is the spine of Reconstruction; the photos are the beats. The sister is where the work begins; the cliff is where the last photo lives.
+The champ is Construction-only. No Reality counterpart. Their reality is the cliff (`05-postgame.md`).
 
-The shopkeeper kept the history because the protagonist could not. The sister holds the book because she is not entangled in the absence the way the shopkeeper is. Each found photo is the protagonist saying: someone has been keeping this. I am here for it now.
+## Period
 
-## The cliff
-
-A separate place from the hometown. The cliff where the friend died.
-
-The cliff is the structural opposite of the break (`02-cracks-and-break.md`). The break is forced acceptance of Reality (the wall comes down on you). The cliff is chosen acceptance of the absence (you walk to where you should have been). The two are bookends.
-
-The shopkeeper was at the cliff when it happened. The protagonist was not. The visit closes that absence by chosen presence. The last scattered photo is here.
-
-After the cliff visit, the champ's pushiness softens. They become a partner the player can rally with in the construction. The path to the call opens through the final reconciliation actions.
-
-## Score-checking surfaces
-
-Per `03-reconstruction.md`, the score is hidden in Construction during Reconstruction. The number can be checked, but only in Reality, at specific surfaces:
-
-- The sister's place: she may glance at her phone, mention what she remembers of the day's number, or have a small note pinned somewhere.
-- The closed shop: the door has the closing-time hours written on it; somewhere the number lives in plain sight if you know to look.
-- The cliff: once unlocked, the cliff carries the count too, though the form is downstream design.
-
-The specific surfaces are open; what matters here is the structural commitment that the score lives in Reality, not on the rally HUD.
+Late 90s or early 2000s as a tonal range. Pre-smartphone. Phones flip or candy-bar or land-line. Numbers held in heads or written on paper, not auto-named in pocket databases. Period-appropriate clothes, signage, phone hardware, photo prints. The unnamed-number mechanic depends on the period.
 
 ## Production notes
 
-- Reality is finite hand-crafted content. The hometown is built once with iterative additions across Reconstruction.
-- The sister is the most-visited Reality character (she holds the photo book). Her scene supports many returns.
-- The scattered-photos mechanic gates the protagonist's progress. Each photo is a hand-crafted reconciliation scene.
-- The cliff is a separate location built once. Used at the chosen-acceptance moment and reused as the seashell's destination in postgame.
+- Reality is finite hand-crafted content. The hometown is built once with iterative additions across Part 2.
+- The sister is the most-visited Reality character (she holds the photo album). Her scene supports many returns.
+- The cliff is a separate location built once. Used at the chosen-acceptance moment and re-enterable through the unlocked gate after the call (`05-postgame.md`).
 - Specific Reality tooling (interaction surfaces, scene state, dialogue, navigation) belongs to SH-279.

--- a/designs/concept/05-postgame.md
+++ b/designs/concept/05-postgame.md
@@ -6,9 +6,9 @@ The ending and what comes after. The cliff is the chosen-acceptance bookend to t
 
 The album fills. The hidden compartment opens. The sister hands over the key. The protagonist returns to the garden, walks to the locked gate, unlocks it, walks through.
 
-The cliff is on the other side. The bench is there, dedicated to the friend who died. The shopkeeper is on the bench. Alive.
+The cliff is on the other side. The same edge the friend group used to jump from. The bench is there, dedicated to the friend who died. The shopkeeper is on the bench. Alive.
 
-The act-2 dread inverts. Relief. The fear was wrong. The shopkeeper has been here, withdrawn, refusing calls. The shopkeeper was at the cliff when it happened; the protagonist was not. The visit closes that absence by chosen presence.
+The act-2 dread inverts. Relief. The fear was wrong. The shopkeeper has been here, withdrawn, refusing calls, sitting at the place they jumped from together and walked away from alone. The visit closes that absence by chosen presence: the protagonist arriving at the spot they were not at the day it happened, beside the one who was.
 
 ## The call
 
@@ -16,7 +16,7 @@ The protagonist takes out their phone. They could walk up silently. They do not.
 
 The shopkeeper's phone rings on the bench beside them. They could ignore it like they have been ignoring all the others. They do not. They look up at the sound. See the protagonist. Pick up.
 
-The dial does two things at once. Chosen presence (the door staging adapts to the cliff: the dial bridges the small distance between them on the bench). And finally attaching the name to the number the protagonist has been carrying. The phone log entry is not just digits anymore.
+The dial does two things at once. Chosen presence (the door staging adapts to the cliff: the dial bridges the small distance between them on the bench). And finally attaching the name to the number the protagonist has been carrying. The phone log entry is not just digits anymore. It is the person who jumped that day and came back; the one whose survival the protagonist could not look at, until now.
 
 ### Staging
 

--- a/designs/concept/05-postgame.md
+++ b/designs/concept/05-postgame.md
@@ -1,48 +1,48 @@
-# The Call and Postgame
+# The Cliff, the Call, the Postgame
 
-The ending and what comes after. High-level architecture in `00-three-styles.md`.
+The ending and what comes after. The cliff is the chosen-acceptance bookend to the break; the call is the one beat the whole game has been reaching for; the credits play over the rally that proves it; postgame keeps the rally going. High-level architecture in `00-three-styles.md`. Part 2's arc into the gate is in `03-reconstruction.md`.
+
+## The cliff
+
+The album fills. The hidden compartment opens. The sister hands over the key. The protagonist returns to the garden, walks to the locked gate, unlocks it, walks through.
+
+The cliff is on the other side. The bench is there, dedicated to the friend who died. The shopkeeper is on the bench. Alive.
+
+The act-2 dread inverts. Relief. The fear was wrong. The shopkeeper has been here, withdrawn, refusing calls. The shopkeeper was at the cliff when it happened; the protagonist was not. The visit closes that absence by chosen presence.
 
 ## The call
 
-Reaching the world record means winning the championship. Winning the championship means dialling the shopkeeper's phone number. The protagonist dials while standing at the shop door. The shopkeeper's phone rings inside; the protagonist hears it through the door of the shop they have been avoiding for years. The shopkeeper picks up. The first words happen on the phone with both of them in the same building, voice and body simultaneously. The call connects; the door is right there.
+The protagonist takes out their phone. They could walk up silently. They do not. They dial the unnamed number. The digits are whole in their head now from all the recovered fragments.
 
-The shopkeeper is still there. The protagonist is reaching the person who was there when they were not; the shared knowledge has been waiting all along.
+The shopkeeper's phone rings on the bench beside them. They could ignore it like they have been ignoring all the others. They do not. They look up at the sound. See the protagonist. Pick up.
+
+The dial does two things at once. Chosen presence (the door staging adapts to the cliff: the dial bridges the small distance between them on the bench). And finally attaching the name to the number the protagonist has been carrying. The phone log entry is not just digits anymore.
 
 ### Staging
 
-The call is one image, two presences. Composition splits the frame: protagonist on the outside, shopkeeper on the inside, the door (or window, or wall) dividing them. Both holding phones. After the touchstone of *Broken Age*'s key art, where two characters share one image divided by a structural element. The split IS the years of distance; the shared frame IS the resolution. The phone is the line that crosses the split. One moment, two people, finally in the same picture.
-
-### Coming home
-
-The call lands. Both hang up; the door opens. The composition flows from the split frame into a single image of the court, with the shopkeeper crossing onto the right side, racquet in hand. The seashell is on the ground (the champ left it earlier, see below). The first ball is in the air.
-
-This is the postgame opening, and it is not a transition. The player never leaves the moment. The call IS the act of bringing the shopkeeper home; the home is the court; the rally that begins is postgame. The construction's warmth has returned, but as the actual relationship rather than the substitute. The right person is in the right spot.
-
-The call is the ending. The warmth in Construction is now available without the pretense; the protagonist can be in their hometown, with the people who are actually there, and the rally is something they do, with the right person, in a world that no longer has to be a wall.
+Split frame at the path, the bench, the phones. The protagonist outside the bench area; the shopkeeper on the bench, holding their phone. The dial bridges intention, not space. They look at each other across the small distance, both holding their phones. After the touchstone of *Broken Age*'s key art, where two characters share one image divided by a structural element. The split is the years of distance; the shared frame is the resolution. Then the protagonist crosses, sits beside them. The call ends.
 
 ## Credits
 
-Credits roll over the rally. The first one between the MC and the shopkeeper, the championship spot occupied by the actual person, racquet in their hand, the ball going back and forth. The substitute is gone; the right side of the court holds the friend the protagonist had been reaching for the whole time. The names scroll over the play. The rally keeps going.
+Credits play over the rally. The first one between the protagonist and the shopkeeper. Construction's championship spot now occupied by the actual person, not the substitute. Racquet in their hand. The ball going back and forth. The names scroll over the play. The rally keeps going.
 
 The image is the proof: the daily thing the protagonist did alone is finally done together.
 
+The visual style is Construction's saturated, generous light, with the texture Reality has worn into it across Part 2. The bench from the cliff visible somewhere: maybe in a corner, maybe glimpsed past the gate that now stays open.
+
+The audio: per the SH-281 arc, full-orchestra range available. The synth warmth that opened the game returns layered with the acoustic instruments Reality brought. Audio synthesis at exactly the visual moment of synthesis.
+
 ## Postgame
 
-Postgame is rallying with the shopkeeper. They take the right side of the court that used to be the championship spot, the same spot the champ once held. The construction is at last what the protagonist was always reaching for: themselves on the left, the shopkeeper on the right, the rally going.
+Rallying with the shopkeeper as the championship-spot partner. The cliff stays returnable through the now-unlocked gate. Construction has its centre back, but as the actual relationship rather than the substitute. The right person is in the right spot.
 
-The champ exited earlier, late in Reconstruction (see `01-construction.md` and `03-reconstruction.md`). They had become a partner the player could rally with after the cliff; once the path to the call was opened, they left, with the seashell where they had been. Reaching the call clears the championship spot for the shopkeeper; the seashell stays.
+The cliff is a place to sit, look at the sea, listen. No new gameplay there. Grief integrated as access, not as event. The cliff was chosen acceptance the first time it was visited; returning is a chosen visit.
 
-The seashell, carried by the protagonist from the call onward, opens the cliff as a place the protagonist can return to anytime. There is no new gameplay there: the cliff is a place to sit, look at the sea, listen. Grief integrated as access, not as event. The cliff was chosen acceptance the first time it was visited; the seashell makes it a chosen visit.
-
-## What this opens
-
-The narrative doc names "Regret" as a future-update perspective for someone who never made the call. The postgame item could grow further down that road, but the seashell is the structural minimum: one object, one returned place, one small daily ritual the bright world did not have before.
-
-Postgame is the slot where additional perspectives, alternate runs, or extended mechanics could live. The seashell is the load-bearing piece that closes the prototype-to-alpha arc; further postgame content is downstream.
+The champ does not return; they exited at the end of Part 1 (`02-cracks-and-break.md`). The championship spot belongs to the shopkeeper now.
 
 ## Open questions
 
-- **Reality cycling post-call.** After the call, does the game continue, close, or open into a Regret-style alt-perspective? Default: stays open with the seashell as the persistent affordance, no new gameplay loops. Confirm.
-- **What the bright world looks like in postgame.** With the champ gone, the right side of the championship match is empty. Does the player still rally in Construction at all? With which partners? Or is Construction effectively closed once the call has landed?
-- **The shopkeeper after the call.** They picked up. What does the relationship look like after that? Reachable in Reality continuously? A character the player can visit? Or held off-screen as a closed beat?
-- **Save state and the call.** Does reaching the call create a save-flag the player crosses once, or is the call something the player can replay? The call as a one-time moment is the cleaner narrative shape; replay is the structurally simpler implementation.
+- **Reality cycling post-call.** After the call, does the game continue, close, or open into a Regret-style alt-perspective for someone who never made the call? Default: stays open with the cliff as the persistent affordance, no new gameplay loops.
+- **What Construction looks like in postgame.** With the shopkeeper now occupying the right side of the championship match, what is the relationship between the rally with them and the rest of the partners? Are the earlier coaches still rotatable, or is the postgame rally fixed on the shopkeeper?
+- **The shopkeeper after the call.** Reachable in Reality continuously? A character the player can visit at the shop or on the bench? Or held off-screen as a closed beat with the postgame rally as the only ongoing presence?
+- **Save state and the call.** Does reaching the call create a save-flag the player crosses once, or is the call replayable? The call as a one-time moment is the cleaner narrative shape; replay is the structurally simpler implementation.

--- a/designs/concept/05-postgame.md
+++ b/designs/concept/05-postgame.md
@@ -12,7 +12,9 @@ The act-2 dread inverts. Relief. The fear was wrong. The shopkeeper has been her
 
 ## The call
 
-The protagonist takes out their phone. They could walk up silently. They do not. They dial the unnamed number. The digits are whole in their head now from all the recovered fragments.
+Recognition lands at the cliff for the first time. The unnamed number in the phone, the world record the protagonist reached, the digits the championship match resolved on, the shopkeeper sitting in front of them on the bench: all of it the same number, held unnamed all along, only now legible.
+
+The protagonist takes out their phone. They could walk up silently. They do not. They dial the unnamed number, knowing now whose it is.
 
 The shopkeeper's phone rings on the bench beside them. They could ignore it like they have been ignoring all the others. They do not. They look up at the sound. See the protagonist. Pick up.
 

--- a/designs/concept/05-postgame.md
+++ b/designs/concept/05-postgame.md
@@ -18,11 +18,11 @@ The protagonist takes out their phone. They could walk up silently. They do not.
 
 The shopkeeper's phone rings on the bench beside them. They could ignore it like they have been ignoring all the others. They do not. They look up at the sound. See the protagonist. Pick up.
 
-The dial does two things at once. Chosen presence (the door staging adapts to the cliff: the dial bridges the small distance between them on the bench). And finally attaching the name to the number the protagonist has been carrying. The phone log entry is not just digits anymore. It is the person who jumped that day and came back; the one whose survival the protagonist could not look at, until now.
+The dial does two things at once. Chosen presence: the protagonist could close the silence by walking up, and chooses instead to call. The shopkeeper could ignore the ring like every other, and chooses instead to pick up. And finally attaching the name to the number the protagonist has been carrying. The phone log entry is not just digits anymore. It is the person who jumped that day and came back; the one whose survival the protagonist could not look at, until now.
 
 ### Staging
 
-Split frame at the path, the bench, the phones. The protagonist outside the bench area; the shopkeeper on the bench, holding their phone. The dial bridges intention, not space. They look at each other across the small distance, both holding their phones. After the touchstone of *Broken Age*'s key art, where two characters share one image divided by a structural element. The split is the years of distance; the shared frame is the resolution. Then the protagonist crosses, sits beside them. The call ends.
+Split frame at the path, the bench, the phones. The protagonist standing; the shopkeeper on the bench, holding their phone. The dial bridges intention, not space. They look at each other across the silence both have been holding, both with phones to their ears. After the touchstone of *Broken Age*'s key art, where two characters share one image divided by a structural element. The split is the years between them; the shared frame is the resolution. Then the protagonist crosses, sits beside them. The call ends.
 
 ## Credits
 


### PR DESCRIPTION
Six-file restructure of `designs/concept/` against the locked canon. Strips dead framings (seashell, bidirectional carry, unwinnable championship), sharpens per-file scope so each doc carries one clear job, sweeps cross-references.

Net flat on word count (~4900 → ~4870) but heavily reorganised. `00-three-styles.md` reframed around the two-act spine. `02-cracks-and-break.md` carries the win-is-the-break. `03-reconstruction.md` carries dread, search, album, unnamed-number. `05-postgame.md` cliff-via-locked-gate, dial-at-bench, credits over the rally.

Part of Mission Page One's restructure round.