### PR TITLE
docs: drop Reference boards section from art index

### DIFF
--- a/designs/art/INDEX.md
+++ b/designs/art/INDEX.md
@@ -11,15 +11,3 @@ The living reference for Volley!'s visual direction. Concept studies and product
 | [Tech Pipeline](tech-pipeline.md) | How the style is implemented in Godot: rendering, assets, register shifts. |
 | [Character Lighting](character-lighting.md) | Post-prototype dynamic light-state pipeline for characters across venues. |
 
----
-
-## Reference boards
-
-Internal reference boards live alongside these docs but are kept out of the public repo because they compile third-party imagery (film stills, anime frames, game screenshots). The concepts they explore show up publicly in the bible, direction, and style workshop; the imagery stays local.
-
-Two frameworks from the boards worth knowing:
-
-- **Contrast pairs.** Each shift between the constructed and real registers is studied as a deliberate pair: same reference or same pattern, rendered at different saturations, edge qualities, and levels of composition. The pair is the unit of study, not the single image. Contributors reading the bible or direction will see the same shift described in prose.
-- **Animation moment-types.** Character motion is split into expression and body language, hit/miss/impact, idle and breathing, sports energy, and fluid movement. Each moment-type has its own reference cluster internally; the qualities it points at are captured in [direction.md](direction.md) and [bible.md](bible.md).
-
-External contributors have everything they need to make coherent choices without the private boards.

--- a/designs/research/STYLE.md
+++ b/designs/research/STYLE.md
@@ -1,0 +1,335 @@
+# Style guide for the open-development essay
+
+This is the working style guide for every contributor (human or agent) editing the essay in `designs/research/drafts/`. Read it once before touching a section; follow it on every line.
+
+## Purpose of the document
+
+The essay argues that open development is the path most likely to give a new indie a fair shot at being seen, and that the same principle — visible work, credited contribution, broad participation — is the durable answer to the wider questions of how creative work survives in an age of consolidation, AI displacement, and platform gatekeeping. The framing is game development. The implications are larger.
+
+The essay is for everyone: developers, players, journalists, open-source maintainers, accessibility advocates, the curious passer-by. Write so that any of them can pick it up cold.
+
+## Voice
+
+- **Calm, measured, factual.** No hype, no breathless claims, no "this changes everything". Authority comes from evidence and from being unafraid of the counter-argument.
+- **Warm and humble.** Lead with what a thing *is* and *does*, not what it isn't. Praise people by name. Stand on the shoulders of giants and say so.
+- **Confident, not strident.** The argument wins because it is right, not because it is loud. Never suggest the essay itself is important; let the reader decide.
+- **Universal, not tribal.** There is no us-against-them. We are all human. Adversaries are mistaken, not enemies. Kill them with kindness.
+- **Persuasive, not manipulative in the ugly sense.** Use simile, metaphor, rhythm, and emotive language to make the reader feel the stakes. Earn every emotional beat with a fact.
+
+## Voice calibration: the author's natural register
+
+The above is the target voice for the published essay. The list below is the texture of the author's own writing, taken from a corpus of his earlier prose. The published voice should sit at roughly 80% of the target voice and 20% of the texture below. The mix lets the essay read as a person, not a polished document.
+
+What to bring across:
+
+- **Declarative confidence with the occasional twist setup.** The author's signature move is to state a clean claim, then immediately turn it. "Robots will not steal our jobs. Unless, they're given help." Use the move sparingly; it loses force on the third repeat in a section.
+- **The "what most people don't realise" register.** The writer naming the thing the headlines miss, calmly. Not contrarian for its own sake; informed and unsurprised.
+- **First-person flickers outside the explicit first-person section.** A small "I" beat in a section that otherwise sits in third person can land if the moment is genuinely the author's, not a rhetorical flourish.
+- **Direct attribution and direct calling-of-names.** Power gets named by the thing it does, not softened. "The US has a tendency for not playing by the rules" register. Confident, plain, never aggressive.
+- **Concrete texture details that have no business being in the prose except that they ground it.** A specific brand, a specific moustache, a specific number nobody would have rounded. The essay already does this through citations; one or two paragraphs may earn an extra texture beat.
+- **British English throughout.** Already conformant.
+
+What not to bring across:
+
+- **Manifesto sign-offs.** "For the safety and preservation of humanity, it needs to be done." The author's older work reaches for this; the published essay should not.
+- **Schematic transitions.** "Furthermore", "Additionally", "Therefore X. Therefore Y." Already cut by editorial passes; do not reintroduce.
+- **Em dashes.** The older work uses them; the style guide forbids them.
+- **"Fortunately" / "Unfortunately" as section openers.** Voice marker but rhetorical filler.
+- **Absurdist comedy at any volume.** The author can write it; the essay is not the place.
+- **Over-rhetorical closes.** The current close is restrained. Do not gild it.
+
+Net: where the essay reads as too polished and too careful, loosen by about one tenth. Not by half.
+
+## Sentences
+
+- Short over long. Concrete over abstract. Active over passive. A sentence that needs a comma to breathe is fine; one that needs three is two sentences pretending.
+- Vary length. A long sentence that establishes context, then a short one that lands the point.
+- Read every paragraph aloud in your head. If it stumbles, cut.
+
+### Punctuation as voice
+
+Punctuation is not only grammar; it is breath, hesitation, weight, and pace. Choose each mark for what it does to the reader's ear, not by reflex.
+
+- **Period.** Closure. Hardness. Land on the loaded word and stop.
+- **Comma.** Breath, parenthetical, list. Overuse muddies; underuse rushes. Three or more commas in a sentence usually means it is two sentences pretending.
+- **Semicolon.** Two complete thoughts in tight relation. The held breath between them.
+- **Colon.** The reveal. Names what is to come.
+- **Ellipsis.** Hesitation, trailing-off, the moment of held dread before the reveal. Use sparingly: at most twice across the whole essay, and only where the felt pause matters more than the clean delivery.
+- **Parentheses.** The aside, the qualifier you do not want to halt the main sentence for. Cut or integrate where the main flow can carry it.
+- **Question mark.** Real questions only. Convert rhetorical questions to declarative.
+- **Dash.** En dash for number ranges (1939–1945) only. No em dashes anywhere.
+- **Exclamation mark.** Forbidden, except where it is part of a proper noun (the game name *Volley!*).
+
+A comma joining two independent clauses is a splice; upgrade to semicolon, period, or rewrite. The closing sentence of a paragraph should land on a period unless the kicker genuinely needs the trailing pause; do not let commas dribble away the loaded word.
+
+## Forbidden tics
+
+- **No em dashes.** Use a colon, a semicolon, a comma, or a full stop.
+- **No exclamation marks.** Ever.
+- **No buzzwords**: "leverage", "synergy", "disrupt", "10x", "ecosystem" (unless literal), "game-changer", "paradigm shift". If a sentence reads like a LinkedIn post, rewrite it.
+- **No filler**: "it is important to note that", "needless to say", "in today's world", "at the end of the day".
+- **No second-person command voice** ("you should", "you must"). Show; don't instruct.
+- **No first-person plural unless earned.** "We" is the reader and the writer together, not the author and an imaginary team.
+- **No hedging stack.** "It might possibly perhaps be the case that" is one word: "is", or cut.
+- **No "small game", "small project", "tiny indie"** when describing Volley! or Shuck. The work is the work.
+
+## AI prose tells (the words and constructions to cut)
+
+This pass is not about hiding that the essay was drafted with an AI assistant. The essay says so openly in section 11 and the argument depends on saying so. The pass is about humanising the prose: cutting the residue that reads as model-shaped rather than person-shaped, so the writing carries the voice of the person who wrote it instead of the average of the corpus the model was trained on. The aim is recognisability, not concealment.
+
+Large language models leave a residue. Editors, linguists, and the maintainers of `Wikipedia:Signs of AI writing` have catalogued it; the Berens lab's *Delving into LLM-assisted writing in biomedical publications through excess vocabulary* (Kobak, Márquez González, Horvát, Lause, *Science Advances*, 2025) puts numbers on the shift; Reuters Institute, *How AI-generated prose diverges from human writing* (2024), names the rhythm and the empty hedge. Run this checklist on every draft.
+
+**Vocabulary to cut on sight.** delve, delves, delving; tapestry; landscape (metaphorical); navigate (metaphorical); realm; underscore, underscores; pivotal; crucial; essential; robust; comprehensive; leverage; harness; foster; cultivate (metaphorical); embrace (metaphorical); myriad; plethora; intricate; nuanced; multifaceted; holistic; transformative; vibrant; seamless; ever-evolving; meticulous; commendable; boast; primarily as filler; ultimately as a connector.
+
+**Constructions to rewrite or cut.** "It is important to note that"; "It is worth noting that"; "Not just X, but Y"; "More than just X"; "X is a testament to Y"; "X speaks to Y"; "X lies at the intersection of Y"; "stands as", "serves as", "plays a role in"; "paints a picture"; "sets the stage for"; "the cornerstone of", "a hallmark of", "a beacon of"; "ushering in"; "stands the test of time"; "in essence"; "X keeps Y honest"; "X keeps Y accountable"; the false-balance "Some would argue X. Others would argue Y."; the closing moral ("the work matters", "the choice is ours"); the paragraph that restates its own thesis to finish.
+
+**Structural and punctuation tells.** Tricolons stacked across consecutive paragraphs; adjective stacks where one modifier would carry the load; the colon-as-header used four or more times in one section; the single-word fragment ("Quietly.", "None.") used more than twice; the em dash anywhere (the guide forbids it); the Oxford comma drifting mid-essay; "however" used as a soft pivot more than once per section.
+
+Sources: Berens lab, *Delving into LLM-assisted writing*, *Science Advances*, 2025; *Wikipedia:Signs of AI writing*; Reuters Institute, *How AI-generated prose diverges from human writing* (Lewandowsky and Ecker, 2024); *ChatGPT Is Changing the Words We Use in Conversation*, *Scientific American*, 2024.
+
+## Citations
+
+- Every empirical claim has a citation in `[src:slug]` form, matching slugs already in use (e.g. `[src:fff-1]`, `[src:hk-wiki]`, `[src:octoverse-24-geo]`). New citations get a new slug and a corresponding entry the cohesive pass will collect.
+- Cite primary sources where they exist. Cite the strongest secondary source where they don't.
+- Do not paraphrase a quote into a "fact". If it's a quote, quote it.
+- Numbers: include the units, the date, and the source. "$57M paid to Workshop creators by January 2015 [src:engadget-workshop]" not "Valve has paid creators a lot".
+
+## Structure of a section
+
+- Open with a concrete particular: a person, a date, a number, a moment. Not a thesis statement.
+- Build the argument through cases. Two or three is usually enough; four if the cases are genuinely different.
+- Close on the structural point the cases support. Land it and stop. Do not summarise the section in the final paragraph; the section is the summary.
+
+## Naming and credit
+
+- Real names, full first time, surname only after: "Maddy Thorson … Thorson". Pronouns when known and used by the person. If unsure, look it up.
+- Studio names italicised? No. Game titles italicised: *Celeste*, *Hollow Knight*, *Factorio*. Songs, books, films: italics. Albums: italics.
+- Currency with the symbol and unit: "AU$57,138", "US$1B", not "57k AUD".
+- Dates spelled long-form on first use in a section: "27 September 2013".
+- Credit communities by name where the contribution came from a community, not a company.
+
+## Counter-arguments
+
+- Every section that makes a load-bearing claim must survive the obvious counter-argument. Either pre-empt it inside the section, or know that section 13 (fears) handles it.
+- Honest caveats strengthen the argument. Name them. The Asparouhova caveat in the inclusivity section is the model.
+
+## Tone on AI, on industry, on self
+
+- AI is a force multiplier. Used well, it amplifies human creativity. Used as a substitute for it, it produces a thinner culture. Say this without contempt for AI or for the people building it.
+- The closed-development industry is not the villain. It is the system most people inherited. The essay invites readers out of it, not against the people inside it.
+- The author is a software engineer four years into a career, building a first game. That is the speaker. No false modesty, no false authority.
+
+## What "fully fleshed out" means
+
+A section is fully fleshed out when:
+1. Every claim has a citation or is plainly an opinion clearly marked.
+2. The strongest counter-argument to the section has been answered or honestly conceded.
+3. A reader who has never heard of the case studies could follow them from the section alone.
+4. The prose has been read aloud and trimmed.
+5. There is at least one moment in the section the reader will remember an hour later: a quote, an image, a number that lands.
+
+## Length
+
+There is no minimum or maximum. Long enough to be airtight, short enough to be read. If a paragraph isn't pulling weight, it isn't there.
+
+## What this essay must not become
+
+- A manifesto.
+- A sales pitch for Volley!.
+- A complaint about the industry.
+- A celebration of the author.
+
+It is a quiet, careful, generous piece of writing that happens to make a strong argument. Hold the line.
+
+## Craft (the techniques the prose actually uses)
+
+The essay should not feel like a chore. It should feel like a person walking the reader through a real thought, with rhythm and weight. The techniques below are the ones the prose leans on. Use them deliberately. The companion piece [`visual-positioning.md`](visual-positioning.md) is the in-house model: read it as an example of every technique on this list working together.
+
+### Throughline and circle-back
+
+The essay has one central image and one central claim. Both should land in the first section and return, in altered form, in the last. This is the inclusio: the close echoes the opening so the reader feels the structure even when they cannot name it. Mary Douglas (*Thinking in Circles: An Essay on Ring Composition*) names the minimum criterion: the ending must join up with the beginning, ideally through conspicuous key words from the exposition.
+
+The model: visual-positioning opens on Rusty's Retirement, "a small farm at the bottom of the screen", and closes on Despelote's "kick against a wall, a radio carrying through the heat". Different cases; the same shape; the reader's body remembers the opening when the close lands.
+
+For this essay, the central image is the developer alone with an empty repository who commits anyway. State it (or its emotional equivalent) early. Return to it (or its inverse: the audience that came) at the end. Do not announce the return; let the rhyme do the work.
+
+### Hook
+
+The first sentence makes a promise the reader wants kept. It is not the thesis. It is a particular: a number, a person, a moment, a contradiction. The hook earns the next sentence; the next sentence earns the next.
+
+Bad: "Open development is the most reliable practice for indie discoverability in 2026."
+Good: "In 2024 Steam shipped roughly fifty-one new games a day, and four-fifths of them went unplayed."
+
+Long-form editorial guidance (drawn from how *The New Yorker* and similar publications open features) lands the same way: the lead is an anecdote, a vivid scene, or a single precise figure that creates tension the reader wants resolved. Keep the hook to one or two sentences before the next earns its place.
+
+### Concrete particulars open every section
+
+The first sentence of every section is a fact, not an abstraction. A name, a date, a sum, a quoted line. Definitions and structural claims earn their place by arriving after the case has been set up, never before.
+
+### Show, don't tell
+
+The fact lands harder than the claim about the fact. If the reader cannot picture it, rewrite. "Maddy Thorson rewrote the line" beats "the studio engaged with feedback". Cite specifics, name people, give the room and the year. Roy Peter Clark's *Writing Tools* frames the same instruction as climbing the ladder of abstraction: ground the reader in the concrete first; reach for higher meaning only after the case is set.
+
+### Sentence rhythm
+
+Long sets up; short lands. A paragraph that runs three medium sentences is forgettable. A paragraph that runs two long sentences and one short one is read twice. The short sentence at the end is the loaded one.
+
+Gary Provost's canonical passage (*100 Ways to Improve Your Writing*, 1985) is the test: "This sentence has five words. Here are five more words. Five-word sentences are fine. But several together become monotonous." Vary length and the writing makes music; hold one length and the ear gives up.
+
+Read every paragraph aloud. Where the breath stumbles, cut.
+
+### Prose rhythm: where the ear lands
+
+Aristotle, in the *Rhetoric*, was the first to insist prose has rhythm — well-rhythmed, but not metrical like verse. Cicero translated the Greek *rhuthmos* as *numerus* and built Roman oratory on the principle that the close of a clause carries the weight. Modern craft writers say the same in plainer terms. Ursula K. Le Guin (*Steering the Craft*, 2015): "The sound of the language is where it all begins. The test of a sentence is, Does it sound right?" Verlyn Klinkenborg (*Several Short Sentences About Writing*, 2012): "Pay attention to rhythm, first and last." Constance Hale (*Sin and Syntax*, 1999) frames the music chapter around the choice between Anglo-Saxon shun and Latinate avoid. William Zinsser (*On Writing Well*) and Roy Peter Clark (*Writing Tools*) both put the loaded word at the end of the sentence.
+
+The principles, as a checklist editors can run on every paragraph:
+
+- **End-stress.** The last word of a sentence is the most prominent. Engineer it. Land on the noun or verb you want the reader to keep, not on a connector or a pronoun.
+- **Anglo-Saxon for force, Latinate for nuance.** Short Old English words (kick, lost, found, work, bread) hit. Long Romance words (recognition, displacement, consolidation) qualify. Use the first when the sentence must land; the second when it must shade.
+- **Plosive endings hit hardest.** Words ending in /t/, /d/, /k/, /p/, /b/, /g/ stop the ear cleanly. Fricative endings (/s/, /f/, /sh/) drift. Nasal endings (/m/, /n/, /ng/) hum on. Choose the consonant the sentence asks for.
+- **Vary length.** Long sets up, short lands. Three medium sentences in a row deaden a paragraph. A long-long-short pattern reads twice.
+- **Read every paragraph aloud.** The ear catches what the eye misses. Where the breath stumbles, cut. Where it speeds up at the wrong moment, slow down.
+
+Avoid:
+
+- **Prepositional close.** A sentence ending in *for, with, from, of, to* dribbles. Reorder.
+- **Weak-pronoun close.** *It, this, that, them* at the end is a wasted slot. Find the noun.
+- **Adverbial drift.** "In the end", "at the end of the day", "ultimately": filler closes that make the sentence shrug.
+- **Hedge stack at the close.** "May possibly be the case in some sense" empties the kicker. One word, or none.
+
+Sources: Aristotle, *Rhetoric* III.8; Cicero, *Orator* and *De Oratore*, on *numerus*; Le Guin, *Steering the Craft* (Houghton Mifflin Harcourt, 2015); Klinkenborg, *Several Short Sentences About Writing* (Knopf, 2012); Hale, *Sin and Syntax* (Three Rivers Press, 1999); Zinsser, *On Writing Well* (Harper, 2006); Clark, *Writing Tools* (Little, Brown, 2006).
+
+### Paragraphs end on the loaded sentence
+
+The last sentence of a paragraph is the one the reader will remember. Engineer it. Do not waste it on a transition; transitions go in the first sentence of the next paragraph.
+
+### Anaphora and the rule of three
+
+Three short sentences starting with the same word make a paragraph land. Use sparingly: the technique tires fast. Three is the magic number for lists, examples, and rhythmic builds. Four feels long; two feels incomplete.
+
+### Trust the reader
+
+If a metaphor lands, do not explain it. If a joke lands, do not gild it. If a citation makes the point, do not paraphrase the citation in the next sentence. Every paragraph that explains the previous paragraph is one paragraph too many.
+
+### No signposting
+
+Avoid "first", "second", "third", "in conclusion", "to summarise", "as we discussed earlier", "as the next section will show". The structure should be felt, not announced. The exception: a section can refer back to a named earlier section by topic, not by number. ("As the inclusivity section showed" is fine; "as section 09 showed" is not.)
+
+### Strong nouns and verbs
+
+Adjectives are accomplices, not principals. "The studio shipped" beats "the small independent studio successfully released". Cut adverbs aggressively; King is right that they are a road to hell. Adjectives stay only when they carry information no noun could ("hand-drawn animation" yes; "beautiful animation" no).
+
+### Active voice
+
+Passive voice obscures who did what. Most of the time the actor matters. "Wube reversed the redesign" beats "the redesign was reversed". Passive is allowed when the actor genuinely does not matter or when the receiver of the action is the point ("the file was leaked").
+
+### Cut filler ruthlessly
+
+Words to find and remove (or justify): something, actually, really, very, quite, just, basically, essentially, somewhat, rather, in some sense, to a degree, in a way, the fact that, the thing is, it is worth noting that, needless to say, in today's world. William Zinsser (*On Writing Well*) puts the diagnosis plainly: "Clutter is the disease of American writing." His remedy is the same one this guide takes: strip every sentence to its cleanest components, and ask of every word whether it is doing new work. Most second drafts are 30% shorter than first drafts and lose nothing. The craft is in the cut.
+
+### One idea per paragraph
+
+A paragraph is a unit of thought. If two ideas live inside it, the reader splits attention and the paragraph blunts both. Break it.
+
+### Quote what is quoted, summarise what is summarised
+
+Direct quotes go in quotation marks with citations. Summaries do not. Never paraphrase a sentence so that it sounds like a quote without being one; the reader will catch the seam and trust drops.
+
+### Comedy is a precision instrument
+
+A joke must come from a real observation, not wordplay. Never more than one per section. Never in places where the register must stay clean (heavy emotional material, the close, sections about real people's hardships). The test: does the smile move in the same direction as the argument? If not, cut. Default is no joke.
+
+### British dry wit as a sparingly-used register
+
+When humour is warranted, the move is British understatement, not American punchline. The wit is in what the sentence declines to say. Concrete handles, with the practitioners who exemplify each:
+
+- **Litotes and the deadpan factual sentence.** Orwell's essays are the model: a plain claim that lands hard because of what it leaves implied. "Not the worst" does more work than "good".
+- **Bathos: the drop from grand register to mundane.** Alan Bennett (LRB diaries) and Clive James (TV criticism, *Cultural Amnesia*) move from portentous to domestic in a single clause.
+- **Mock-formal politeness around damning observations.** Adam Curtis's narration; *The Economist* house style; *Private Eye*'s editorial register. Treat the absurd with the gravity of a select committee.
+- **The held comma and the pause.** Bennett and Jenny Diski (LRB) build the joke into the punctuation, not the words.
+- **The aside that turns out to be the point.** Hitchens, Diski, Stewart Lee's prose criticism. A parenthetical that quietly carries the load of the paragraph.
+- **Self-deprecation as a stalking horse.** Charlie Brooker's early *Screen Burn* columns: the writer absorbs the first hit, then names what is in front of everyone.
+
+Sources: Mary Beard, "What's so funny?" *TLS*, 2014, on litotes and English wit; Robert McCrum on Alan Bennett's "under-statement, the cunningly judged pause" (*Observer*, 2016); Christopher Hitchens, *Letters to a Young Contrarian* (Basic Books, 2001), on irony as the gymnasium of dissent.
+
+Where it lands in this essay: case sections (03 through 10) and fears (13), where the absurdity is already in the material. Where it would jar: AI (11), humanity (12), and the close (14). Default remains no addition.
+
+### Footnotes and references
+
+Inline citations use Markdown footnote syntax `[^slug]`. The slug points to a definition in the bibliography section. Hyperlinks within the essay text are reserved for cross-references and external resources the reader should click.
+
+### Editing checklist (run before declaring a section done)
+
+1. The opening sentence is a particular, not a thesis.
+2. The closing sentence of the section is the one the reader will remember.
+3. Every paragraph passes the read-aloud test.
+4. Every claim has a citation, a quote, or is plainly an opinion clearly marked.
+5. Every adverb has been examined; most are gone.
+6. Every "really", "actually", "something", "very" has been cut or justified.
+7. No paragraph summarises the previous paragraph.
+8. No transition word does work the structure should do silently.
+9. The throughline is visible: someone reading this section without context can still feel the central image and claim of the essay.
+10. The section earns its place. If it could be cut without weakening the whole, cut it.
+
+## Narrative momentum: making the essay a page-turner
+
+A long essay survives or fails on whether the reader wants the next paragraph. Argument alone does not pull; momentum does. The techniques below are how a working essayist engineers it. Use them on every section.
+
+### The but/therefore rule
+
+Trey Parker and Matt Stone, talking to NYU film students in 2011 (clip widely circulated; see Scott Myers, "Writing Advice from Matt Stone and Trey Parker", *Go Into The Story*, 2014), name the test plainly: between any two beats, the connector must be "but" or "therefore", never "and then". "And then" is summary; "but" is reversal; "therefore" is consequence. Read every paragraph break with that test. If three paragraphs in a row connect on "and then", restructure until each one earns the next.
+
+### Curiosity gaps
+
+Each paragraph poses a small question the next answers. The reader is pulled forward by the gap, not by the argument. Robert Boynton (*The New New Journalism*, Vintage, 2005) collects the longform reporters who do this best; the through-line in their interviews is that a paragraph closes by raising a question the next paragraph cannot duck. Engineer the gaps deliberately. A paragraph that resolves itself is a paragraph the reader can stop on.
+
+### Scene, then reflect
+
+Ira Glass, in his 2009 storytelling videos for the *Current TV* / *PRI* series (transcribed widely; see Daniel Webster's transcript on Medium, 2014), names the two building blocks of narrative: the anecdote (a sequence of actions with momentum) and the moment of reflection (the line that says why the reader is being asked to listen). Good pieces flip between the two. A section that is all anecdote is gossip; a section that is all reflection is a lecture. Pace the toggle.
+
+### Name the dog
+
+Roy Peter Clark, *Writing Tools* (Little, Brown, 2006), tool 14: get the name of the dog. Specificity that no general writer would notice is what breaks through. A date, a sum, a phrase from a primary source, the colour of the build account password ("blank") — the detail nobody else included is the detail the reader remembers.
+
+### Engineer the kicker
+
+The closing sentence of every section is the one the reader carries away. Cut everything after the line that lands. If a section ends on a synthesis ("the pattern is clear"), find the loaded sentence already in the section and end on it instead. Ben Yagoda (*The Sound on the Page*, HarperCollins, 2004) is the canonical reference; the rule is older than him.
+
+### The reversal
+
+At least once per part, set up the obvious answer and then overturn it. Malcolm Gladwell's MasterClass lesson "Structuring Narrative: The Imperfect Puzzle" (2017) frames the same move: articulate the assumption the reader is bringing, show where it fails, replace it. A reversal hidden mid-paragraph is wasted; stage it.
+
+### Stakes that escalate
+
+Robert McKee, *Story* (ReganBooks, 1997), on the obligation of rising stakes: each act must matter more than the last, or the reader checks out. Part I's stakes are one developer's first commit. Part III's stakes are what creative work is for. The middle is the climb.
+
+## Structure: the essay as a mini-book
+
+The essay runs to roughly ten thousand words. That is a mini-book, not a blog post and not a position paper. Treat the structure accordingly. Sections are chapters; chapters cluster into parts; parts move the argument from invitation to evidence to consequence. Ring the close back to the open.
+
+### Three parts
+
+Borrow the three-act spine that nonfiction workshops adapt from drama (see Rachael Hanel's "3-Act Structure for Nonfiction", 2017). Name them in running text rather than numbering them.
+
+- **Part one — The mark.** Sets the problem and the promise. Establishes that discoverability is a relationship, not a campaign. Houses sections 01 and 02.
+- **Part two — The practice.** Walks the cases that prove open development is the durable mechanism. Houses sections 03 through 10. This is the long middle; pace it with the lightest case first and the largest (Valve) last.
+- **Part three — The stakes.** Widens from craft to consequence: AI, humanity, fears, close. Houses sections 11 through 14.
+
+### The nut graf
+
+Long-form features in *The New Yorker*, *The Atlantic*, and the *Wall Street Journal* place a "nutshell paragraph" after the lead and before the body. It tells the reader, in plain language, what the piece is about and why now (see Chip Scanlan, "The Nut Graf, Part I", Poynter, 2003). For a ten-thousand-word essay the nut graf can be a short paragraph or two. It belongs at the hinge between the opening case (section 01) and the structural reframe (section 02) — the closing paragraph of section 02 is the natural seat. State the claim once, plainly, then return to the cases.
+
+### Toulmin's six elements
+
+Stephen Toulmin's *The Uses of Argument* (Cambridge University Press, 1958) breaks an argument into claim, grounds, warrant, backing, qualifier, and rebuttal. The essay already carries each, distributed: the claim sits in section 02; the grounds are the case studies in sections 03 through 10; the warrant — that visible work compounds into recognition — runs through the devlog and transparency sections; backing arrives via Valve in section 10; the qualifier is the Asparouhova caveat in section 09 and the structural-not-guaranteed line in section 12; the rebuttal is section 13 (fears). When editing, name which element the section is carrying. If two sections carry the same element and add nothing new, one of them is redundant.
+
+### The hourglass
+
+Scientific abstracts open broad, narrow to method, narrow again to findings, then widen to implications (Sollaci and Pereira, "The IMRAD structure: a fifty-year survey", *Journal of the Medical Library Association*, 2004). The essay should follow the same shape at book scale: open on the indie-discoverability problem, narrow to the cases, narrow further to specific exchanges (Thorson and Halfcoordinated; Wube reversing a redesign), widen to AI and humanity, close on the broadest claim the cases have earned.
+
+### Book conventions to adopt
+
+- An epigraph on the title page is optional but recommended; one short quotation, attributed, no commentary.
+- A brief preface or author's note (one or two paragraphs) at the very front, naming what the piece is and what it is not. The essay does not currently have one.
+- Running part titles between sections, set as their own page break.
+- No chapter numbering inside running text. Sections may be referred to by topic ("the inclusivity section"), never by number.


### PR DESCRIPTION
Reference boards content is integrated into the bible now; the standalone section in art/INDEX.md no longer earns its place.