### PR TITLE
chore: clean wiki page titles for index files

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -50,16 +50,42 @@ jobs:
                 my @dir = split m{/}, ($ENV{DIR} // "");
                 my @parts = split m{/}, $p;
                 while (@parts && $parts[0] eq "..") { shift @parts; pop @dir; }
-                my $joined = join("-", @dir, @parts);
-                "]($joined$a)"
+                my @combined = (@dir, @parts);
+                my $target;
+                if (@combined > 1 && $combined[-1] eq "INDEX") {
+                  # designs/<sub>/INDEX.md publishes as <Sub>.md (titlecased leaf).
+                  pop @combined;
+                  my $leaf = pop @combined;
+                  $leaf =~ s/^([a-z])/uc($1)/e;
+                  $leaf =~ s/(-)([a-z])/$1 . uc($2)/ge;
+                  $target = join("-", @combined, $leaf);
+                } elsif (@combined == 1 && $combined[0] eq "INDEX") {
+                  # designs/INDEX.md publishes as Home.
+                  $target = "Home";
+                } else {
+                  $target = join("-", @combined);
+                }
+                "]($target$a)"
               }ge' "$src" > "$dest"
+          }
+
+          # Titlecase a hyphen-separated dir name: 01-prototype -> 01-Prototype, art -> Art.
+          titlecase_dir() {
+            python3 -c 'import sys; print("-".join(p[:1].upper()+p[1:] if p and p[0].islower() else p for p in sys.argv[1].split("-")))' "$1"
           }
 
           for src in designs/**/*.md; do
             rel="${src#designs/}"
             [ "$rel" = "INDEX.md" ] && continue
-            flat="${rel//\//-}"
             dir="$(dirname "$rel")"
+            base="$(basename "$rel")"
+            if [ "$base" = "INDEX.md" ] && [ "$dir" != "." ]; then
+              # designs/<sub>/INDEX.md becomes wiki/<Sub>.md so the wiki page
+              # title is "Sub" instead of "sub-INDEX".
+              flat="$(titlecase_dir "${dir//\//-}").md"
+            else
+              flat="${rel//\//-}"
+            fi
             [ "$dir" = "." ] && dir=""
             copy_with_rewrite "$src" "wiki/$flat" "$dir"
           done

--- a/designs/_Sidebar.md
+++ b/designs/_Sidebar.md
@@ -5,13 +5,13 @@
 - [North Star](north-star)
 
 **By phase**
-- [Prototype](01-prototype-INDEX)
-- [Alpha](02-alpha-INDEX)
-- [Beta](03-beta-INDEX)
-- [Content Updates](04-content-INDEX)
+- [Prototype](01-Prototype)
+- [Alpha](02-Alpha)
+- [Beta](03-Beta)
+- [Content Updates](04-Content)
 
 **Art**
-- [Art](art-INDEX)
+- [Art](Art)
 
 **Process**
 - [Ticket Writing](process-ticket-writing)
@@ -22,4 +22,4 @@
 - [Visual Positioning](research-visual-positioning)
 
 **Roadmaps**
-- [Roadmaps](roadmaps-INDEX)
+- [Roadmaps](Roadmaps)


### PR DESCRIPTION
The wiki sync was publishing each subdirectory's INDEX.md as `<dir>-INDEX.md`, which GitHub renders with the page title "art INDEX" or "01-prototype INDEX". The "INDEX" suffix is a filename convention, not something that belongs in a published title.

Subdirectory INDEX files now publish as titlecased single-word pages: `Art`, `Research`, `Roadmaps`, `01-Prototype`, `02-Alpha`, `03-Beta`, `04-Content`. The top-level `designs/INDEX.md` continues to map to `Home`, and non-INDEX pages keep their existing flattened lowercase names so existing wiki bookmarks for content pages stay valid.

The perl link rewriter learned the same rule, so cross-references like `01-prototype/INDEX.md` resolve to `01-Prototype` rather than the old `01-prototype-INDEX`. `designs/_Sidebar.md` is updated to match.

Tested by running the bash step against the live `designs/` tree into a scratch directory and verifying the eight INDEX-derived pages, the absence of any `-INDEX` artefacts, and the rewritten links in `Home.md`.