### PR TITLE
docs: narrative discipline doc (designs/narrative/)

### DIFF
--- a/designs/narrative/discipline.md
+++ b/designs/narrative/discipline.md
@@ -2,7 +2,7 @@
 
 How the prose, scenes, and dialogue of Volley get made. Not what the story is: that lives in [`outline.md`](outline.md) (sibling, in flight). This is the craft register the writing aims for, line by line.
 
-The voice rules sit one level up in [`../../ai/skills/voice.md`](../../ai/skills/voice.md). The world canon sits in [`../01-prototype/artist-world-bible.md`](../01-prototype/artist-world-bible.md). The protagonist's interior is in [`../characters/protagonist.md`](../characters/protagonist.md). The structural spine is in [`../concept/`](../concept/). Read those first; this doc tells you how to write inside them.
+The prose voice lives in [`../../ai/STYLE.md`](../../ai/STYLE.md). The world canon sits in [`../01-prototype/artist-world-bible.md`](../01-prototype/artist-world-bible.md). The protagonist's interior is in [`../characters/protagonist.md`](../characters/protagonist.md). The structural spine is in [`../concept/`](../concept/). Read those first; this doc tells you how to write inside them.
 
 ## Scene construction
 
@@ -22,9 +22,9 @@ Reality speaks plainer. Half-finished sentences. The thing said while looking at
 
 The protagonist talks less than they are talked to. Their lines are short. They answer when asked, and the answer is usually one beat shorter than expected. The interior is in the protagonist profile; on the page it shows up as economy, not as introspection.
 
-When characters share memories of the shopkeeper, the memory arrives sideways. A coach mid-rally says something the shopkeeper used to say; the sister, turning a page, mentions the time her brother burnt the toast. The memory is the mention, not a story told to camera. No character explains the shopkeeper to the player. Each one knew them differently, and the prose lets that asymmetry sit.
+When characters share memories of the shopkeeper, the memory arrives sideways. A coach mid-rally says something the shopkeeper used to say; the sister, turning a page, mentions the time her brother burnt the toast. The memory is the mention. Each character knew the shopkeeper differently, and the prose lets that asymmetry sit; the player assembles the shopkeeper from the asymmetry, the way grief assembles a person from the people who loved them.
 
-No exposition dumps. If a piece of canon needs to land, it lands as something a character does in front of the protagonist, or as something the world shows. The locked gate is shown, not narrated. The number sits in the phone; nobody tells the player what it is.
+Canon lands as action. A piece of world that needs to reach the player reaches it as something a character does in front of the protagonist, or as something the world shows. The locked gate is shown. The number sits in the phone, ready when the player finds it.
 
 ## Tone modulation
 
@@ -38,11 +38,11 @@ The cliff and the call run thin, then full. The walk to the bench is plain prose
 
 ## Memory surfacings
 
-In Reconstruction rallies, memory shows up as a half-second image. The friend at the counter, an elbow, a tilt of the head, a sentence half-heard. Present tense. Never past-tense framed: "they used to" is exposition; "an elbow on the counter, the head tilted toward the play" is a surfacing.
+In Reconstruction rallies, memory shows up as a half-second image. The friend at the counter, an elbow, a tilt of the head, a sentence half-heard. Present tense. The surfacing puts the image in the room: "an elbow on the counter, the head tilted toward the play". Past-tense framings ("they used to") slide into exposition; the present tense keeps the memory alive in the rally.
 
-The surfacing is brief. One sentence, sometimes a fragment. Never explained, never followed by a beat that tells the player what the memory means. The rally continues. The image fades. The next hit lands.
+The surfacing is brief. One sentence, sometimes a fragment. The image lands and the rally takes it back; the player carries the meaning forward without a beat of explanation. The image fades. The next hit lands.
 
-Surfacings come from a specific moment with the friend at the counter, never from an abstract well of memory. The reader builds the friend out of the particulars across many surfacings: a sleeve, a laugh, the way they handed back a racquet. Generalities ("the friend's warmth", "the old days") are the failure mode.
+Surfacings come from a specific moment with the friend at the counter. The reader builds the friend out of the particulars across many surfacings: a sleeve, a laugh, the way they handed back a racquet. Specificity is the engine; generalities like "the friend's warmth" or "the old days" reach for the meaning before the picture has earned it.
 
 ## Cracks at the line level
 
@@ -54,7 +54,7 @@ A tonal crack in description is a flicker named with weight, not buried. A wrong
 
 The cumulative pattern is the load. One crack is a flourish; a dozen across an act is the world failing to reconcile. The protagonist's construct is failing to reconcile for them in the same shape and at the same pace. Player and protagonist drift out of alignment with Construction together. By the time the break arrives, the player has been collecting evidence the protagonist has been collecting too, and the recognition is shared rather than delivered.
 
-Write the crack, then read it back and ask two questions. Does the player notice? If no, the crack is too soft; sharpen until the beat lands. Does the player have somewhere to put it that is not "the game is telling me the world is fake"? If no, the crack has tipped into signpost; pull back until the in-fiction reach is available again. The target is a beat the player sees clearly and explains away, not a beat the player misses.
+Write the crack, then read it back and ask two questions. Does the player notice? Sharpen until the beat lands. Does the player have somewhere in-fiction to put it, somewhere short of "the game is telling me the world is fake"? Pull back until the in-fiction reach is available again. The target is a beat the player sees clearly and explains away.
 
 ## Pacing rhythms
 
@@ -66,12 +66,12 @@ Settle when the moment settles. A scene with the sister at the table runs in lon
 
 The Construction warmth at credits runs longer paragraphs again, the prose unhurried, light returning. Pacing is not a global setting; it is a per-beat decision, and the beat decides.
 
-## What the writing does not do
+## What the writing reaches for
 
-No closing morals. A scene that ends on what the scene meant has explained itself. End on the loaded particular: the cup, the gate, the hand on the racquet. The reader carries the meaning out.
+Endings land on a particular. The cup, the gate, the hand on the racquet. A scene that closes on the loaded image lets the reader carry the meaning out the door with them; the scene trusts the reader to do that work, and the reader does.
 
-No "this is a story about" framings, in prose or in dialogue. Volley is not about grief and is not about presence; Volley is the rally, the friend at the stall, the cliff and the call. The themes live in what happens, never in what is said about what happens.
+The themes live in what happens. Volley is the rally, the friend at the stall, the cliff and the call. Whatever the story is about arrives through those particulars, and the prose lets it arrive without naming it. Characters and narration alike stay inside the world rather than describing it.
 
-No flashbacks as exposition. Memory surfaces present-tense, brief, in the rally or in the room. A scene that cuts away to "years ago, the protagonist and the friend were…" has stopped trusting the surfacing to do its work.
+Memories arrive as present-tense surfacings. An elbow on the counter, a sleeve, a sentence half-heard, the rally still going on around it. The image does the work a flashback would do, faster, and leaves the rally intact.
 
-No on-the-nose dialogue about themes. Characters talk about the weather, the toast, the score, the bus that did not come. They do not talk about loss, or presence, or the construct. The themes arrive through what the characters do not say, and through what the prose places in the room around them.
+Dialogue plays oblique to the theme it carries. Characters talk about the weather, the toast, the score, the bus that arrived late. The themes ride underneath those conversations, surfacing through what is left in the room rather than through what is said. The reader hears both registers at once and feels the second one most because the first one carried it.

--- a/designs/narrative/discipline.md
+++ b/designs/narrative/discipline.md
@@ -28,7 +28,7 @@ No exposition dumps. If a piece of canon needs to land, it lands as something a 
 
 ## Tone modulation
 
-Tone moves moment to moment. Construction's default is the coach's grin between rallies, the friend at the stall calling a name across the court, the lift in a line that did not need lift. It slips for a beat into a meta-crack, and resettles. The slip is a half-second; the resettle is the rest of the rally. A scene that crackles for two paragraphs has overcommitted.
+Tone moves moment to moment. Construction's default is the coach's grin between rallies, the friend at the stall calling a name across the court, the lift in a line that did not need lift. A meta-crack lands, the player notices and reaches for a way to read it, the rally moves on. The slip is one beat the prose commits to and lets land; the resettle is the rest of the rally. A scene that crackles for two paragraphs has overcommitted.
 
 The break runs cold and short. Sentences shrink. Adjectives drop. Light becomes light, sound becomes sound, the prose stops reaching for warmth because the construct has stopped supplying it. Then the walk through the hometown begins and the prose finds Reality's plainer register for the first time.
 

--- a/designs/narrative/discipline.md
+++ b/designs/narrative/discipline.md
@@ -28,7 +28,7 @@ No exposition dumps. If a piece of canon needs to land, it lands as something a 
 
 ## Tone modulation
 
-Tone moves moment to moment. Construction holds vibrant warmth as the default, slips for a beat into a meta-crack, and resettles. The slip is a half-second; the resettle is the rest of the rally. A scene that crackles for two paragraphs has overcommitted.
+Tone moves moment to moment. Construction's default is the coach's grin between rallies, the friend at the stall calling a name across the court, the lift in a line that did not need lift. It slips for a beat into a meta-crack, and resettles. The slip is a half-second; the resettle is the rest of the rally. A scene that crackles for two paragraphs has overcommitted.
 
 The break runs cold and short. Sentences shrink. Adjectives drop. Light becomes light, sound becomes sound, the prose stops reaching for warmth because the construct has stopped supplying it. Then the walk through the hometown begins and the prose finds Reality's plainer register for the first time.
 
@@ -54,7 +54,7 @@ Deniability is the discipline. A crack the player could name aloud as "the game 
 
 ## Pacing rhythms
 
-Volley's structure inherits its rhythm from the rally. Short sentences land like hits; longer sentences carry the rally between them. Voice's long-long-short pattern is the prose-level version of the same shape.
+A hit lands. The ball arcs back, slower, carrying the rally across the net before the next hit lands. Short sentences hit; longer sentences carry the rally between them. Voice's long-long-short pattern is the prose-level version of the same shape.
 
 Push when the moment pushes. The break wants short sentences in a stack. The cliff walk wants one breath, then the next. The recognition is a single sentence with no qualifier.
 

--- a/designs/narrative/discipline.md
+++ b/designs/narrative/discipline.md
@@ -46,11 +46,15 @@ Surfacings come from a specific moment with the friend at the counter, never fro
 
 ## Cracks at the line level
 
-A meta-crack in dialogue is a line that almost-acknowledges the construct and then moves on. A coach saying "we'll do this again next week, won't we" with a beat of weight on "won't we" that the player half-feels. The line is in-fiction; the weight is the crack. A version of the line that names the construct out loud has tipped into signpost.
+A crack is a visible, authored beat. The player notices. The discipline is not in hiding the crack; the discipline is in the crack earning its place and giving the player something to reach for when they try to explain it.
 
-A tonal crack in description is a flicker, a wrong colour, a sound out of place, named in plain prose and then dropped. "The light cools at the edge of the frame for a beat. It warms again." Two short sentences, no commentary, no character noticing. The reader feels the temperature drop; the text moves on.
+A meta-crack in dialogue is a line that almost-acknowledges the construct. A coach saying "we'll do this again next week, won't we" with weight on "won't we" the player hears. A friend at the stall ending a goodbye with "see you tomorrow, same as always". The line stays in-fiction; the construct stays unnamed; the weight is on the page. The player notices and reaches for an answer: the coach is being warm, the friend is being a friend, the line was meant kindly. The reach is the deniability. Each meta-crack does specific work: it widens the gap between what Construction says about itself and what the player is starting to suspect.
 
-Deniability is the discipline. A crack the player could name aloud as "the game is showing me something" has failed. A crack the player half-felt and shrugged off has worked. Write the crack, then read it back and ask whether a friend reading the page would point at it. If yes, soften.
+A tonal crack in description is a flicker named with weight, not buried. A wrong colour at the edge of a frame. A sound that does not belong to the place it lands in. "The light at the corner of the court goes blue for a beat, then back." "Somewhere behind the stall, a kettle clicks off in a kitchen that is not there." Two sentences, plain prose, no character noticing. The player notices. The player reaches: a lighting cue, a sound bug, an atmospheric flourish. The reach is the deniability. The crack has done its work: it has put a piece of the world out of true and let the player carry it.
+
+The cumulative pattern is the load. One crack is a flourish; a dozen across an act is the world failing to reconcile. The protagonist's construct is failing to reconcile for them in the same shape and at the same pace. Player and protagonist drift out of alignment with Construction together. By the time the break arrives, the player has been collecting evidence the protagonist has been collecting too, and the recognition is shared rather than delivered.
+
+Write the crack, then read it back and ask two questions. Does the player notice? If no, the crack is too soft; sharpen until the beat lands. Does the player have somewhere to put it that is not "the game is telling me the world is fake"? If no, the crack has tipped into signpost; pull back until the in-fiction reach is available again. The target is a beat the player sees clearly and explains away, not a beat the player misses.
 
 ## Pacing rhythms
 

--- a/designs/narrative/discipline.md
+++ b/designs/narrative/discipline.md
@@ -1,0 +1,73 @@
+# Narrative discipline
+
+How the prose, scenes, and dialogue of Volley get made. Not what the story is: that lives in [`outline.md`](outline.md) (sibling, in flight). This is the craft register the writing aims for, line by line.
+
+The voice rules sit one level up in [`../../ai/skills/voice.md`](../../ai/skills/voice.md). The world canon sits in [`../01-prototype/artist-world-bible.md`](../01-prototype/artist-world-bible.md). The protagonist's interior is in [`../characters/protagonist.md`](../characters/protagonist.md). The structural spine is in [`../concept/`](../concept/). Read those first; this doc tells you how to write inside them.
+
+## Scene construction
+
+A Reality scene is a room with several things going on at once. A kettle that has just clicked off. A photo on a side table, half tucked under a magazine. A back at the window, watching the street. The protagonist walks in and the scene does not stop for them; the scene was already running.
+
+The puzzle the player is solving is presence. Not which dialogue option, not which item to pick up. Being in the room long enough to notice what wants to happen. The sister is turning a page; the protagonist can sit, or not. The kettle is cooling; the protagonist can pour, or not. Each interaction is small and contextual and reads as something a person would do without being prompted.
+
+A scene that works has more going on than the player will touch in one visit. A scene that feels flat has been written as a list of interactions: tap A, tap B, leave. Layer first, prune second. If three things are happening and the player engages with one, the other two were not wasted; they were the room.
+
+The geography is built before the people are. Place the nouns: the table is by the window, the book is on the table, the sister is across the table from where the protagonist will sit. The reader walks in behind the protagonist and finds the room already standing. Voice's place-the-nouns rule applies to scene prose word for word.
+
+## Dialogue
+
+Construction speaks warmer and lighter. Coaches perform a little; the friend at the stall keeps things easy; lines have lift. The register is the register of a place that wants to be enjoyable. It is not arch and it is not knowing, but it carries more colour than Reality does.
+
+Reality speaks plainer. Half-finished sentences. The thing said while looking at something else. Long pauses where the prose holds its breath instead of filling. The sister mentions the weather and means the weather; the cashier asks after the protagonist and means it; nothing performs.
+
+The protagonist talks less than they are talked to. Their lines are short. They answer when asked, and the answer is usually one beat shorter than expected. The interior is in the protagonist profile; on the page it shows up as economy, not as introspection.
+
+When characters share memories of the shopkeeper, the memory arrives sideways. A coach mid-rally says something the shopkeeper used to say; the sister, turning a page, mentions the time her brother burnt the toast. The memory is the mention, not a story told to camera. No character explains the shopkeeper to the player. Each one knew them differently, and the prose lets that asymmetry sit.
+
+No exposition dumps. If a piece of canon needs to land, it lands as something a character does in front of the protagonist, or as something the world shows. The locked gate is shown, not narrated. The number sits in the phone; nobody tells the player what it is.
+
+## Tone modulation
+
+Tone moves moment to moment. Construction holds vibrant warmth as the default, slips for a beat into a meta-crack, and resettles. The slip is a half-second; the resettle is the rest of the rally. A scene that crackles for two paragraphs has overcommitted.
+
+The break runs cold and short. Sentences shrink. Adjectives drop. Light becomes light, sound becomes sound, the prose stops reaching for warmth because the construct has stopped supplying it. Then the walk through the hometown begins and the prose finds Reality's plainer register for the first time.
+
+Part 2 defaults to dread. The temperature is low. Warm surfacings are rare and earned: a memory at a rally's apex, a small mercy from the sister, a cup of tea poured without comment. The contrast is the point. Warmth on a dread floor reads brighter than warmth on a warm floor.
+
+The cliff and the call run thin, then full. The walk to the bench is plain prose at minimum volume; the recognition lands in one sentence; the call opens the prose back up, a notch, no more. Credits return Construction's saturated light with Reality's texture worn into it. Each beat has a different temperature; none of them is loud.
+
+## Memory surfacings
+
+In Reconstruction rallies, memory shows up as a half-second image. The friend at the counter, an elbow, a tilt of the head, a sentence half-heard. Present tense. Never past-tense framed: "they used to" is exposition; "an elbow on the counter, the head tilted toward the play" is a surfacing.
+
+The surfacing is brief. One sentence, sometimes a fragment. Never explained, never followed by a beat that tells the player what the memory means. The rally continues. The image fades. The next hit lands.
+
+Surfacings come from a specific moment with the friend at the counter, never from an abstract well of memory. The reader builds the friend out of the particulars across many surfacings: a sleeve, a laugh, the way they handed back a racquet. Generalities ("the friend's warmth", "the old days") are the failure mode.
+
+## Cracks at the line level
+
+A meta-crack in dialogue is a line that almost-acknowledges the construct and then moves on. A coach saying "we'll do this again next week, won't we" with a beat of weight on "won't we" that the player half-feels. The line is in-fiction; the weight is the crack. A version of the line that names the construct out loud has tipped into signpost.
+
+A tonal crack in description is a flicker, a wrong colour, a sound out of place, named in plain prose and then dropped. "The light cools at the edge of the frame for a beat. It warms again." Two short sentences, no commentary, no character noticing. The reader feels the temperature drop; the text moves on.
+
+Deniability is the discipline. A crack the player could name aloud as "the game is showing me something" has failed. A crack the player half-felt and shrugged off has worked. Write the crack, then read it back and ask whether a friend reading the page would point at it. If yes, soften.
+
+## Pacing rhythms
+
+Volley's structure inherits its rhythm from the rally. Short sentences land like hits; longer sentences carry the rally between them. Voice's long-long-short pattern is the prose-level version of the same shape.
+
+Push when the moment pushes. The break wants short sentences in a stack. The cliff walk wants one breath, then the next. The recognition is a single sentence with no qualifier.
+
+Settle when the moment settles. A scene with the sister at the table runs in longer paragraphs that breathe. A coach's quiet line gets a paragraph break before and after. The reader's breath is part of the pacing budget.
+
+The Construction warmth at credits runs longer paragraphs again, the prose unhurried, light returning. Pacing is not a global setting; it is a per-beat decision, and the beat decides.
+
+## What the writing does not do
+
+No closing morals. A scene that ends on what the scene meant has explained itself. End on the loaded particular: the cup, the gate, the hand on the racquet. The reader carries the meaning out.
+
+No "this is a story about" framings, in prose or in dialogue. Volley is not about grief and is not about presence; Volley is the rally, the friend at the stall, the cliff and the call. The themes live in what happens, never in what is said about what happens.
+
+No flashbacks as exposition. Memory surfaces present-tense, brief, in the rally or in the room. A scene that cuts away to "years ago, the protagonist and the friend were…" has stopped trusting the surfacing to do its work.
+
+No on-the-nose dialogue about themes. Characters talk about the weather, the toast, the score, the bus that did not come. They do not talk about loss, or presence, or the construct. The themes arrive through what the characters do not say, and through what the prose places in the room around them.


### PR DESCRIPTION
First pass at the narrative discipline doc, the craft principles for writing the story bulk. Sits next to the new outline doc under `designs/narrative/`. Covers scene construction, dialogue, tone modulation, memory surfacings, line-level cracks, pacing, and what the writing does not do.