### PR TITLE
docs: promote narrative outline to designs/narrative/

### DIFF
--- a/designs/narrative/outline.md
+++ b/designs/narrative/outline.md
@@ -1,0 +1,177 @@
+# Volley! narrative outline
+
+The canonical outline of the story Volley! tells. The art bible (`../01-prototype/artist-world-bible.md`) covers world and tone; the protagonist profile (`../characters/protagonist.md`) covers the arc in close-up; the per-style canon sits in `../concept/`. This document holds the shape of the whole.
+
+## Setting
+
+Pre-smartphone era. Late 90s into early 2000s. Phones are flip, candy-bar, and land-line. Numbers live in heads or on paper, never in pocket databases that auto-name themselves. Period feel runs through the art direction: clothes, signage, phone hardware, photo prints with the date in the corner.
+
+The protagonist's hometown is a small coastal town, the Welsh and Cornish coast in an imagined warmer climate. Painted terraces in seaside colours: pinks, yellows, sea-greens, sky-blues, the actual palette of Tenby and Aberaeron. Whitewashed walls. Palm trees in places. The high street smells of rain and citrus. Mediterranean light on a British coastline. Ordinary, lived-in, faded grandeur with sun on it. The reference points are real; the town sits on no map.
+
+## Two worlds
+
+Volley! has two worlds, two visual treatments, two maps: Construction and Reality.
+
+The player meets Construction first. The premise is that this is the world. Through cracks, a second reading lands: Construction is a construct, not the real world. The garden the player has been rallying in is built from the protagonist's memory of their actual garden in Reality, sprucing it up. The constructed garden and the real garden remain separate places.
+
+## The garden as meeting point
+
+The garden is the one venue where construct and reality meet. Other Construction venues sit in the purely fantastic: underwater, a meteor field, a treetop canopy. None have a Reality counterpart. The garden's "out of place out of time" feel comes from being the one venue grounded in the real hometown.
+
+The title carries the weight of that doubling. A literal place. A tended thing, the protagonist's daily care. Where things grow: the rally, the obsession, the memories. A pre-Fall innocence preserved. A walled enclosure.
+
+## One locked gate
+
+There is exactly one locked gate in the whole game. It sits in the garden. Walking through it transitions to Reality. The cliff is on the other side.
+
+## The court has no top wall
+
+The top edge of the court is sky, not surface. The ball travels up to apex and returns under gravity and the friendship-bound: the bond between the protagonist and the friend at the stall is what the rally lives inside, and the bond's reach is what the ball cannot escape. Mechanically the ball changes direction at apex; diegetically nothing physical bounces it.
+
+The moment of return is a visible beat in Construction's register. A bloom of light, a brief connecting arc, a satisfying synth chime, a reaction from the friend at the stall: eyes up, racquet lift, a small gesture from the counter. Satisfying, not loud. Each rally point closes on this beat. The friend is a co-celebrant of the return, not scenery.
+
+The garden carries the apex event through the friend's reaction, since it has no physical ceiling. Other Construction venues use physical referents that play the same role: the treetop canopy, the underwater surface, the meteor field. The bond is what the friendship actually is in every venue.
+
+The Reconstruction implication is open. If the apex event is the friendship visualised, the bloom and chime should thin or fall silent in the garden once the friend is gone. The rally returns mechanically, and the celebratory beat does not. The hollow in Construction's warm centre lands in the rally's own texture. Whether this carries across all Construction venues or specifically the garden is still to decide.
+
+The bottom edge of the court stays physical: the ground, the mat, the surface where the racquet meets the ball. Left and right remain open as miss zones.
+
+A friend reaction per rally point is animated state on the stall character. Even one looped frame plus a short return reaction is per-frame work the artist signs up for. Worth scoping with Aubrey before this lands as a hard requirement.
+
+## Friendship as wind
+
+The bond is treated, in the fiction and in the rally physics, as the medium the ball moves through. In the garden, the wind is the friendship; in the other Construction venues, the same bond expresses through whatever the venue offers. The friendship is not metaphorically present in the rally. It is the rally's invisible structure. When the bond thins, the rally still happens, and the air around it moves differently.
+
+## Cast
+
+The protagonist is mid-30s, androgynous, agender, less athletic than they used to be. Drawn like any other character in both styles: a Construction render and a Reality render. Visible throughout. Picked up a racquet long ago and never quite put it down. Lost their best friend years ago to a cliff-jumping accident. Pushed away the shopkeeper.
+
+The shopkeeper stands behind the counter of the small wooden stall in Construction's garden. The warm centre of the venue. In Reality, alive, in the hometown, withdrawn, the person the protagonist pushed away. Was cliff-jumping with the friend the day they died; the protagonist was not there. The protagonist's relationship to them is the load-bearing emotional shape of the game.
+
+The sister is the tinkerer's real-world counterpart. The shopkeeper's younger sister. Less weighted by the death than the shopkeeper. Holds the photo album. The bridge.
+
+Martha and the partners are real people from the protagonist's life, summoned into Construction as coach-partners. Each teaches one mechanic through the rally. Each has a Reality render at their actual age, in their actual life. The naming convention: each partner is named for a character from a science-fiction author's work.
+
+The dead friend died years ago in a cliff-jumping accident. Cliff jumping was a normalised activity in the friend group: dangerous, but routine, until it wasn't. The reason the protagonist built Construction.
+
+The champ is the dead friend rendered into Construction as the championship final. A Construction-only construct, no Reality counterpart. Someone the protagonist looks up to, never a rival. The player wins the championship by beating them; the champ exits at the end of Part 1.
+
+The tinkerer is the sister's Construction render. Workshop in another corner of the garden.
+
+## The unnamed number
+
+The shopkeeper's phone number is in the protagonist's phone, sitting in the call log or contacts list, unnamed. The protagonist either deleted the contact, never saved the name, or the device just holds digits without labels. Period-appropriate.
+
+The player has full control of the phone throughout. The number is dialable any time: Construction, Reconstruction, before the cliff. It never connects. The shopkeeper has withdrawn and isn't picking up.
+
+The unnamed number is the load-bearing mechanic across both acts. The player's reaching out, with no answer back, is the protagonist's reaching out, with no answer back.
+
+## Part 1: Construction
+
+### The hook
+
+The protagonist's stated goal is the world volley record. Friends help along the way. The count climbs. The tournament gives the structural shape: each main venue hosts one round; coach-partners train the protagonist in mechanics that compose into the kit; the championship at the top of the ladder is the goal.
+
+What the player does not know yet: the world record is the shopkeeper's phone number.
+
+### Cracks
+
+Reality leaks into Construction in small atmospheric ways. Two flavours.
+
+Tonal cracks live inside Construction's fiction. A flicker in the venue light. A partner's tilt held a beat too long. A colour cooling at the edge of the frame. Atmospheric oddness.
+
+Meta-contextual cracks live outside the fiction, in the surfaces around it. A music cue that skips. A UI element that blinks the wrong colour. A loading screen that says something it should not. A pause-menu wording that shifts.
+
+Both authored, both deniable. Never concrete leakage; no real-world object literally appears inside Construction.
+
+### The championship and the win
+
+The protagonist climbs every round. The obsession with becoming champ deepens. The double meaning carries: become the champion, win the thing; and become the dead friend, the champ in their construction.
+
+The player wins the championship. They beat the champ.
+
+The win feels off, in the way real-world achievement does not equal happiness. The win was supposed to fix the protagonist; it didn't. Both pulls of "becoming champ" satisfy, and neither was the thing.
+
+The win is the break. The construct cannot hold itself together once its central goal has been achieved and proved meaningless.
+
+At the win moment, the count completes. The digits land. The protagonist sees them, vaguely familiar, and the connection does not form. The number stays unnamed in their phone. Recognition is held until the cliff.
+
+### After the win
+
+The player is pulled into Reality involuntarily for the first time. Walks through the protagonist's hometown. Sees the people behind the partners. Discovers that the shopkeeper is missing. The shop is empty. The family is worried. The person the protagonist was reaching for without admitting it has actually disappeared.
+
+The champ exits at this point. Not in Part 2.
+
+End of Part 1.
+
+## Part 2: Reconstruction
+
+### Emotional state and driving force
+
+The driving feeling is dread. The player believes the shopkeeper is gone, has followed the dead friend's path, is lost. The unnamed number doesn't connect; the no-answer state is the player-facing weight of the protagonist's ineffectual reaching.
+
+The driving force is the search for what happened. Not "find the shopkeeper" generically, but "find out what they did, where they went, whether it's too late." The work is the search-for-confirmation, all of it shadowed by the fear that the confirmation will be terrible.
+
+### Mechanics
+
+The sister has the photo album. Half-filled, with a hidden compartment that won't open until enough pages are filled.
+
+Volley becomes memory recall. Each rally surfaces a memory; each memory becomes a photo, or unlocks one; each photo points to a place in Reality where the shopkeeper might be, or left a trace. Coaches share their own memories of the shopkeeper as the player rallies with them. The volley is the search done sideways.
+
+Reality scenes are hand-crafted, gated by photos. Each found photo unlocks a hand-crafted Reality scene; the photo and the scene together compound the trail.
+
+The unnamed number stays unnamed. No fragments surface. No partial recognition. The number sits in the phone throughout Construction and Reconstruction, dialable, never picked up. The reveal is held until the cliff.
+
+### Three play-level differentiators
+
+Reconstruction must feel different. Three changes carry that.
+
+The score is hidden. The count climbed visibly through Part 1; in Part 2 the number disappears from the rally HUD. The player rallies without seeing the count. The number can be checked, but only in Reality: the sister's, the closed shop, the cliff once unlocked.
+
+The champ's dialogue softens gradually. The champ exits at the end of Part 1, so this beat may shift onto a partner who absorbs some of those lines, or drop. To reconcile.
+
+Audio shifts. Construction's bright synthetic music thins; acoustic instruments arrive; balance moves toward fuller arrangement by late Part 2. Full direction sits in the audio docs.
+
+### Reaching the key
+
+The album fills. The hidden compartment opens. The key is inside.
+
+The sister hands it over.
+
+The player returns to the first venue, the garden, with the key. Walks to the locked gate. Unlocks it. Walks through to Reality.
+
+## The cliff and the call
+
+### The cliff
+
+The protagonist arrives at the cliff. The bench is there, dedicated to the friend who died. The shopkeeper is on the bench. Alive.
+
+The Act 2 dread inverts. Relief. The fear was wrong. They've been here, withdrawn, refusing calls.
+
+### The dial
+
+The protagonist sees the shopkeeper on the bench. Recognition lands at the cliff for the first time: the unnamed number in their phone, the world record they reached, the digits the championship match resolved on, the shopkeeper sitting in front of them, all of it the same number. Held in the phone the whole game, never named, only now legible.
+
+The protagonist takes out their phone. They could walk up silently. They don't. They dial the unnamed number, knowing now whose it is. The shopkeeper's phone rings on the bench beside them. They could ignore it like they've been ignoring all the others. They don't. They look up at the sound. See the protagonist. Pick up.
+
+The dial does two things at once: chosen presence, and finally attaching the name to the number. The phone log entry is no longer just digits.
+
+### Staging
+
+A split frame at the path, the bench, the phones. The protagonist outside the bench area; the shopkeeper on the bench, holding their phone. The dial bridges intention, not space. They look at each other across the small distance, both holding their phones. After the touchstone of *Broken Age*'s key art, two characters sharing one frame divided by a structural element. Then the protagonist crosses, sits beside them. The call ends.
+
+## Credits
+
+Credits play over the protagonist and the shopkeeper volleying. The first rally between them. Construction's championship spot now occupied by the actual person, not the substitute. The rally is the proof: the daily thing the protagonist did alone is finally done together.
+
+The visual style is Construction's saturated, generous light, with the texture Reality has worn into it across Reconstruction. The bench from the cliff is visible somewhere, maybe in a corner, maybe glimpsed past the gate that now stays open.
+
+The audio sits in synthesis at exactly the visual moment of synthesis. The synth warmth that opened the game returns layered with the acoustic instruments Reality brought.
+
+## Postgame
+
+Rallying with the shopkeeper as the championship-spot partner. The cliff stays returnable through the now-unlocked gate. Construction has its centre back, as the actual relationship rather than the substitute.
+
+## Cross-references
+
+The art bible at `../01-prototype/artist-world-bible.md` carries world rendering, the Six Marks, and tone direction. The protagonist profile at `../characters/protagonist.md` carries the arc in close-up. The per-style canon, including audio direction, sits in `../concept/`. The discipline doc at `discipline.md` is the parallel branch on player practice and ritual.

--- a/designs/narrative/outline.md
+++ b/designs/narrative/outline.md
@@ -58,7 +58,7 @@ Martha and the partners are real people from the protagonist's life, summoned in
 
 The dead friend died years ago in a cliff-jumping accident. Cliff jumping was a normalised activity in the friend group: dangerous, but routine, until it wasn't. The reason the protagonist built Construction.
 
-The champ is the dead friend rendered into Construction as the championship final. A Construction-only construct, no Reality counterpart. Someone the protagonist looks up to, never a rival. The player wins the championship by beating them; the champ exits at the end of Part 1.
+The champ is the dead friend rendered into Construction as the championship final. A Construction-only construct, no Reality counterpart. Someone the protagonist looks up to, painted at championship scale because that is the size the friendship sits at in the protagonist's chest. The player wins the championship by beating them; the champ exits at the end of Part 1.
 
 The tinkerer is the sister's Construction render. Workshop in another corner of the garden.
 

--- a/designs/narrative/outline.md
+++ b/designs/narrative/outline.md
@@ -26,21 +26,25 @@ There is exactly one locked gate in the whole game. It sits in the garden. Walki
 
 ## The court has no top wall
 
-The top edge of the court is sky, not surface. The ball travels up to apex and returns under gravity and the friendship-bound: the bond between the protagonist and the friend at the stall is what the rally lives inside, and the bond's reach is what the ball cannot escape. Mechanically the ball changes direction at apex; diegetically nothing physical bounces it.
+The top edge of the court is sky, not surface. The ball travels up to apex and returns under gravity and the friendship-bound: whichever bond is in play in that venue is what the rally lives inside, and the bond's reach is what the ball cannot escape. Mechanically the ball changes direction at apex; diegetically nothing physical bounces it.
 
-The moment of return is a visible beat in Construction's register. A bloom of light, a brief connecting arc, a satisfying synth chime, a reaction from the friend at the stall: eyes up, racquet lift, a small gesture from the counter. Satisfying, not loud. Each rally point closes on this beat. The friend is a co-celebrant of the return, not scenery.
+The moment of return is a visible beat in Construction's register. A bloom of light, a brief connecting arc, a satisfying synth chime, a reaction from the present friend: eyes up, racquet lift, a small gesture from wherever they stand. Satisfying, not loud. Each rally point closes on this beat. The friend is a co-celebrant of the return, not scenery.
 
-The garden carries the apex event through the friend's reaction, since it has no physical ceiling. Other Construction venues use physical referents that play the same role: the treetop canopy, the underwater surface, the meteor field. The bond is what the friendship actually is in every venue.
+The garden's version of the apex event runs through the shopkeeper's reaction at the stall, since the venue has no physical ceiling and the shopkeeper is the bond the garden holds. Other Construction venues run the same beat through the coach who teaches there: the partner's reaction at the treetop canopy, at the underwater surface, in the meteor field. The bond doing the work changes by venue. The pattern is the same.
 
-The Reconstruction implication is open. If the apex event is the friendship visualised, the bloom and chime should thin or fall silent in the garden once the friend is gone. The rally returns mechanically, and the celebratory beat does not. The hollow in Construction's warm centre lands in the rally's own texture. Whether this carries across all Construction venues or specifically the garden is still to decide.
+The Reconstruction implication follows from the same logic. The garden's bloom and chime thin or fall silent once the shopkeeper is gone, because the bond that carried them is broken. The rally returns mechanically, and the celebratory beat does not. The hollow in Construction's warm centre lands in the rally's own texture. The other Construction venues, with their coaches still present, keep their wind.
 
 The bottom edge of the court stays physical: the ground, the mat, the surface where the racquet meets the ball. Left and right remain open as miss zones.
 
-A friend reaction per rally point is animated state on the stall character. Even one looped frame plus a short return reaction is per-frame work the artist signs up for. Worth scoping with Aubrey before this lands as a hard requirement.
+A reaction per rally point is animated state on whichever character holds the bond in that venue: the shopkeeper at the stall in the garden, the coach in their own venue elsewhere. Even one looped frame plus a short return reaction is per-frame work the artist signs up for, multiplied across every venue. Worth scoping with Aubrey before this lands as a hard requirement.
 
 ## Friendship as wind
 
-The bond is treated, in the fiction and in the rally physics, as the medium the ball moves through. In the garden, the wind is the friendship; in the other Construction venues, the same bond expresses through whatever the venue offers. The friendship is not metaphorically present in the rally. It is the rally's invisible structure. When the bond thins, the rally still happens, and the air around it moves differently.
+Friendship, treated as a force, is the medium the ball moves through. Each bond in the protagonist's life is its own wind. The garden's wind is the bond with the shopkeeper. The treetop venue's wind is the bond with the coach who teaches there. The underwater venue's wind is the bond with the coach who teaches there. The protagonist's bonds, taken together, carry the rally across the whole game.
+
+The friendships are not metaphorically present in the rally. They are the rally's invisible structure. The shopkeeper bond is the load-bearing one for the story arc, the warm centre Construction is built around. The coach bonds are real in their own right, each one the wind in its own venue.
+
+When a bond thins, the rally still happens, and the air around it moves differently. The garden in Reconstruction shows this directly. The other venues, with their winds intact, still play.
 
 ## Cast
 


### PR DESCRIPTION
Public canonical narrative outline at `designs/narrative/outline.md`, promoted from the gitignored scratchpad. Holds the beat-by-beat story canon (setting, two worlds, garden, locked gate, court has no top wall, friendship-as-wind, cast, unnamed number, Part 1, Part 2, cliff and call, credits, postgame). Defers to the bible for tone, MC profile for protagonist, concept docs for structural detail.