### PR TITLE
docs: external touchstone links in spike concept docs

### DIFF
--- a/designs/concept/01-construction.md
+++ b/designs/concept/01-construction.md
@@ -98,7 +98,7 @@ The prototype's job is to land the championship-shape: meet a coach, learn from 
 - **Round match format.** Pong with items and effects active, 1v1, no partner on court. What is the win condition? First-to-N points? Reach a count threshold against the coach's pressure? Survive a number of returns?
 - **Tournament round count for the full game.** SH-275 will name venues. One round per venue means tournament length tracks venue count.
 - **Drop-out behaviour.** If the player loses a round, what happens? Re-attempt? Train more?
-- **Encounter shape per round.** The round-match staging needs sharpening; the gym-leader framing reads close to Omori and is being reworked toward something venue-specific.
+- **Encounter shape per round.** The round-match staging needs sharpening; the gym-leader framing reads close to [Omori](https://en.wikipedia.org/wiki/Omori_(video_game)) and is being reworked toward something venue-specific.
 
 ## Production notes
 

--- a/designs/concept/02-cracks-and-break.md
+++ b/designs/concept/02-cracks-and-break.md
@@ -6,7 +6,7 @@ The wall thinning across Part 1, the championship win that lands wrong, and the 
 
 Reality leaks into Construction in small atmospheric ways across Part 1. Each leak is dismissible on its own. The cumulative pressure is what matters.
 
-Cracks earn their dismissibility from prior generosity. Construction has to land as genuinely fun before a single crack works. Spec Ops's first heat shimmer arrives roughly three hours in, after the player has settled into a competent-soldier rhythm; Doki Doki's first poem night arrives after hours of dating-sim warmth; Inscryption's first scrybe-room break arrives once the player has earned the deck. Volley's idle pacing scales these numbers up; the principle holds.
+Cracks earn their dismissibility from prior generosity (see [Pattern 1](../research/game-structure-references.md#pattern-1-cracks-earn-dismissibility-from-prior-generosity)). Construction has to land as genuinely fun before a single crack works. [Spec Ops: The Line](https://en.wikipedia.org/wiki/Spec_Ops:_The_Line)'s first heat shimmer arrives roughly three hours in, after the player has settled into a competent-soldier rhythm; [Doki Doki Literature Club](https://en.wikipedia.org/wiki/Doki_Doki_Literature_Club!)'s first poem night arrives after hours of dating-sim warmth; [Inscryption](https://en.wikipedia.org/wiki/Inscryption)'s first scrybe-room break arrives once the player has earned the deck. Volley's idle pacing scales these numbers up; the principle holds.
 
 ### Two kinds of crack
 

--- a/designs/concept/04-reality.md
+++ b/designs/concept/04-reality.md
@@ -16,7 +16,7 @@ Characters are at their actual ages. Less vibrant, less full, deliberately uncon
 
 The pull of Reality is its honesty. The player ends up wanting it.
 
-Touchstones: Spiritfarer's quieter moments, Lake, Omori's Faraway Town. Loss is acknowledged; the prose breathes; the rally is not the engine here.
+Touchstones: [Spiritfarer](https://store.steampowered.com/app/972660/Spiritfarer_Farewell_Edition/)'s quieter moments, [Lake](https://store.steampowered.com/app/1812120/Lake/), [Omori](https://en.wikipedia.org/wiki/Omori_(video_game))'s Faraway Town. Loss is acknowledged; the prose breathes; the rally is not the engine here.
 
 ## Audio register
 


### PR DESCRIPTION
Adds inline external links (Wikipedia + Steam) to touchstones named in the spike concept docs, matching the bible's section-16 pattern. Eight touchstones linked across 01, 02, 04 (Spec Ops, Doki Doki, Inscryption, Omori in 01/02, Spiritfarer/Lake/Omori in 04, plus internal cross-link to Pattern 1).