### PR TITLE
chore: strip leading H1 from wiki pages

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -44,7 +44,10 @@ jobs:
             #   - flatten internal slashes to dashes
             #   - prefix bare relative links with the source file's folder
             # [^):] in the character class excludes "://" so http URLs are untouched.
-            DIR="$dir" perl -pe '
+            # Slurp mode (-0777) lets us also strip the file's leading H1 in one pass:
+            # the wiki publisher injects the page title from the filename, so leaving
+            # the source's first `# Heading` produces a duplicate title row.
+            DIR="$dir" perl -0777 -pe '
               s{\]\(([^):\s]+)\.md(\#[^)]*)?\)}{
                 my ($p, $a) = ($1, $2 // "");
                 my @dir = split m{/}, ($ENV{DIR} // "");
@@ -66,7 +69,13 @@ jobs:
                   $target = join("-", @combined);
                 }
                 "]($target$a)"
-              }ge' "$src" > "$dest"
+              }ge;
+              # Strip the very first leading H1 (and the blank line after it, if any).
+              # Anchored at start-of-file so navigation files like _Sidebar.md, whose
+              # first line is bold-link text rather than `# `, are untouched, and so
+              # subsequent `# Headings` deeper in the document survive.
+              s{\A\# [^\n]*\n\n?}{};
+            ' "$src" > "$dest"
           }
 
           # Titlecase a hyphen-separated dir name: 01-prototype -> 01-Prototype, art -> Art.


### PR DESCRIPTION
The wiki publisher renders the page title from the filename, so every page on the wiki now ends up with two stacked titles: the publisher's own H1 from the slug, and the source file's first `# Heading` directly below it. The duplicate is purely cosmetic but it's on every page.

This extends the existing `copy_with_rewrite` perl pass in `sync-wiki.yml` (slurp mode now, so we get the whole file in `$_`) with one extra substitution that strips the very first `# ` line and the blank line after it. Anchored at start-of-file, so `_Sidebar.md` (whose first line is bold-link navigation, not an H1) and any deeper `# Headings` inside a doc are untouched. Source files on disk and on the GitHub-rendered repo still carry their H1 — only the wiki copies lose it.

Verified locally by running the patched bash step against `designs/` into `/tmp/wiki-test-h1`: 112 pages produced, leading H1 stripped on every doc that had one, `_Sidebar.md` and `itch-description.md` (no leading H1) untouched, and the multi-H1 file `04-shop-drag-drop.md` went from 5 H1s to 4 (only the leader removed).