### PR TITLE
docs: H1 titles to Title Case across designs

### DIFF
--- a/designs/01-prototype/09-item-ui.md
+++ b/designs/01-prototype/09-item-ui.md
@@ -1,4 +1,4 @@
-# Item UI — Diegetic Drag and Drop
+# Item UI: Diegetic Drag and Drop
 
 Design notes for how items are presented and manipulated in the UI.
 

--- a/designs/01-prototype/15-deferred-item-work.md
+++ b/designs/01-prototype/15-deferred-item-work.md
@@ -1,4 +1,4 @@
-# Deferred item work
+# Deferred Item Work
 
 Tracking incomplete item features that depend on external systems not yet built (partners, kit UI, art direction). Features that only need new effect types belong in the item's ticket, not here.
 

--- a/designs/art/character-lighting.md
+++ b/designs/art/character-lighting.md
@@ -1,4 +1,4 @@
-# Character lighting pipeline
+# Character Lighting Pipeline
 
 Post-prototype scope. Volley!'s prototype authors character lighting into the sprite per venue: the painted light is the light the characters see, and the characters are painted to match it. This doc captures the dynamic light-state pipeline planned for the full-pass art phase, so the direction is recorded without committing prototype time to implementation.
 

--- a/designs/north-star.md
+++ b/designs/north-star.md
@@ -1,4 +1,4 @@
-# Volley! - North Star
+# Volley!: North Star
 
 ## What is this game?
 

--- a/designs/process/swarm-architecture.md
+++ b/designs/process/swarm-architecture.md
@@ -1,4 +1,4 @@
-# Swarm architecture
+# Swarm Architecture
 
 How Volley's parallel agent system is shaped, why it is shaped that way, and where the open edges still are. Reference material (role rosters, commit templates, tier table) lives in [`ai/swarm/README.md`](../../ai/swarm/README.md); the live coordination board lives in [`ai/PARALLEL.md`](../../ai/PARALLEL.md). This doc is the design layer above both.
 

--- a/designs/research/STYLE.md
+++ b/designs/research/STYLE.md
@@ -1,4 +1,4 @@
-# Style guide for the open-development essay
+# Style Guide for the Open-Development Essay
 
 This is the working style guide for every contributor (human or agent) editing the essay in `designs/research/drafts/`. Read it once before touching a section; follow it on every line.
 

--- a/designs/research/meta/BOOK-EXTENSION.md
+++ b/designs/research/meta/BOOK-EXTENSION.md
@@ -1,4 +1,4 @@
-# Notes for a book-length extension
+# Notes for a Book-Length Extension
 
 The essay makes the case for open development as one practice. A book would break the practice into its constituent disciplines and argue each independently. Each discipline is a distinct production decision a studio makes, with its own evidence base, its own counter-arguments, and its own people. The essay treats them as one bundled case because that is what an essay can do. A book has the room to give each discipline its own chapter (or short part) and prove it on its own merits, so a reader convinced of one but not another still has somewhere to land.
 

--- a/designs/research/meta/PERSUASION-AUDIT.md
+++ b/designs/research/meta/PERSUASION-AUDIT.md
@@ -1,4 +1,4 @@
-# Persuasion audit: *The Case for Open Development*
+# Persuasion Audit: *The Case for Open Development*
 
 A read of the essay against the canon of argumentation, rhetoric, and long-form essay craft. Line numbers refer to `designs/research/the-case-for-open-development.md` as it stands. Section names match the essay's running heads. Style guide constraints (`STYLE.md`) are treated as the boundary; nothing proposed here pushes against them. Where a fix would technically work but cuts against voice (manifesto sign-off, second-person command, signposting), it is not proposed.
 

--- a/designs/research/open-development-plan.md
+++ b/designs/research/open-development-plan.md
@@ -1,4 +1,4 @@
-# Open Development as the Path for New Indies — Essay Plan
+# Open Development as the Path for New Indies: Essay Plan
 
 A scaffolding document. The essay earns its argument through peer evidence before it ever names itself.
 

--- a/designs/tech-art/INDEX.md
+++ b/designs/tech-art/INDEX.md
@@ -1,4 +1,4 @@
-# Tech art
+# Tech Art
 
 The seam between art and engine. Pipelines that need both disciplines to land sit here: the painted sprite that the runtime tints, the authored animation that the rig drives, the LUT that the artist tunes and the shader that applies it.
 

--- a/designs/tech-art/grading.md
+++ b/designs/tech-art/grading.md
@@ -1,4 +1,4 @@
-# Colour grade pipeline
+# Colour Grade Pipeline
 
 The garden in late afternoon is warm, saturated, gleaming. The same garden in Reality is cooler, looser, weather in the air. Same silhouettes, same staging, different register. Volley! ships both, and the seam where the artist's neutral PNG becomes a registered surface is a runtime colour grade.
 


### PR DESCRIPTION
Sweeps 11 H1 lines to Title Case (Tech art → Tech Art, Style guide → Style Guide, Item UI etc) and replaces em dashes / hyphens in titles with colons. Source files retain H1; the wiki sync workflow strips it on publish per #456.