### PR TITLE
docs: refresh INDEX and Sidebar with new docs

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -4,40 +4,59 @@ The design thinking behind Volley!, organised by subject. Each folder has its ow
 
 ## Start here
 
-| Doc | Description |
+| Doc | Purpose |
 |---|---|
-| [North Star](north-star.md) | What the game is, who it's for, and why it matters |
-| [Roadmap](roadmap.md) | The five phases at a glance |
+| [North Star](north-star.md) | What the game is, who it's for, and why it matters. |
+| [Roadmap](roadmap.md) | The five phases at a glance. |
 
 ## By phase
 
-| Phase | Folder | Description |
+| Phase | Folder | Purpose |
 |---|---|---|
-| Prototype | [01-prototype/](01-prototype/INDEX.md) | Public demo on itch.io |
-| Alpha | [02-alpha/](02-alpha/INDEX.md) | Construction era content-complete, the break designed |
-| Beta | [03-beta/](03-beta/INDEX.md) | Reconstruction and both endings playable |
-| Content Updates | [04-content/](04-content/INDEX.md) | Supplementary content |
+| Prototype | [01-prototype/](01-prototype/INDEX.md) | Public demo on itch.io. |
+| Alpha | [02-alpha/](02-alpha/INDEX.md) | Construction era content-complete, the break designed. |
+| Beta | [03-beta/](03-beta/INDEX.md) | Reconstruction and both endings playable. |
+| Content Updates | [04-content/](04-content/INDEX.md) | Supplementary content past the main game. |
 
 ## By discipline
 
-| Folder | Description |
+| Folder | Purpose |
 |---|---|
-| [art/](art/INDEX.md) | The art bible, direction, style workshop, and inspirations |
-| [platform/](platform/threaded-web-export.md) | Platform and distribution decisions (web export, hosting) |
+| [art/](art/INDEX.md) | Art bible, direction, inspirations, and the rendering pipeline. |
+| [tech-art/](tech-art/INDEX.md) | The seam between art and engine: LUTs, shaders, authoring contracts. |
+| [narrative/](narrative/) | Story discipline and the through-line outline. |
+| [platform/](platform/threaded-web-export.md) | Platform and distribution decisions: web export, hosting. |
+
+### Narrative
+
+| Doc | Purpose |
+|---|---|
+| [Discipline](narrative/discipline.md) | The writing rules the story holds itself to. |
+| [Outline](narrative/outline.md) | The arc from Construction through the break to Reconstruction. |
+
+### Tech art
+
+| Doc | Purpose |
+|---|---|
+| [Colour Grade Pipeline](tech-art/grading.md) | Per-style and per-venue LUTs, the neutral-sprite contract, the runtime shader. |
 
 ## Process
 
-| Doc | Description |
+| Doc | Purpose |
 |---|---|
-| [Ticket Writing](process/ticket-writing.md) | How we write Linear and GitHub issues |
-| [Labels](process/labels.md) | The label taxonomy and what each label means |
-| [Swarm Architecture](process/swarm-architecture.md) | How the parallel agent system is shaped and why |
+| [Ticket Writing](process/ticket-writing.md) | How we write Linear and GitHub issues. |
+| [Labels](process/labels.md) | The label taxonomy and what each label means. |
+| [Swarm Architecture](process/swarm-architecture.md) | How the parallel agent system is shaped and why. |
 
 ## Research
 
-See [research/INDEX.md](research/INDEX.md) for the full list.
+The full list lives in [research/INDEX.md](research/INDEX.md). Highlights:
 
-| Doc | Description |
+| Doc | Purpose |
 |---|---|
-| [Visual Positioning](research/visual-positioning.md) | Where Volley! sits visually among its neighbours |
-| [Early Clone Games](research/early-clone-games.md) | Why Breakout's clone lineage outlasted Pong's |
+| [The Case for Open Development](research/the-case-for-open-development.md) | The published essay on open development as the most reliable practice for a new indie to be seen. |
+| [STYLE.md](research/STYLE.md) | The style guide every editor (human or agent) reads before touching long-form prose. |
+| [Visual Positioning](research/visual-positioning.md) | Where Volley! sits visually among its neighbours. |
+| [Early Clone Games](research/early-clone-games.md) | Why Breakout's clone lineage outlasted Pong's. |
+| [Open Development Plan](research/open-development-plan.md) | The earlier internal plan that seeded the essay. |
+| [Why AI Loves Em Dashes](research/ai/why-ai-loves-em-dashes.md) | A short paper on a typographic tic with surprisingly load-bearing causes. |

--- a/designs/_Sidebar.md
+++ b/designs/_Sidebar.md
@@ -1,8 +1,8 @@
 **[Home](Home)**
 
 **Top-level**
-- [Roadmap](roadmap)
 - [North Star](north-star)
+- [Roadmap](roadmap)
 
 **By phase**
 - [Prototype](01-Prototype)
@@ -13,10 +13,26 @@
 **Art**
 - [Art](Art)
 
+**Tech art**
+- [Tech Art](Tech-Art)
+- [Colour Grade Pipeline](tech-art-grading)
+
+**Narrative**
+- [Discipline](narrative-discipline)
+- [Outline](narrative-outline)
+
+**Platform**
+- [Threaded Web Export](platform-threaded-web-export)
+
 **Process**
 - [Ticket Writing](process-ticket-writing)
 - [Labels](process-labels)
+- [Swarm Architecture](process-swarm-architecture)
 
 **Research**
-- [Early Clone Games](research-early-clone-games)
+- [The Case for Open Development](research-the-case-for-open-development)
+- [Style Guide](research-STYLE)
 - [Visual Positioning](research-visual-positioning)
+- [Early Clone Games](research-early-clone-games)
+- [Open Development Plan](research-open-development-plan)
+- [Why AI Loves Em Dashes](research-ai-why-ai-loves-em-dashes)


### PR DESCRIPTION
Wiki consistency sweep. INDEX restructured into Start here / By phase / By discipline (narrative + tech-art subtables) / Process / Research. Sidebar mirrors. New docs added: tech-art, narrative, STYLE, open-development essay + plan, AI em-dashes paper. Phantom style-workshop reference dropped.

Narrative entries point at files only present on PRs #451/#452; links resolve once those merge.