### PR TITLE
docs: sweep architectural register to style across art/ and tech-art/

### DIFF
--- a/designs/art/INDEX.md
+++ b/designs/art/INDEX.md
@@ -7,6 +7,6 @@ The living reference for Volley!'s visual direction. Concept studies and product
 | [Art Bible](bible.md) | Canonical rules: palette, silhouette, line, mood, era, treatment. The source of truth for visual direction. |
 | [Direction](direction.md) | The creative direction distilled into themes. The narrative layer that feeds the bible. |
 | [Inspirations](inspirations.md) | Works Volley! has looked at; factual attribution list. |
-| [Tech Pipeline](tech-pipeline.md) | How the style is implemented in Godot: rendering, assets, register shifts. |
+| [Tech Pipeline](tech-pipeline.md) | How the style is implemented in Godot: rendering, assets, style shifts. |
 | [Character Lighting](character-lighting.md) | Post-prototype dynamic light-state pipeline for characters across venues. |
 

--- a/designs/art/bible.md
+++ b/designs/art/bible.md
@@ -8,7 +8,7 @@ The bible is the decision layer. [Direction](direction.md) is the narrative; thi
 
 ## The Six Marks
 
-Every piece of art in Volley! carries all six. Not style rules, not commandments: Shuck is a sanctuary for craft, not a place that tells people what to make. The Six Marks describe what Volley! looks like when the work is landing, so an artist working on any asset, any screen, either register, has something to hold the work up against rather than a set of commands to obey.
+Every piece of art in Volley! carries all six. Not style rules, not commandments: Shuck is a sanctuary for craft, not a place that tells people what to make. The Six Marks describe what Volley! looks like when the work is landing, so an artist working on any asset, any screen, either style, has something to hold the work up against rather than a set of commands to obey.
 
 **Intentional.** Every mark, colour, and placement is a choice. Nothing is filler, nothing is accidental.
 
@@ -20,11 +20,11 @@ Every piece of art in Volley! carries all six. Not style rules, not commandments
 
 **Breathing.** Feels alive. Movement carries personality. Still frames feel about to move.
 
-**Shifting.** Designed for more than one state. The constructed register and the real register do not look the same, and both are Volley!.
+**Shifting.** Designed for more than one state. The constructed style and the real style do not look the same, and both are Volley!.
 
 ---
 
-## The two registers
+## The two styles
 
 Volley! has two visual worlds that share the same shapes, proportions, and line work. The difference is how much comfort the art offers. The constructed world is a simplification of the real one: the same place, rendered by someone who needed it to be okay.
 
@@ -42,9 +42,9 @@ The real world is revealed at **The Break**, when the player walks through the m
 
 Cozy, never stressful. Earnest, never ironic. Personal, never melodramatic. The art takes itself slightly more seriously than a pong game should, and that is intentional.
 
-The cozy surface is not a lie. Warmth is the main register. Under the warmth sits something honest. The art holds both at once without undercutting either.
+The cozy surface is not a lie. Warmth is the main style. Under the warmth sits something honest. The art holds both at once without undercutting either.
 
-The game is sad, but it earns the sadness and never wallows. The art is **never scary or distressing**; the real register is quieter, not darker. Sadness is a consequence the player can sit with, not a tone the art chases.
+The game is sad, but it earns the sadness and never wallows. The art is **never scary or distressing**; the real style is quieter, not darker. Sadness is a consequence the player can sit with, not a tone the art chases.
 
 ---
 
@@ -52,9 +52,9 @@ The game is sad, but it earns the sadness and never wallows. The art is **never 
 
 Hand-drawn illustration with **bold shapes, limited but confident colour**. Not pixel art. Not painterly realism. Not vector-clean.
 
-**Constructed register.** Saturated, warm, deliberately arranged. Warm golds, soft blues, deep warm shadows. Colour as comfort.
+**Constructed style.** Saturated, warm, deliberately arranged. Warm golds, soft blues, deep warm shadows. Colour as comfort.
 
-**Real register.** Quieter. Muted warms, honest greys, natural greens. The saturation dial turned down; the palette is the same family, less pushed.
+**Real style.** Quieter. Muted warms, honest greys, natural greens. The saturation dial turned down; the palette is the same family, less pushed.
 
 *(Exact hex values to be locked as the first assets land.)*
 
@@ -64,9 +64,9 @@ Hand-drawn illustration with **bold shapes, limited but confident colour**. Not 
 
 The line has life in it. Confident, slightly imperfect, visibly made by someone. No flat vector polish; no mechanical precision.
 
-**Constructed register.** Cleaner line; edges resolved.
+**Constructed style.** Cleaner line; edges resolved.
 
-**Real register.** Looser line; the mark breathes more. Same hand, less composed.
+**Real style.** Looser line; the mark breathes more. Same hand, less composed.
 
 Stroke weight is consistent within a scene. Silhouette reads first; line detail second.
 
@@ -78,7 +78,7 @@ Characters and props read by silhouette at any size. If two things could be conf
 
 Simple shapes with enormous emotional range. A storybook shape that body-language-acts more than it model-sheet-acts. The gap between how simple a character looks and how deeply they make you feel is the territory.
 
-Silhouettes hold across both registers; only the light, colour, and line quality shift.
+Silhouettes hold across both styles; only the light, colour, and line quality shift.
 
 ---
 
@@ -116,7 +116,7 @@ No specific real-world era pastiche. The references are emotional, not period.
 
 ## Characters
 
-Characters share the same level of simplicity across both registers; the world around them shifts.
+Characters share the same level of simplicity across both styles; the world around them shifts.
 
 *(Per-character notes as they lock: main character, Martha, the tinkerer, the rival, the friend.)*
 
@@ -166,7 +166,7 @@ Every cut, movement, and colour choice can serve the rhythm. Visual rhythm is fe
 
 *(Direction questions that have not landed yet. Move them into the sections above as they resolve.)*
 
-- Exact colour palette for constructed and real registers.
+- Exact colour palette for constructed and real styles.
 - Typography: display and reading faces.
 - Per-character silhouette and palette notes.
 - How partner introductions (portraits, dialogue) render.

--- a/designs/art/direction.md
+++ b/designs/art/direction.md
@@ -8,7 +8,7 @@ This layer is narrative. The bible is the decision layer.
 
 ## Warmth that carries weight
 
-The cozy surface is not a lie. Warmth is the main register: interior light, soft colour, hand-drawn confidence. Under the warmth sits something honest. The art has to hold both at once without undercutting either.
+The cozy surface is not a lie. Warmth is the main style: interior light, soft colour, hand-drawn confidence. Under the warmth sits something honest. The art has to hold both at once without undercutting either.
 
 ## Simple shapes, full emotion
 
@@ -26,9 +26,9 @@ Personality lives in movement. How a character shifts weight, how they land, how
 
 Hits, misses, rallies, streaks, reactions, UI feedback all land on a felt rhythm. The game has a pulse the art and sound both serve.
 
-## Two registers, same world
+## Two styles, same world
 
-The game has phases and moods that shift without breaking the fiction. The same characters, the same court, the same rules, but the feeling can change. The art needs to hold both the bright surface and the heavier register without either feeling like a betrayal of the other.
+The game has phases and moods that shift without breaking the fiction. The same characters, the same court, the same rules, but the feeling can change. The art needs to hold both the bright surface and the heavier style without either feeling like a betrayal of the other.
 
 ## Diegetic, specific, lived-in
 
@@ -36,4 +36,4 @@ UI, props, and interfaces belong to the world. The ball rack, the gear rack, the
 
 ## Looked at, not copied
 
-Influences are honest. The game takes from a wide field: sports animation, cozy film, games with twin registers, painterly environments, rhythm-aware composition. None of it is transplanted; each is translated into Volley!'s own palette, line, and tempo.
+Influences are honest. The game takes from a wide field: sports animation, cozy film, games with twin styles, painterly environments, rhythm-aware composition. None of it is transplanted; each is translated into Volley!'s own palette, line, and tempo.

--- a/designs/art/tech-pipeline.md
+++ b/designs/art/tech-pipeline.md
@@ -8,7 +8,7 @@ This is a living spike. Colours, typography, and per-character notes still route
 
 ## Game shape
 
-Volley! is 2D throughout. Hand-drawn sprites, Control-node UI, Parallax2D backgrounds. Characters are simple and expressive; environments carry depth through layered, painted backgrounds. Two registers share the same assets where possible and diverge through palette, light, and edge treatment.
+Volley! is 2D throughout. Hand-drawn sprites, Control-node UI, Parallax2D backgrounds. Characters are simple and expressive; environments carry depth through layered, painted backgrounds. Two styles share the same assets where possible and diverge through palette, light, and edge treatment.
 
 The target resolution is **1920x1080**, set in `project.godot` under `window/size`. Stretch mode is `canvas_items`: the viewport scales to the window while Control and CanvasItem nodes keep crisp edges. All sprite and layout budgets in this doc assume that base.
 
@@ -69,7 +69,7 @@ assets/
 
 One asset, one canonical path. If the shop and the kit both show the same item, they reference the same PNG in `surfaces/`. If the pinboard shows it in the world and a HUD slot shows it as an icon, same file. Duplicated sprites rot separately.
 
-File names are `lower_snake_case.png`. Animation frames suffix the state: `martha_idle_01.png`, `martha_idle_02.png`, `martha_hit.png`. Registers suffix the file: `kitchen_real.png` alongside `kitchen_constructed.png`. Each register ships its own painted asset (see [Register shift](#register-shift)).
+File names are `lower_snake_case.png`. Animation frames suffix the state: `martha_idle_01.png`, `martha_idle_02.png`, `martha_hit.png`. Styles suffix the file: `kitchen_real.png` alongside `kitchen_constructed.png`. Each style ships its own painted asset (see [Style shift](#style-shift)).
 
 ---
 
@@ -129,7 +129,7 @@ Venues use **Parallax2D** (available since Godot 4.3; Volley! runs on 4.6.2, the
 4. **Near foreground.** Near props, foreground trim. Slightly faster than the playing surface.
 5. **Foreground.** Occasional foreground pass (a beam, a curtain edge) that sells depth. Optional.
 
-Scroll scales tune per venue. The court stays composed; The Break reveal uses a looser, slower parallax to mark the register shift.
+Scroll scales tune per venue. The court stays composed; The Break reveal uses a looser, slower parallax to mark the style shift.
 
 Layers are authored as **separate PNGs sized to the layer's visible range** (at the @2x authoring density from [Sprites](#sprites)), not full-resolution panoramas. A background layer the camera only sees 2000 logical pixels of is authored at 4000px, not at 8000px or the full world width. Repeat, if needed, is handled by `Parallax2D.repeat_size`.
 
@@ -168,20 +168,20 @@ Runtime lighting is reserved for two roles:
 
 `DirectionalLight2D` and `PointLight2D` with `shadow_enabled = true` are avoided; shadows come from painting. The ball's trail and hit spark FX are `GPUParticles2D` on an additive blend layer, not light.
 
-### Register shift
+### Style shift
 
-**The constructed-to-real shift is a repaint.** This is the only way it actually looks good. Shader tricks and global tint cannot recover the reweighted line, the cooler pigments, the loosened edges that make the real register feel like the same world seen honestly; attempting to fake it produces the "filter over the same image" look the bible explicitly rejects.
+**The constructed-to-real shift is a repaint.** This is the only way it actually looks good. Shader tricks and global tint cannot recover the reweighted line, the cooler pigments, the loosened edges that make the real style feel like the same world seen honestly; attempting to fake it produces the "filter over the same image" look the bible explicitly rejects.
 
 Each venue ships two painted sets:
 
-- **Constructed register.** Warm, saturated, arranged. The world as the player wants to see it.
-- **Real register.** Cooler, muted, looser. Same silhouettes, same staging, repainted.
+- **Constructed style.** Warm, saturated, arranged. The world as the player wants to see it.
+- **Real style.** Cooler, muted, looser. Same silhouettes, same staging, repainted.
 
-Characters follow the same rule: constructed and real sprite sets per character where the register shift is felt. The bible's "silhouettes hold across both registers; only the light, colour, and line quality shift" rule governs what stays and what moves.
+Characters follow the same rule: constructed and real sprite sets per character where the style shift is felt. The bible's "silhouettes hold across both styles; only the light, colour, and line quality shift" rule governs what stays and what moves.
 
-At runtime the shift is a crossfade between the two painted sets, timed to the narrative beat, delivered through a `RegisterManager` that swaps sprite textures on affected nodes and tweens opacity between them. Shaders and modulation are adjuncts used only where the repaint itself does not need help: a mild saturation ease on the frame during the crossfade, a brief dimming of over-arranged props as the real register settles in. The heavy lifting is paint.
+At runtime the shift is a crossfade between the two painted sets, timed to the narrative beat, delivered through a `StyleManager` that swaps sprite textures on affected nodes and tweens opacity between them. Shaders and modulation are adjuncts used only where the repaint itself does not need help: a mild saturation ease on the frame during the crossfade, a brief dimming of over-arranged props as the real style settles in. The heavy lifting is paint.
 
-The Break itself is the exception: a scripted, one-time transition with authored keyframes in an `AnimationPlayer`, permitting stronger visual disruption than the routine register shift.
+The Break itself is the exception: a scripted, one-time transition with authored keyframes in an `AnimationPlayer`, permitting stronger visual disruption than the routine style shift.
 
 ---
 
@@ -191,8 +191,8 @@ Kept minimal. Every shader is a named resource under `resources/shaders/` with a
 
 Shipping list (spike-time):
 
-- **`register_shift.gdshader`:** CanvasItem shader used only as an easing adjunct during a register crossfade (saturation and edge-softness offsets driven by one float). The shift itself is the repaint; this shader smooths the transition while the painted sets swap.
-- **`painted_outline.gdshader`:** CanvasItem shader that thickens and breaks the existing painted outline at a per-sprite modulation. Used sparingly on a handful of props whose silhouettes need to harden in the real register; disabled by default.
+- **`style_shift.gdshader`:** CanvasItem shader used only as an easing adjunct during a style crossfade (saturation and edge-softness offsets driven by one float). The shift itself is the repaint; this shader smooths the transition while the painted sets swap.
+- **`painted_outline.gdshader`:** CanvasItem shader that thickens and breaks the existing painted outline at a per-sprite modulation. Used sparingly on a handful of props whose silhouettes need to harden in the real style; disabled by default.
 - **`streak_glow.gdshader`:** additive CanvasItem shader on the ball when streak count crosses thresholds.
 
 No screen-space post-process stack. If an effect is universal enough to sit at the Viewport level, it is painted into the backgrounds instead.

--- a/designs/tech-art/grading.md
+++ b/designs/tech-art/grading.md
@@ -6,23 +6,23 @@ This document fixes the grading contract: what the artist delivers, what the eng
 
 ## Why a grade lives in code
 
-Each Construction venue and Reality scene has its own colour register, locked per the canon in [the world bible](../01-prototype/artist-world-bible.md) Section 3 and Section 15. Construction holds saturated colour and generous warm light; Reality pulls cooler, plainer, more atmospheric. Reconstruction is the arc between the two, not a third register; a Reconstruction scene renders in whichever style it sits inside.
+Each Construction venue and Reality scene has its own colour register, locked per the canon in [the world bible](../01-prototype/artist-world-bible.md) Section 3 and Section 15. Construction holds saturated colour and generous warm light; Reality pulls cooler, plainer, more atmospheric. Reconstruction is the arc between the two, not a third style; a Reconstruction scene renders in whichever style it sits inside.
 
-Authoring every sprite twice, once for each register, is the path the bible already takes for character renders and venue paintings where the register shift is felt. Repainting is right when the line-weight, edge treatment, and pigment selection have to change with the register. Grading is right when the same painted surface needs to read warmer here, cooler there, without the artist redoing the work. Most surfaces sit in the second category: a prop on the workshop bench, a stray ball at rest, a gear-rack item, the friend's stall. The grade carries those.
+Authoring every sprite twice, once for each style, is the path the bible already takes for character renders and venue paintings where the style shift is felt. Repainting is right when the line-weight, edge treatment, and pigment selection have to change with the style. Grading is right when the same painted surface needs to read warmer here, cooler there, without the artist redoing the work. Most surfaces sit in the second category: a prop on the workshop bench, a stray ball at rest, a gear-rack item, the friend's stall. The grade carries those.
 
 ## Authoring contract
 
 The artist delivers neutral sprites against the rules already named in [the tech pipeline](../art/tech-pipeline.md): PNG, sRGB, 32-bit with alpha, no embedded profile, painted at the @2x density the pipeline calls for. Painted shadow and form lighting stay in the sprite; the grade does not replace them. The painting carries the light direction, the modelling, the weight; the grade shifts the colour temperature, the saturation, the contrast curve.
 
-Per-character variation rides the grade rather than fighting it. A particular outfit colour is authored against the neutral baseline; the LUT modulates everything in the frame uniformly, so a character whose blue sits a notch warmer than the cast in Construction sits a notch warmer than the cast in Reality too. The relationship holds across registers because the grade is uniform.
+Per-character variation rides the grade rather than fighting it. A particular outfit colour is authored against the neutral baseline; the LUT modulates everything in the frame uniformly, so a character whose blue sits a notch warmer than the cast in Construction sits a notch warmer than the cast in Reality too. The relationship holds across styles because the grade is uniform.
 
-Surfaces that need to stay colour-stable across every register live outside the graded layer. A UI mark whose meaning is its colour, a key prop that has to read the same in Construction and Reality, both sit on a separate `CanvasLayer` that the grade does not touch. The Six Marks rule that silhouettes hold while light, colour, and line quality shift gets its colour-stable counterpart from this exemption: a few surfaces are exempt from the shift on purpose.
+Surfaces that need to stay colour-stable across every style live outside the graded layer. A UI mark whose meaning is its colour, a key prop that has to read the same in Construction and Reality, both sit on a separate `CanvasLayer` that the grade does not touch. The Six Marks rule that silhouettes hold while light, colour, and line quality shift gets its colour-stable counterpart from this exemption: a few surfaces are exempt from the shift on purpose.
 
 ## Per-style LUT
 
 Construction and Reality each carry one LUT. Construction's pushes saturation and warmth, holds shadows warm, lifts the midtone toward the gold-and-honey range the bible names. Reality's pulls toward the naturalistic: a notch of saturation off, a cooler shadow, a midtone that lets weather sit in the air.
 
-Reconstruction does not get a LUT. Construction venues across Reconstruction wear the Construction LUT and the bible's "weathering" effect is delivered through the LUT itself easing toward a slightly muted variant as the arc progresses; Reality scenes wear the Reality LUT throughout. The two registers stay distinct in code as they do in the canon.
+Reconstruction does not get a LUT. Construction venues across Reconstruction wear the Construction LUT and the bible's "weathering" effect is delivered through the LUT itself easing toward a slightly muted variant as the arc progresses; Reality scenes wear the Reality LUT throughout. The two styles stay distinct in code as they do in the canon.
 
 ## Per-venue overrides
 
@@ -44,11 +44,11 @@ Iteration is fast because the LUT is the variable. A grade tweak ships as one fi
 
 ## Limits
 
-A LUT is a uniform colour transform. It cannot do per-element colour swaps or selective hue isolation; a sprite that needs its red turned green while everything else holds is not a grade problem, it is a repaint or a per-sprite shader problem. Surfaces that need to remain colour-stable across all registers live above the graded layer or carry an inverse grade applied per-sprite to cancel the layer they sit inside.
+A LUT is a uniform colour transform. It cannot do per-element colour swaps or selective hue isolation; a sprite that needs its red turned green while everything else holds is not a grade problem, it is a repaint or a per-sprite shader problem. Surfaces that need to remain colour-stable across all styles live above the graded layer or carry an inverse grade applied per-sprite to cancel the layer they sit inside.
 
-The grade also cannot recover what the painting establishes. A sprite painted with cool light cannot be made warm by a warm LUT; the painted shadows fight the grade and the result reads wrong. This is why the painting carries the form light and the grade carries only the register shift. The bible's note that runtime lighting cannot recover what the painting establishes applies to the grade too: paint first, grade second.
+The grade also cannot recover what the painting establishes. A sprite painted with cool light cannot be made warm by a warm LUT; the painted shadows fight the grade and the result reads wrong. This is why the painting carries the form light and the grade carries only the style shift. The bible's note that runtime lighting cannot recover what the painting establishes applies to the grade too: paint first, grade second.
 
-The constructed-to-real shift inside a venue, where the same place is rendered in both registers, remains a repaint per [the tech pipeline](../art/tech-pipeline.md). The grade handles register-by-style; the repaint handles register-by-meaning. They are different jobs.
+The constructed-to-real shift inside a venue, where the same place is rendered in both styles, remains a repaint per [the tech pipeline](../art/tech-pipeline.md). The grade handles the per-style shift; the repaint handles the per-meaning shift. They are different jobs.
 
 ---
 


### PR DESCRIPTION
Sweeps remaining register stragglers in the art canon and tech-art docs to style per project canon. Bible's Two Registers heading + register/style swap throughout, direction.md, tech-pipeline.md, INDEX.md, tech-art/grading.md. Preserves legitimate non-architectural uses (Reality's own internal Visual register / Audio register sections, the Linear ticket title, lit-crit colour-register references).