### PR TITLE
docs: drop cozy as a Volley self-descriptor

### DIFF
--- a/designs/01-prototype/20a-ball-speed-tier-progression.md
+++ b/designs/01-prototype/20a-ball-speed-tier-progression.md
@@ -27,7 +27,7 @@ Rewards are what fires on `on_tier_completed`. They are tuned for first playtest
 
 All four rewards are opt-in for items; an item effect bound to `on_tier_completed` with a tier filter can add to these without replacing them. Partners can hook `on_peak_hit` (emitted per paddle hit while Peak is open) to add their own beats without any special casing.
 
-Tone constraints: no banners, no floating text, no venue-rule violations. Rewards are a sound, a light, a trail, a coin, or an unlock signal the player will see next time they visit the shop. Cozy and diegetic.
+Tone constraints: no banners, no floating text, no venue-rule violations. Rewards are a sound, a light, a trail, a coin, or an unlock signal the player will see next time they visit the shop. Warm and diegetic.
 
 ## What a tier climb feels like
 

--- a/designs/02-alpha/01-world-and-narrative.md
+++ b/designs/02-alpha/01-world-and-narrative.md
@@ -6,7 +6,7 @@ The world building and emotional core of Volley!. Who these people are, what hap
 
 ## The premise (what the player thinks)
 
-A plucky little paddle has a dream: beat the world volley record. It trains, recruits friends, gets better. Cozy, wholesome, idle. Nothing is wrong.
+A plucky little paddle has a dream: beat the world volley record. It trains, recruits friends, gets better. Warm, wholesome, idle. Nothing is wrong.
 
 ---
 
@@ -76,7 +76,7 @@ The first partner. The cashier at the local newsagent. See `01-prototype/11-firs
 
 ### Pre-break
 
-The cozy idle game. The surface holds. Clues build through partner barks, item descriptions, and the rival's presence, but the game feels warm and safe. The main character is hiding and it's working.
+The idle game at its warmest. The surface holds. Clues build through partner barks, item descriptions, and the rival's presence, but the game feels warm and safe. The main character is hiding and it's working.
 
 ### The break
 
@@ -120,5 +120,5 @@ The game is personal, emotional, and sad. It earns that sadness and doesn't wall
 **The narrative should always:**
 - Respect players who don't engage with it. The game works without the story.
 - Reward players who do. Attention should feel valued, not required.
-- Let the warmth be real. The cozy surface is not a trick. Learning the truth doesn't retroactively ruin the fun.
+- Let the warmth be real. The bright surface is not a trick. Learning the truth doesn't retroactively ruin the fun.
 - Move forward. The break happens, the game continues, the player and the paddle both keep going.

--- a/designs/02-alpha/05-clue-ladder.md
+++ b/designs/02-alpha/05-clue-ladder.md
@@ -49,4 +49,4 @@ These are hard to ignore. The warm framing is straining.
 - Partner barks become more urgent and less characteristic. "Please" where they'd normally be breezy. "Not yet" on a milestone that should be celebrated.
 - The ball occasionally moves wrong in a way that can't be blamed on physics. Too slow, too deliberate. Like something is resisting.
 - Visual artifacts: a single frame where the art style is different. Not a bug. When the player looks again it's gone.
-- The world record gets very close and the game's tone doesn't match. The music is still warm, the UI still tended, but something underneath is pulling the other way.
+- The world record gets very close and the game's tone doesn't match. The music is still warm, the UI still inviting, but something underneath is pulling the other way.

--- a/designs/02-alpha/05-clue-ladder.md
+++ b/designs/02-alpha/05-clue-ladder.md
@@ -34,7 +34,7 @@ The earnestness is the first clue. Not in a winking, self-aware way. The game ge
 
 ## Stage 2: Something is definitely wrong (rival appears, more partners unlocked)
 
-These are noticeable on replay but easy to rationalise the first time. The rival's arrival is itself a stage 2 moment: someone shows up who doesn't play nice, and their aggression doesn't quite make sense for a cozy pong game.
+These are noticeable on replay but easy to rationalise the first time. The rival's arrival is itself a stage 2 moment: someone shows up who doesn't play nice, and their aggression doesn't quite make sense for a warm pong game.
 
 - A partner says something that couldn't be in-game knowledge. A reference to time passing in their world, a name that isn't their own, a memory that predates the game.
 - One partner's barks occasionally shift register. More direct, less warm. The real person bleeding through, not the version the main character constructed.
@@ -44,9 +44,9 @@ These are noticeable on replay but easy to rationalise the first time. The rival
 
 ## Stage 3: The surface is cracking (approaching the record, final milestones)
 
-These are hard to ignore. The cozy framing is straining.
+These are hard to ignore. The warm framing is straining.
 
 - Partner barks become more urgent and less characteristic. "Please" where they'd normally be breezy. "Not yet" on a milestone that should be celebrated.
 - The ball occasionally moves wrong in a way that can't be blamed on physics. Too slow, too deliberate. Like something is resisting.
 - Visual artifacts: a single frame where the art style is different. Not a bug. When the player looks again it's gone.
-- The world record gets very close and the game's tone doesn't match. The music is still cozy, the UI is still warm, but something underneath is pulling the other way.
+- The world record gets very close and the game's tone doesn't match. The music is still warm, the UI still tended, but something underneath is pulling the other way.

--- a/designs/03-beta/01-the-break-scene.md
+++ b/designs/03-beta/01-the-break-scene.md
@@ -6,7 +6,7 @@ The playable sequence between pre-break and post-break. The player leaves the po
 
 ## Trigger
 
-As the volley count approaches the record, something resists. Not a game mechanic, something external to the game's logic. The ball slows. Not gradually, not like a physics change. Deliberately. Like something is pushing back against the number being reached. The cozy music continues. The UI is still warm. But the ball moves like it's moving through something.
+As the volley count approaches the record, something resists. Not a game mechanic, something external to the game's logic. The ball slows. Not gradually, not like a physics change. Deliberately. Like something is pushing back against the number being reached. The music continues, warm as ever. The UI is still warm. But the ball moves like it's moving through something.
 
 This is not explained. There is no visual effect, no partner comment, no UI acknowledgement. The resistance is just there.
 

--- a/designs/03-beta/01-the-break-scene.md
+++ b/designs/03-beta/01-the-break-scene.md
@@ -6,7 +6,7 @@ The playable sequence between pre-break and post-break. The player leaves the po
 
 ## Trigger
 
-As the volley count approaches the record, something resists. Not a game mechanic, something external to the game's logic. The ball slows. Not gradually, not like a physics change. Deliberately. Like something is pushing back against the number being reached. The music continues, warm as ever. The UI is still warm. But the ball moves like it's moving through something.
+As the volley count approaches the record, something resists. Not a game mechanic, something external to the game's logic. The ball slows. Not gradually, not like a physics change. Deliberately. Like something is pushing back against the number being reached. The music continues at its usual warmth, the UI unchanged. But the ball moves like it's moving through something.
 
 This is not explained. There is no visual effect, no partner comment, no UI acknowledgement. The resistance is just there.
 

--- a/designs/art/bible.md
+++ b/designs/art/bible.md
@@ -40,9 +40,9 @@ The real world is revealed at **The Break**, when the player walks through the m
 
 ## Mood
 
-Cozy, never stressful. Earnest, never ironic. Personal, never melodramatic. The art takes itself slightly more seriously than a pong game should, and that is intentional.
+Warm, never stressful. Earnest, never ironic. Personal, never melodramatic. The art takes itself slightly more seriously than a pong game should, and that is intentional.
 
-The cozy surface is not a lie. Warmth is the main register. Under the warmth sits something honest. The art holds both at once without undercutting either.
+The bright surface is not a lie. Warmth is the main register, vibrant and tended; under it sits something honest. The art holds both at once without undercutting either.
 
 The game is sad, but it earns the sadness and never wallows. The art is **never scary or distressing**; the real register is quieter, not darker. Sadness is a consequence the player can sit with, not a tone the art chases.
 
@@ -102,7 +102,7 @@ UI uses the same hand and voice as the world. Cuphead-level commitment: nothing 
 
 ## Era and Feel
 
-Present-day, cosy interior. Domestic textures. The court is a small space that feels like everything, because someone arranged it that way.
+Present-day, tended interior. Domestic textures. The court is a small space that feels like everything, because someone arranged it that way.
 
 No specific real-world era pastiche. The references are emotional, not period.
 

--- a/designs/art/direction.md
+++ b/designs/art/direction.md
@@ -8,7 +8,7 @@ This layer is narrative. The bible is the decision layer.
 
 ## Warmth that carries weight
 
-The cozy surface is not a lie. Warmth is the main register: interior light, soft colour, hand-drawn confidence. Under the warmth sits something honest. The art has to hold both at once without undercutting either.
+The bright surface is not a lie. Warmth is the main register: interior light, vibrant colour, hand-drawn confidence. Under the warmth sits something honest. The art has to hold both at once without undercutting either.
 
 ## Simple shapes, full emotion
 

--- a/designs/north-star.md
+++ b/designs/north-star.md
@@ -45,12 +45,12 @@ The game should respect the player's time whether they engage with the narrative
 - **Come back to good news.** The player returns to rewards, not a reset. Being away should feel like the game kept going without them.
 - **Don't make it a chore.** Active play is fun, not mandatory. Idle play earns less but still earns. The player chooses how much attention to give.
 - **Pinch points, not paywalls.** Progression slows naturally. Breakthrough moments feel earned. Nothing is gated behind anything except playing.
-- **The warmth is real.** The cozy surface is not a lie. Learning the narrative should not make the player feel tricked for enjoying the game. The idle loop and the story both hold up on their own.
+- **The warmth is real.** The bright surface is not a lie. Learning the narrative should not make the player feel tricked for enjoying the game. The idle loop and the story both hold up on their own.
 - **Trust the player.** Don't explain. Don't signpost. Don't break the fourth wall. Let the player notice, wonder, and eventually understand. The game respects players who pay attention and doesn't punish players who don't.
 
 ## Tone
 
-Cozy, never stressful. Earnest, never ironic. Personal, never melodramatic. Characters are warm and specific. Competition is self-driven. Small wins are celebrated. The game takes itself slightly more seriously than a pong game should, and that's intentional.
+Warm, never stressful. Earnest, never ironic. Personal, never melodramatic. Characters are specific. Competition is self-driven. Small wins are celebrated. The game takes itself slightly more seriously than a pong game should, and that's intentional.
 
 ## Non-goals
 

--- a/designs/north-star.md
+++ b/designs/north-star.md
@@ -50,7 +50,7 @@ The game should respect the player's time whether they engage with the narrative
 
 ## Tone
 
-Warm, never stressful. Earnest, never ironic. Personal, never melodramatic. Characters are specific. Competition is self-driven. Small wins are celebrated. The game takes itself slightly more seriously than a pong game should, and that's intentional.
+Warm, never stressful. Earnest, never ironic. Personal, never melodramatic. Characters are specific and warmly drawn. Competition is self-driven. Small wins are celebrated. The game takes itself slightly more seriously than a pong game should, and that's intentional.
 
 ## Non-goals
 

--- a/designs/research/visual-positioning.md
+++ b/designs/research/visual-positioning.md
@@ -10,7 +10,7 @@ Jordan Morris released *Rusty's Retirement* in April 2024: a pixel farming sim t
 
 This is an unusual kind of hit. Its technical footprint is modest. Its art style is the retro-pixel register almost every Steam idle defaults to. It is not visually ambitious, and it does not try to be. What made it land was the fit: the game takes the shape of the time the player has to give it. Against the dashboard maximalism that has defined the idle genre since *Cookie Clicker*, and against the mobile cozy lineage that has grown for a decade, *Rusty's* names something quieter. A game you work beside, not over.
 
-Volley! is neither *Rusty's Retirement* nor a *Cookie Clicker* descendant. It shares *Rusty's* attitude (a game that sits with the player through a long day) but builds a different object: a hand-drawn pong rally as the idle loop, a cozy surface that opens into harder material as the story goes, and a secondary desktop-companion mode that enters the ambient category only after the primary work is done. The question is whether the combination has a place in the current indie landscape, and what the game has to be to earn it.
+Volley! is neither *Rusty's Retirement* nor a *Cookie Clicker* descendant. It shares *Rusty's* attitude (a game that sits with the player through a long day) but builds a different object: a hand-drawn pong rally as the idle loop, a warm surface that opens into harder material as the story goes, and a secondary desktop-companion mode that enters the ambient category only after the primary work is done. The question is whether the combination has a place in the current indie landscape, and what the game has to be to earn it.
 
 ---
 
@@ -84,7 +84,7 @@ The criticism of *Omori* worth registering is about pacing. Some reviewers found
 
 Two more recent releases fill out this lineage. *In Stars and Time* (insertdisc5, November 2023, ongoing accolades into 2025) runs a hand-drawn storybook cast through a time-loop. The game opens charming and settles into a meditation on repetition and friendship. *The Berlin Apartment* (Inkas Games, November 2025) uses a renovation-and-relics framing to shift between a present-day apartment and historical vignettes across decades of Berlin life, delivering dual-timeline warmth through ordinary domestic tasks. *Herdling* (Okomotive, August 2025), from the studio behind *FAR: Lone Sails*, runs a pastoral journey guiding creatures up a mountain, with small narrative beats revealing heavier themes through environmental storytelling.
 
-What these games share is a refusal to treat the cozy surface as a lie to be dismantled. Learning the truth in *Omori* does not punish the player for enjoying Headspace. The grief in *Wanderstop* does not undercut the satisfaction of brewing tea. Volley! takes the same approach. The cozy idle works without the narrative layer, and the narrative layer does not retract the warmth.
+What these games share is a refusal to treat the warm surface as a lie to be dismantled. Learning the truth in *Omori* does not punish the player for enjoying Headspace. The grief in *Wanderstop* does not undercut the satisfaction of brewing tea. Volley! takes the same approach. The idle loop works without the narrative layer, and the narrative layer does not retract the warmth.
 
 ---
 
@@ -96,7 +96,7 @@ What makes it relevant here is how the art behaves under narrative pressure. The
 
 *Slay the Princess* shares *The Stanley Parable*'s unreliable-narrator structure, but delivers it through art rather than script. The combination of drawn-by-hand specificity, shifting forms, and register responsive to player interpretation is a direct influence on how Volley! thinks about its own visual storytelling. The two registers Volley! works in (constructed and real) are a milder version of the same move: the art changes because the story has changed, and the change is the point.
 
-Hand-made quality reads as honest in a way polished rendering does not, which matters for a game with a cozy surface that needs to be trusted. Art that shifts with narrative is a structural device, not decoration. Visual ambition at indie scale comes down to matching technique to scope early: pencil and paper for *Slay the Princess*; simple shapes that carry expression through motion for Volley!.
+Hand-made quality reads as honest in a way polished rendering does not, which matters for a game with a warm surface that needs to be trusted. Art that shifts with narrative is a structural device, not decoration. Visual ambition at indie scale comes down to matching technique to scope early: pencil and paper for *Slay the Princess*; simple shapes that carry expression through motion for Volley!.
 
 ---
 
@@ -114,7 +114,7 @@ Volley!'s secondary mode sits in this category with a specific constraint. Most 
 
 Each current Volley! combines has a recent exemplar. *Despelote* for sport as an emotional frame [5][7]. *Wanderstop* for the cozy-to-honest register shift [9][10][11]. *Slay the Princess* for hand-drawn art that responds to narrative [29][30]. *Rusty's Retirement* for desktop-resident idle as a commercial format [1][2][3]. The exemplars exist. The scarcity is in combining them.
 
-That scarcity is structural. Each thread carries its own production discipline, its own design conviction, and its own demand on player trust. Holding four disciplines in one release is harder than delivering any one of them, and the difficulty is what keeps the intersection open. A hand-drawn idle with sport at its centre, cozy-to-honest weight underneath, and art that shifts with the narrative is the specific thing the 2025 landscape has not built.
+That scarcity is structural. Each thread carries its own production discipline, its own design conviction, and its own demand on player trust. Holding four disciplines in one release is harder than delivering any one of them, and the difficulty is what keeps the intersection open. A hand-drawn idle with sport at its centre, warmth-to-honest weight underneath, and art that shifts with the narrative is the specific thing the 2025 landscape has not built.
 
 For the secondary desktop-companion mode, *Rusty's Retirement* is the format peer and *Desktop Meadow* the spirit peer. The primary experience is where the position's weight sits.
 


### PR DESCRIPTION
Sweeps cozy → warm/bright/tended across docs that describe Volley itself. Keeps external uses verbatim: market-category mentions, direct quotes from other developers (Spiritfarer's Guérin), source titles and URL slugs in citations, market-data references.