### PR TITLE
docs: canon niggles in roadmap, INDEX, cracks doc

### DIFF
--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -95,8 +95,8 @@ The [open-development essay](research/the-case-for-open-development.md) sits in 
 | Phase | Folder | What lives here now |
 |---|---|---|
 | Prototype | [01-prototype/](01-prototype/INDEX.md) | The public itch.io demo. Active drafts that have not yet matured into discipline canon. |
-| Alpha | [02-alpha/](02-alpha/INDEX.md) | Construction (Act 1) content-complete; the break-interlude designed. |
-| Beta | [03-beta/](03-beta/INDEX.md) | Reconstruction (Act 2), the cliff-end, and the postgame playable end-to-end. |
+| Alpha | [02-alpha/](02-alpha/INDEX.md) | Construction content-complete; the break designed. |
+| Beta | [03-beta/](03-beta/INDEX.md) | Reconstruction, the cliff and the call, and the postgame playable end-to-end. |
 | Content Updates | [04-content/](04-content/INDEX.md) | Supplementary content past the main arc. |
 
 Drafts start in the active phase folder, settle into the discipline folder when they earn canon, and the phase folder keeps the working history.

--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -95,8 +95,8 @@ The [open-development essay](research/the-case-for-open-development.md) sits in 
 | Phase | Folder | What lives here now |
 |---|---|---|
 | Prototype | [01-prototype/](01-prototype/INDEX.md) | The public itch.io demo. Active drafts that have not yet matured into discipline canon. |
-| Alpha | [02-alpha/](02-alpha/INDEX.md) | Part 1 content-complete; the break designed. |
-| Beta | [03-beta/](03-beta/INDEX.md) | Reconstruction and the cliff playable end-to-end. |
+| Alpha | [02-alpha/](02-alpha/INDEX.md) | Construction (Act 1) content-complete; the break-interlude designed. |
+| Beta | [03-beta/](03-beta/INDEX.md) | Reconstruction (Act 2), the cliff-end, and the postgame playable end-to-end. |
 | Content Updates | [04-content/](04-content/INDEX.md) | Supplementary content past the main arc. |
 
 Drafts start in the active phase folder, settle into the discipline folder when they earn canon, and the phase folder keeps the working history.

--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -95,7 +95,7 @@ The [open-development essay](research/the-case-for-open-development.md) sits in 
 | Phase | Folder | What lives here now |
 |---|---|---|
 | Prototype | [01-prototype/](01-prototype/INDEX.md) | The public itch.io demo. Active drafts that have not yet matured into discipline canon. |
-| Alpha | [02-alpha/](02-alpha/INDEX.md) | Construction era content-complete; the break designed. |
+| Alpha | [02-alpha/](02-alpha/INDEX.md) | Part 1 content-complete; the break designed. |
 | Beta | [03-beta/](03-beta/INDEX.md) | Reconstruction and the cliff playable end-to-end. |
 | Content Updates | [04-content/](04-content/INDEX.md) | Supplementary content past the main arc. |
 

--- a/designs/concept/02-cracks-and-break.md
+++ b/designs/concept/02-cracks-and-break.md
@@ -4,7 +4,7 @@ The wall thinning across Part 1, the championship win that lands wrong, and the 
 
 ## Cracks
 
-Reality leaks into Construction in small atmospheric ways across Part 1. Each leak is dismissible on its own. The cumulative pressure is what matters.
+Reality leaks into Construction across Part 1. Each leak is dismissible on its own. The cumulative pressure is what matters.
 
 Cracks earn their dismissibility from prior generosity (see [Pattern 1](../research/game-structure-references.md#pattern-1-cracks-earn-dismissibility-from-prior-generosity)). Construction has to land as genuinely fun before a single crack works. [Spec Ops: The Line](https://en.wikipedia.org/wiki/Spec_Ops:_The_Line)'s first heat shimmer arrives roughly three hours in, after the player has settled into a competent-soldier rhythm; [Doki Doki Literature Club](https://en.wikipedia.org/wiki/Doki_Doki_Literature_Club!)'s first poem night arrives after hours of dating-sim warmth; [Inscryption](https://en.wikipedia.org/wiki/Inscryption)'s first scrybe-room break arrives once the player has earned the deck. Volley's idle pacing scales these numbers up; the principle holds.
 
@@ -24,7 +24,7 @@ The protagonist climbs every round. The obsession with becoming champ deepens. T
 
 The player wins the championship. They do beat the champ.
 
-The win feels off. Like real-world achievement that turns out not to fix the thing it was supposed to fix. Both pulls of becoming-champ are satisfied at the same beat and neither was the thing the protagonist actually needed.
+The win feels off. Both pulls of becoming-champ are satisfied at the same beat and neither was the thing the protagonist actually needed.
 
 The win IS the break. The construct cannot hold itself together once its central goal has been achieved and proved meaningless. Cumulative cracks have been preparing the player to read what just happened; the win is the singular moment that makes the prior cracks legible as a chord rather than as noise.
 

--- a/designs/roadmap.md
+++ b/designs/roadmap.md
@@ -8,11 +8,11 @@ A public itch.io demo with the core loop tight, first-pass art and sound through
 
 ## Alpha
 
-Construction (Act 1) playable end to end: real art landed, the cast and the tournament filled out, and the break-interlude designed.
+Construction playable end to end: real art landed, the cast and the tournament filled out, and the break designed.
 
 ## Beta
 
-The whole arc playable from start to finish: Construction, the break-interlude, Reconstruction (Act 2), the cliff-end, and the postgame, with every style holding up across the run.
+The whole arc playable from start to finish: Construction, the break, Reconstruction, the cliff and the call, and the postgame, with every style holding up across the run.
 
 ## v1
 

--- a/designs/roadmap.md
+++ b/designs/roadmap.md
@@ -8,11 +8,11 @@ A public itch.io demo with the core loop tight, first-pass art and sound through
 
 ## Alpha
 
-Part 1 playable end to end: real art landed, the cast and the tournament filled out, and the break designed.
+Construction (Act 1) playable end to end: real art landed, the cast and the tournament filled out, and the break-interlude designed.
 
 ## Beta
 
-The whole arc playable from start to finish: the break, Part 2, and the cliff and the call, with every style holding up across the run.
+The whole arc playable from start to finish: Construction, the break-interlude, Reconstruction (Act 2), the cliff-end, and the postgame, with every style holding up across the run.
 
 ## v1
 

--- a/designs/roadmap.md
+++ b/designs/roadmap.md
@@ -8,11 +8,11 @@ A public itch.io demo with the core loop tight, first-pass art and sound through
 
 ## Alpha
 
-The Construction era playable end to end: real art landed, the cast and the tournament filled out, and the break designed.
+Part 1 playable end to end: real art landed, the cast and the tournament filled out, and the break designed.
 
 ## Beta
 
-The whole arc playable from start to finish: the break, the Reconstruction era, and both endings the cliff and the call, with every play style holding up across the run.
+The whole arc playable from start to finish: the break, Part 2, and the cliff and the call, with every style holding up across the run.
 
 ## v1
 


### PR DESCRIPTION
Three small canon-currency fixes spotted while ticking off SH-285.

\`roadmap.md\` and \`designs/INDEX.md\` were calling Construction and Reconstruction \"eras\". They are acts. Beta also said \"both endings the cliff and the call\" — there is one ending (the call IS the cliff). Both rewrites use the canon beat names: Construction, the break, Reconstruction, the cliff and the call, the postgame.

\`concept/02-cracks-and-break.md\`: dropped the \"in small atmospheric ways\" filler clause (the next paragraphs do the work) and the \"like real-world achievement that turns out not to fix the thing it was supposed to fix\" platitude (the surrounding sentences carry the meaning).

Open puzzle still on the table: \`concept/00-three-styles.md\` is titled \"The Three Styles\" but the body talks about two styles plus a Reconstruction bridge. Title vs body drift, flagging not fixing.