### PR TITLE
docs: trim concept folder to structural canon, defer narrative and visual

### DIFF
--- a/designs/concept/01-construction.md
+++ b/designs/concept/01-construction.md
@@ -1,50 +1,8 @@
 # Construction
 
-Part 1. The vibrant world the protagonist is actively maintaining, the tournament shape the climb takes, and the rally that drives it. High-level architecture lives in `00-three-styles.md`; the cracks and the win that breaks Construction live in `02-cracks-and-break.md`.
+Part 1. The structural detail of the vibrant world: the tournament shape the climb takes, the rally that drives it, the count, and the unnamed number sitting underneath. High-level architecture in `00-two-styles.md`; the cracks and the win that breaks Construction in `02-cracks-and-break.md`.
 
-## What Construction is
-
-The garden, the stall, the racquet, the rally. Saturated colour, generous light, surfaces that gleam, shadows held warm. Characters drawn young and full, present. Tennis lives here and only here.
-
-Construction is the structure the protagonist built to keep going. The warmth in it was always real; the rendering is the pretense. They did not assemble it as a hiding place. They assembled it because it was the thing they could assemble that held.
-
-The artist's hardest job lives here. Construction must be straight-up enjoyable as an idle pong game for the player who never thinks about the narrative. The cracks come later (`02-cracks-and-break.md`); if they arrive before the player has good reason to want the rally to keep going, they have nothing to crack.
-
-## The hook
-
-The protagonist holds a racquet. The first session opens in the friend's voice at the stall: chase the world volley record. The count climbs. The friend gives the number meaning.
-
-What the player does not know yet: the world record is a phone number. The shopkeeper's. Every rally is the protagonist's unconscious reach. The vibrant world's whole engine is the substitute relationship being maintained against the day the real one becomes possible.
-
-## The cast
-
-The cast splits into two groups. The supporting cast are real people from the protagonist's life, rendered in Construction. The player will see two asset sets for each: a Construction-render (young, vibrant, present) and a Reality-render (their actual age, plainer, in their actual life). The opposing cast is one person: the champ, who sits at the top of the tournament ladder.
-
-### Supporting cast
-
-**The protagonist.** Drawn like any other character. The player needs to see them to connect to them. Construction-render and Reality-render, same shape as everyone else. The Construction-render is who the player connects to throughout Part 1. The two stay distinct; the protagonist's image does not transform across the arc. The contrast lives in the style-switch.
-
-**The shopkeeper / friend at the stall.** Behind the counter of the small wooden stall in the garden. The warm centre of the venue. In Reality, the same person is alive in the hometown, withdrawn, the one the protagonist pushed away. The shopkeeper was cliff-jumping with the friend the day they died; the protagonist was not there. Their relationship is the load-bearing emotional shape of the game.
-
-**Martha and the partners.** Real people the protagonist knew, summoned into Construction as coach-partners. Each has a Reality-render at their actual age in their actual life. Lineage rule: each partner is named for a character from a science-fiction author's work.
-
-**The tinkerer.** The sister's Construction render. Workshop in another corner of the garden. The sister herself lives in Reality (`04-reality.md` for Reality's style, `03-reconstruction.md` for her role with the photo album).
-
-### Opposing cast
-
-**The champ.** The dead friend, rendered into Construction as the championship final. Someone the protagonist looks up to, never a rival. No Reality counterpart; their reality is the cliff. The champ exits at the end of Part 1.
-
-## Why the shopkeeper is at the stall
-
-The shopkeeper was on the cliff with the friend the day they jumped. The protagonist was not.
-
-That asymmetry is the wedge. Cliff jumping was a normalised activity in the friend group: dangerous, but routine for them, until it wasn't. The shopkeeper was up there too, doing the same thing, and walked away. The friend did not. The shopkeeper carries the memory and the survival; the protagonist carries the absence and the not-being-there. Talking to the shopkeeper would mean hearing what happened, and naming where the protagonist was instead. The protagonist pushes them away because the shopkeeper IS the failure of presence, made daily and visible. Not as judgment, the shopkeeper did not cause it; as mirror, and as the survivor whose survival the protagonist cannot quite hold beside the friend's death.
-
-The shopkeeper's tries to help after the death were partly their own grief reaching for connection, the survivor's reach. They got pushed away because the protagonist could not bear what their presence pointed at.
-
-The protagonist's mind cannot let them go either. The shopkeeper is the only one who knows; the only one who could understand. Construction's compromise is precise: keep the shopkeeper present, warm, available; have the relationship that does not require admitting where the protagonist was when the friend died. The friend at the stall, attentive without intruding, is the relationship the protagonist wants AND the relationship they cannot have in Reality, rendered as the version they can hold.
-
-This is why the world record IS the shopkeeper's phone number. Every rally is the unconscious reach. Reaching the championship means reaching past the substitute toward the actual call.
+Visual canon for Construction lives in [`../art/bible.md`](../art/bible.md) (sections 5 and 14). Cast lives in [`../art/bible.md`](../art/bible.md) § 4 plus the per-character profiles under [`../characters/`](../characters/). Story shape lives in [`../narrative/outline.md`](../narrative/outline.md).
 
 ## The tournament
 
@@ -68,9 +26,9 @@ Concrete mechanics are downstream design. What this doc commits is the shape: co
 
 ### The champ as the championship
 
-The champ is the final coach the protagonist had: the friend they used to play with, the best at the game, the one who pushed the protagonist to be better. In Construction, the champ holds the championship spot, someone the protagonist looks up to.
+The champ holds the championship spot. The protagonist climbs every round, learning each coach's mechanic, until they qualify for the championship. The match is winnable. The break beat (`02-cracks-and-break.md`) lives in what the win turns out to mean.
 
-The protagonist climbs every round, learning each coach's mechanic, until they qualify for the championship. The match is winnable. The break beat (`02-cracks-and-break.md`) lives in what the win turns out to mean.
+The champ's role and arc sit in [`../characters/champ.md`](../characters/champ.md).
 
 ## The rally and the count
 

--- a/designs/concept/02-cracks-and-break.md
+++ b/designs/concept/02-cracks-and-break.md
@@ -18,27 +18,15 @@ Both kinds are authored. Both are deniable. The mix is what makes the cumulative
 
 Concrete leakage stays out. A real-world object literally appearing on the rack reads as a flag the player can point at; the deniability the cumulative shape needs collapses.
 
-## The championship win
+## The championship win as the break
 
-The protagonist climbs every round. The obsession with becoming champ deepens. The word does double work: become the champion (win the title) and become the champ (the dead friend rendered as the final). Both pulls live in one motion; the protagonist does not separate them.
+The structural shape: the win IS the break. The construct cannot hold itself together once its central goal has been achieved and proved meaningless. Cumulative cracks have been preparing the player to read what just happened; the win is the singular moment that makes the prior cracks legible as a chord rather than as noise.
 
-The player wins the championship. They do beat the champ.
+At the moment of the win, the count completes. The digits land. The protagonist sees them, vaguely familiar, and the connection does not form. Recognition is held until the cliff.
 
-The win feels off. Both pulls of becoming-champ are satisfied at the same beat and neither was the thing the protagonist actually needed.
+The full beat (climbing every round, the doubled meaning of "becoming champ", the win landing wrong, the walk through the hometown, the shopkeeper missing, the champ exiting) sits in [`../narrative/outline.md`](../narrative/outline.md). The visual moment of the break is in [`../art/bible.md`](../art/bible.md) § 7.
 
-The win IS the break. The construct cannot hold itself together once its central goal has been achieved and proved meaningless. Cumulative cracks have been preparing the player to read what just happened; the win is the singular moment that makes the prior cracks legible as a chord rather than as noise.
-
-At the moment of the win, the count completes. The digits land. The protagonist sees them, vaguely familiar, and the connection does not form. The number stays unnamed in their phone. Recognition is held until the cliff.
-
-## After the win: the walk through Reality
-
-The player is pulled into Reality involuntarily for the first time. The protagonist walks through the hometown. Sees the people behind the partners. Martha at the actual newsagent. The others in their actual lives, plainer.
-
-They discover the shopkeeper is missing. The shop is empty. The door is locked, lights off, a notice on the door. Family worried. The person the protagonist was reaching for without admitting it has actually disappeared.
-
-The champ exits at this point. They do not appear in Part 2.
-
-The break ends. The player is back in Construction, but Construction has lost its warm centre: the shop is closed; the friend at the stall is gone. End of Part 1. Part 2 begins (`03-reconstruction.md`).
+The break ends with the player back in Construction, the shop closed, the friend at the stall gone. End of Part 1. Part 2 begins (`03-reconstruction.md`).
 
 ## Open questions
 

--- a/designs/concept/03-reconstruction.md
+++ b/designs/concept/03-reconstruction.md
@@ -4,21 +4,13 @@ Part 2. The arc after the break: dread, the search, the photo album, the unnamed
 
 ## What Part 2 is
 
-The shopkeeper is missing. The shop is closed. The friend the protagonist was reaching for without admitting it has actually disappeared.
+The arc after the break: the shopkeeper missing, dread, the search across Reality, the photo album, the unnamed number ringing into nothing, the key that opens the cliff. The full story sits in [`../narrative/outline.md`](../narrative/outline.md); the shopkeeper's withdrawal in [`../characters/shopkeeper.md`](../characters/shopkeeper.md). Construction's visual hollowing in [`../art/bible.md`](../art/bible.md) § 8.
 
-The protagonist's belief, and the player's: the shopkeeper followed the friend's path. Went back to the cliff. Is gone. Cliff jumping was the friend group's normal until the day it wasn't, and the shopkeeper survived once already; the fear is that surviving once was the limit. The unnamed number does not connect, and that no-answer is the player-facing weight of the protagonist's ineffectual reach.
+This doc holds the structural detail: how Part 2 plays, the photo album mechanic, the unnamed number's behaviour, the key.
 
-The driving force is the search. Not "find the shopkeeper" generically: find out what they did, where they went, whether it is too late. The whole arc is the search-for-confirmation, shadowed by the fear that the confirmation will be terrible.
+## Three play-level changes
 
-This is the act-2 dread. It runs the length of Reconstruction. It inverts at the cliff (`05-postgame.md`).
-
-## Where the work happens
-
-Part 2 lives in both styles. Reality carries the search. Construction holds the rally that surfaces what the search needs.
-
-Construction in Part 2 is missing its warm centre. The shopkeeper has left the stall; the shop is closed in Reality and unstaffed in Construction. The protagonist rallies on without them. The vibrant world has been hollowed out where it used to be warmest.
-
-Construction must also feel different to play, not only look hollowed. Three play-level changes mark Part 2:
+Part 2 lives in both styles. Reality carries the search. Construction holds the rally that surfaces what the search needs. Construction must feel different to play, not only look hollowed:
 
 - **The score is hidden in Construction.** The count climbed visibly through Part 1; in Part 2 the number disappears from the rally HUD. The player rallies without seeing how the digits are filling. The number can be checked, but only in Reality (the sister's, the closed shop, the cliff once unlocked). The score migrates from Construction to Reality. Leaving the rally to know how close they are is the exact style-shift Part 2 wants to feel like.
 - **Coaches' lines reach back.** Each coach who keeps showing up in Construction carries memories of the shopkeeper into the rally between points. Their lines soften, lengthen, surface what they remember. The shift is in dialogue, not in stat.
@@ -35,14 +27,6 @@ Each rally in Construction surfaces a memory. Each memory becomes a photo, or un
 The found photos compound. Pages fill. The hidden compartment gets closer to opening. The search closes in.
 
 The photo album mechanic is the protagonist saying: someone has been keeping this. The shopkeeper kept the history because the protagonist could not. The sister holds the album because she is not entangled in the absence the way the shopkeeper is.
-
-## The sister
-
-Less weighted by the death than the shopkeeper. The bridge. She holds the album and the protagonist's first reachable Reality character after the break.
-
-Sitting with her and turning the pages of what is there is the first reconciliation moment. After that, the protagonist goes to find the rest. She receives each found photo. She mentions things in passing as the album fills: the way her brother used to leave the shop door, what was on the radio that morning, a song he played too loud.
-
-She is the most-visited Reality character. Her scene supports many returns.
 
 ## The unnamed number, in Part 2
 

--- a/designs/concept/05-postgame.md
+++ b/designs/concept/05-postgame.md
@@ -2,37 +2,17 @@
 
 The ending and what comes after. The cliff is the chosen-acceptance bookend to the break; the call is the one beat the whole game has been reaching for; the credits play over the rally that proves it; postgame keeps the rally going. High-level architecture in `00-three-styles.md`. Part 2's arc into the gate is in `03-reconstruction.md`.
 
-## The cliff
+## The cliff and the call
 
-The album fills. The hidden compartment opens. The sister hands over the key. The protagonist returns to the garden, walks to the locked gate, unlocks it, walks through.
+The structural shape: the album fills, the compartment opens, the sister hands over the key. The protagonist unlocks the garden gate and walks through to the cliff. The shopkeeper is on the bench. The dread inverts to relief. Recognition lands; the protagonist dials the unnamed number; the shopkeeper picks up. The call ends. The protagonist sits beside them.
 
-The cliff is on the other side. The same edge the friend group used to jump from. The bench is there, dedicated to the friend who died. The shopkeeper is on the bench. Alive.
-
-The act-2 dread inverts. Relief. The fear was wrong. The shopkeeper has been here, withdrawn, refusing calls, sitting at the place they jumped from together and walked away from alone. The visit closes that absence by chosen presence: the protagonist arriving at the spot they were not at the day it happened, beside the one who was.
-
-## The call
-
-Recognition lands at the cliff for the first time. The unnamed number in the phone, the world record the protagonist reached, the digits the championship match resolved on, the shopkeeper sitting in front of them on the bench: all of it the same number, held unnamed all along, only now legible.
-
-The protagonist takes out their phone. They could walk up silently. They do not. They dial the unnamed number, knowing now whose it is.
-
-The shopkeeper's phone rings on the bench beside them. They could ignore it like they have been ignoring all the others. They do not. They look up at the sound. See the protagonist. Pick up.
-
-The dial does two things at once. Chosen presence: the protagonist could close the silence by walking up, and chooses instead to call. The shopkeeper could ignore the ring like every other, and chooses instead to pick up. And finally attaching the name to the number the protagonist has been carrying. The phone log entry is not just digits anymore. It is the person who jumped that day and came back; the one whose survival the protagonist could not look at, until now.
-
-### Staging
-
-Split frame at the path, the bench, the phones. The protagonist standing; the shopkeeper on the bench, holding their phone. The dial bridges intention, not space. They look at each other across the silence both have been holding, both with phones to their ears. After the touchstone of *Broken Age*'s key art, where two characters share one image divided by a structural element. The split is the years between them; the shared frame is the resolution. Then the protagonist crosses, sits beside them. The call ends.
+The full beat (recognition, the dial, what the dial is doing, what the call resolves) lives in [`../narrative/outline.md`](../narrative/outline.md). The split-frame staging at the bench lives in [`../art/bible.md`](../art/bible.md) § 9.
 
 ## Credits
 
-Credits play over the rally. The first one between the protagonist and the shopkeeper. Construction's championship spot now occupied by the actual person, not the substitute. Racquet in their hand. The ball going back and forth. The names scroll over the play. The rally keeps going.
+Credits play over the rally between the protagonist and the shopkeeper, championship spot now held by the actual person. Construction's saturated light returns with the texture Reality has worn into it across Part 2.
 
-The image is the proof: the daily thing the protagonist did alone is finally done together.
-
-The visual style is Construction's saturated, generous light, with the texture Reality has worn into it across Part 2. The bench from the cliff visible somewhere: maybe in a corner, maybe glimpsed past the gate that now stays open.
-
-The audio: per the SH-281 arc, full-orchestra range available. The synth warmth that opened the game returns layered with the acoustic instruments Reality brought. Audio synthesis at exactly the visual moment of synthesis.
+Audio per the SH-281 arc: full-orchestra range, the synth warmth that opened the game returning layered with the acoustic instruments Reality brought. Audio synthesis at exactly the visual moment of synthesis.
 
 ## Postgame
 


### PR DESCRIPTION
The concept folder grew up holding everything per-arc: structure, story, characters, visual. With the bible and characters/* now carrying their share, concept docs can shrink to their actual job — the structural shape of each arc.

Cuts:
- \`01-construction.md\` loses \"What Construction is\" (visual, bible §5), \"The hook\" (narrative, outline), \"The cast\" (characters/* + bible §4), and the entire \"Why the shopkeeper is at the stall\" section (characters/shopkeeper.md).
- \`02-cracks-and-break.md\` trims \"The championship win\" and \"After the win: the walk through Reality\" to a single structural paragraph that links to outline and bible.
- \`03-reconstruction.md\` trims \"What Part 2 is\" and drops the \"## The sister\" section (characters/sister.md).
- \`05-postgame.md\` trims \"The cliff\", \"The call\", and \"Credits\" narrative to a brief structural summary plus links to outline and bible.

Net change: -108 / +18 lines. Tournament shape, rally and count, photo album mechanic, unnamed-number behaviour, the key, and postgame structure all stay where they were. Open questions and production notes intact.
