### PR TITLE
docs: clear last register stragglers in canon prose

### DIFF
--- a/designs/art/bible.md
+++ b/designs/art/bible.md
@@ -151,7 +151,7 @@ Pacing across the climb, escalation rules, and the cumulative-shape principle li
 
 The wall comes down. Once. Light, sound, the venue's surfaces, the friend's posture: all turn at once. A giving-way, not a glitch.
 
-After the rupture the player walks through the protagonist's hometown for the first sustained Reality render: the people behind the partners at their actual ages, the closed shop with the lights off, a sign on the door. The walk's visual job is to introduce Reality's full register before the player carries it back to Construction.
+After the rupture the player walks through the protagonist's hometown for the first sustained Reality render: the people behind the partners at their actual ages, the closed shop with the lights off, a sign on the door. The walk's visual job is to introduce Reality's full style before the player carries it back to Construction.
 
 The break ends and the player is back in Construction, but the wall does not go back up. The shop stays closed. The friend at the stall is gone. The warm centre is hollowed out; the rallies render that absence.
 

--- a/designs/narrative/discipline.md
+++ b/designs/narrative/discipline.md
@@ -1,6 +1,6 @@
 # Narrative discipline
 
-How the prose, scenes, and dialogue of Volley get made. Not what the story is: that lives in [`outline.md`](outline.md) (sibling, in flight). This is the craft register the writing aims for, line by line.
+How the prose, scenes, and dialogue of Volley get made. Not what the story is: that lives in [`outline.md`](outline.md) (sibling, in flight). This is the craft the writing aims for, line by line.
 
 The prose voice lives in [`../../ai/STYLE.md`](../../ai/STYLE.md). The world canon sits in [`../art/bible.md`](../art/bible.md). The protagonist's interior is in [`../characters/protagonist.md`](../characters/protagonist.md). The structural spine is in [`../concept/`](../concept/). Read those first; this doc tells you how to write inside them.
 
@@ -30,7 +30,7 @@ Canon lands as action. A piece of world that needs to reach the player reaches i
 
 Tone moves moment to moment. Construction's default is the coach's grin between rallies, the friend at the stall calling a name across the court, the lift in a line that did not need lift. A meta-crack lands, the player notices and reaches for a way to read it, the rally moves on. The slip is one beat the prose commits to and lets land; the resettle is the rest of the rally. A scene that crackles for two paragraphs has overcommitted.
 
-The break runs cold and short. Sentences shrink. Adjectives drop. Light becomes light, sound becomes sound, the prose stops reaching for warmth because the construct has stopped supplying it. Then the walk through the hometown begins and the prose finds Reality's plainer register for the first time.
+The break runs cold and short. Sentences shrink. Adjectives drop. Light becomes light, sound becomes sound, the prose stops reaching for warmth because the construct has stopped supplying it. Then the walk through the hometown begins and the prose finds Reality's plainer voice for the first time.
 
 Part 2 defaults to dread. The temperature is low. Warm surfacings are rare and earned: a memory at a rally's apex, a small mercy from the sister, a cup of tea poured without comment. The contrast is the point. Warmth on a dread floor reads brighter than warmth on a warm floor.
 

--- a/designs/narrative/outline.md
+++ b/designs/narrative/outline.md
@@ -28,7 +28,7 @@ There is exactly one locked gate in the whole game. It sits in the garden. Walki
 
 The top edge of the court is sky, not surface. The ball travels up to apex and returns under gravity and the friendship-bound: whichever bond is in play in that venue is what the rally lives inside, and the bond's reach is what the ball cannot escape. Mechanically the ball changes direction at apex; diegetically nothing physical bounces it.
 
-The moment of return is a visible beat in Construction's register. A bloom of light, a brief connecting arc, a satisfying synth chime, a reaction from the present friend: eyes up, racquet lift, a small gesture from wherever they stand. Satisfying, not loud. Each rally point closes on this beat. The friend is a co-celebrant of the return, not scenery.
+The moment of return is a visible beat in Construction's style. A bloom of light, a brief connecting arc, a satisfying synth chime, a reaction from the present friend: eyes up, racquet lift, a small gesture from wherever they stand. Satisfying, not loud. Each rally point closes on this beat. The friend is a co-celebrant of the return, not scenery.
 
 The garden's version of the apex event runs through the shopkeeper's reaction at the stall, since the venue has no physical ceiling and the shopkeeper is the bond the garden holds. Other Construction venues run the same beat through the coach who teaches there: the partner's reaction at the treetop canopy, at the underwater surface, in the meteor field. The bond doing the work changes by venue. The pattern is the same.
 


### PR DESCRIPTION
Four `register`-as-tone uses left in canon docs after the bigger sweeps. Outline L31 ("Construction's register" → "Construction's style"), bible L154 ("Reality's full register" → "Reality's full style"), discipline L3 ("the craft register the writing aims for" → "the craft the writing aims for") and L33 ("Reality's plainer register" → "Reality's plainer voice").

The two `## Visual register` / `## Audio register` headings in `concept/04-reality.md` stay: those describe Reality's own register from inside Reality, per the SH-285 note.