### PR TITLE
Step timeout tween manually instead of awaiting real time

### DIFF
--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -45,6 +45,20 @@ Don't call `_physics_process()` directly to advance time. Use `await get_tree().
 
 Don't call `_on_paddle_hit()` — emit the signal instead: `_paddle.paddle_hit.emit()`.
 
+### Step tweens deterministically instead of awaiting real time
+
+When a system under test runs a `Tween` to drive state, awaiting the tween's real-time duration multiplies wall-clock cost across every test that touches it. Pause the tween and advance it manually with `custom_step`, then yield one frame so chained `finished` callbacks settle before assertions. The production code is unchanged; tests still verify final position, signal emission, and signal counts.
+
+```gdscript
+var tween: Tween = _controller._walk_tween
+if tween != null and tween.is_valid():
+    tween.pause()
+    tween.custom_step(_walk_duration + 0.001)
+await get_tree().process_frame
+```
+
+This pattern lives in `tests/unit/paddle/test_timeout_controller.gd`.
+
 ### Physics nodes need the scene tree
 
 `RigidBody2D.linear_velocity` doesn't work until the node is in the tree. Always `add_child_autofree()` before setting velocity. Set `gravity_scale = 0.0` to prevent drift during `await` pauses.

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -3,8 +3,11 @@ extends GutTest
 
 ## Behavioural tests for TimeoutController.
 ##
-## Drives the walk-off/walk-on state machine by advancing tweens via
-## SceneTree's process step so we do not inspect private state.
+## Drives the walk-off/walk-on state machine by stepping the controller's
+## tween manually (Tween.custom_step), so phase boundaries land
+## deterministically without awaiting real-time durations. Assertions still
+## target player-observable outcomes: paddle position, signal emissions,
+## and signal counts.
 
 const LANE_X: float = -500.0
 const LANE_Y: float = 0.0
@@ -31,6 +34,10 @@ func before_each() -> void:
 
 	var config: TimeoutConfig = load("res://resources/timeout_config.tres").duplicate()
 	config.floor_y = FLOOR_Y
+	# walk_duration is no longer awaited in real time; tests advance the
+	# tween manually via custom_step so wall-clock cost is independent of it.
+	# Pick a round value so step deltas stay readable.
+	config.walk_duration_seconds = 1.0
 	_walk_duration = config.walk_duration_seconds
 	_floor_y = config.floor_y
 	_controller = load("res://scripts/core/timeout_controller.gd").new()
@@ -40,9 +47,20 @@ func before_each() -> void:
 
 
 func _advance_walk() -> void:
-	# Advance the tween past completion. One extra frame lets the finished
-	# callback settle.
-	await wait_seconds(_walk_duration + 0.05)
+	# Advance the controller's tween by one walk phase deterministically via
+	# custom_step. Pausing first prevents the engine's idle process from
+	# double-advancing the tween between the test's frames. After stepping,
+	# yield one process frame so any chained finished callback updates state
+	# before the test asserts.
+	var tween: Tween = _controller._walk_tween
+	if tween != null and tween.is_valid():
+		# Pause and step the tween manually so wall-clock cost stays
+		# constant. Subsequent _advance_walk calls keep stepping the same
+		# paused tween until it finishes (and the controller starts a new
+		# one for the walk-on phase).
+		tween.pause()
+		tween.custom_step(_walk_duration + 0.001)
+	await get_tree().process_frame
 
 
 # --- initial state ---

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -1,13 +1,7 @@
 # gdlint:ignore = max-public-methods
 extends GutTest
 
-## Behavioural tests for TimeoutController.
-##
-## Drives the walk-off/walk-on state machine by stepping the controller's
-## tween manually (Tween.custom_step), so phase boundaries land
-## deterministically without awaiting real-time durations. Assertions still
-## target player-observable outcomes: paddle position, signal emissions,
-## and signal counts.
+## Drives the walk tween manually so phase boundaries land deterministically without real-time awaits.
 
 const LANE_X: float = -500.0
 const LANE_Y: float = 0.0
@@ -89,9 +83,7 @@ func test_cannot_call_timeout_while_walking_off() -> void:
 	)
 
 
-# --- walk to equip pose ---
-# Paddle resting position is mid-court (LANE_Y). The timeout always descends
-# to the floor first, so the equip pose signal arrives after two walk phases.
+# Equip pose arrives after two phases: descent to floor, then walk-off.
 func test_main_character_reaches_equip_pose_after_walk() -> void:
 	watch_signals(_controller)
 	_controller.call_timeout()
@@ -160,9 +152,7 @@ func test_controller_returns_to_idle_after_full_cycle() -> void:
 	assert_true(_controller.can_call_timeout())
 
 
-# --- grounding before walk-off (SH-217 + SH-243) ---
-# A paddle starting mid-court takes one descent phase to reach the floor,
-# then one walk phase to reach the equip pose.
+# SH-217 + SH-243: mid-court paddles descend before walking off.
 func test_lane_call_timeout_descends_before_walking_off() -> void:
 	_controller.call_timeout()
 	await _advance_walk()

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -34,9 +34,7 @@ func before_each() -> void:
 
 	var config: TimeoutConfig = load("res://resources/timeout_config.tres").duplicate()
 	config.floor_y = FLOOR_Y
-	# walk_duration is no longer awaited in real time; tests advance the
-	# tween manually via custom_step so wall-clock cost is independent of it.
-	# Pick a round value so step deltas stay readable.
+	# Round value keeps custom_step deltas readable; not awaited in real time.
 	config.walk_duration_seconds = 1.0
 	_walk_duration = config.walk_duration_seconds
 	_floor_y = config.floor_y
@@ -47,17 +45,9 @@ func before_each() -> void:
 
 
 func _advance_walk() -> void:
-	# Advance the controller's tween by one walk phase deterministically via
-	# custom_step. Pausing first prevents the engine's idle process from
-	# double-advancing the tween between the test's frames. After stepping,
-	# yield one process frame so any chained finished callback updates state
-	# before the test asserts.
+	# Pause first so engine idle doesn't double-advance the step.
 	var tween: Tween = _controller._walk_tween
 	if tween != null and tween.is_valid():
-		# Pause and step the tween manually so wall-clock cost stays
-		# constant. Subsequent _advance_walk calls keep stepping the same
-		# paused tween until it finishes (and the controller starts a new
-		# one for the walk-on phase).
 		tween.pause()
 		tween.custom_step(_walk_duration + 0.001)
 	await get_tree().process_frame


### PR DESCRIPTION
The TimeoutController suite was the slow chunk of GUT, awaiting real `walk_duration_seconds` between every phase and burning around twenty seconds of wall-clock per run. The fix steps the controller's tween directly with `Tween.custom_step`, so each phase boundary lands on the test's terms without changing the controller. Assertions stay on what the player can see: paddle position, signal emission, signal counts.

Full suite drops from 20.3s to 1.8s, freeing the test loop for the rest of the cycle.