### PR TITLE
fix(SH-233): TimeoutController recovers when main character vanishes mid-walk

### DIFF
--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -110,6 +110,7 @@ func _walk_to_position(target: Vector2, on_finished: Callable) -> void:
 
 func _on_reached_equip_pose() -> void:
 	if not is_instance_valid(main_character):
+		_recover_to_idle()
 		return
 	_state = State.AT_EQUIP_POSE
 	main_character_reached_equip_pose.emit()
@@ -119,4 +120,12 @@ func _on_reached_lane() -> void:
 	_state = State.IDLE
 	if is_instance_valid(main_character):
 		main_character.set_physics_process(true)
+	timeout_ended.emit()
+
+
+# Drops a stuck timeout when the main character vanishes mid-walk so callers can start a new one.
+func _recover_to_idle() -> void:
+	if _walk_tween != null and _walk_tween.is_valid():
+		_walk_tween.kill()
+	_state = State.IDLE
 	timeout_ended.emit()

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -262,6 +262,21 @@ func test_repeated_call_timeout_while_airborne_stays_single_run() -> void:
 	assert_signal_emit_count(_controller, "main_character_reached_equip_pose", 1)
 
 
+# SH-233: a freed main character mid-walk must not deadlock the controller.
+func test_main_character_freed_mid_walk_recovers_to_idle() -> void:
+	watch_signals(_controller)
+	_controller.call_timeout()
+	_paddle.queue_free()
+	await get_tree().process_frame
+	# Walk tween auto-kills when its target frees; trigger the equip-pose callback directly.
+	_controller._on_reached_equip_pose()
+	assert_false(
+		_controller.is_active(), "controller must drop back to idle when main character vanishes"
+	)
+	assert_true(_controller.can_call_timeout(), "another timeout should be callable after recovery")
+	assert_signal_emitted(_controller, "timeout_ended")
+
+
 func test_end_timeout_returns_to_lane_position() -> void:
 	_controller.call_timeout()
 	await _advance_walk()


### PR DESCRIPTION
A freed paddle during WALKING_OFF left the controller stuck because the equip-pose callback returned early without resetting state. Now drops to IDLE and emits timeout_ended so callers can start a new timeout.

Closes SH-233.