### PR TITLE
Centre container visuals on their position (SH-290)

### DIFF
--- a/scenes/ball_rack.tscn
+++ b/scenes/ball_rack.tscn
@@ -14,49 +14,50 @@ slot_container = NodePath("SlotContainer")
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1349315967]
-offset_right = 300.0
-offset_bottom = 200.0
+offset_left = -150.0
+offset_top = -100.0
+offset_right = 150.0
+offset_bottom = 100.0
 mouse_filter = 2
 color = Color(0.9, 0.5, 0.2, 0.6)
 
 [node name="Name" type="Label" parent="." unique_id=968076420]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 10.0
-offset_bottom = 10.0
+offset_left = -140.0
+offset_top = -90.0
+offset_right = -140.0
+offset_bottom = -90.0
 theme_override_font_sizes/font_size = 36
 text = "BallRack"
 
 [node name="SlotContainer" type="Node2D" parent="." unique_id=1349315968]
 
 [node name="SlotMarker0" type="Node2D" parent="SlotContainer" unique_id=1349315980]
-position = Vector2(37.5, 50)
+position = Vector2(-112.5, -50)
 
 [node name="SlotMarker1" type="Node2D" parent="SlotContainer" unique_id=1349315981]
-position = Vector2(112.5, 50)
+position = Vector2(-37.5, -50)
 
 [node name="SlotMarker2" type="Node2D" parent="SlotContainer" unique_id=1349315982]
-position = Vector2(187.5, 50)
+position = Vector2(37.5, -50)
 
 [node name="SlotMarker3" type="Node2D" parent="SlotContainer" unique_id=1349315983]
-position = Vector2(262.5, 50)
+position = Vector2(112.5, -50)
 
 [node name="SlotMarker4" type="Node2D" parent="SlotContainer" unique_id=1349315984]
-position = Vector2(37.5, 150)
+position = Vector2(-112.5, 50)
 
 [node name="SlotMarker5" type="Node2D" parent="SlotContainer" unique_id=1349315985]
-position = Vector2(112.5, 150)
+position = Vector2(-37.5, 50)
 
 [node name="SlotMarker6" type="Node2D" parent="SlotContainer" unique_id=1349315986]
-position = Vector2(187.5, 150)
+position = Vector2(37.5, 50)
 
 [node name="SlotMarker7" type="Node2D" parent="SlotContainer" unique_id=1349315987]
-position = Vector2(262.5, 150)
+position = Vector2(112.5, 50)
 
 [node name="DropTarget" type="Area2D" parent="." unique_id=1349315969]
 monitoring = false
 monitorable = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DropTarget" unique_id=1349315970]
-position = Vector2(150, 100)
 shape = SubResource("RectangleShape2D_ball_rack_drop")

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -132,13 +132,13 @@ position = Vector2(500, 0)
 position = Vector2(-500, 0)
 
 [node name="BallRack" parent="." unique_id=949376876 instance=ExtResource("8_h0b8m")]
-position = Vector2(-1065, 0)
+position = Vector2(-1000, 583)
 
 [node name="GearRack" parent="." unique_id=445509089 instance=ExtResource("9_c7axm")]
-position = Vector2(760, 0)
+position = Vector2(1000, 583)
 
 [node name="ShipmentMat" parent="." unique_id=530264883 instance=ExtResource("10_5mv5b")]
-position = Vector2(760, 438)
+position = Vector2(1450, 583)
 
 [node name="CurrentVolleyCountLabel" type="Label" parent="." unique_id=1644947756 node_paths=PackedStringArray("court")]
 offset_left = -150.0

--- a/scenes/gear_rack.tscn
+++ b/scenes/gear_rack.tscn
@@ -14,49 +14,50 @@ slot_container = NodePath("SlotContainer")
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1470078387]
-offset_right = 300.0
-offset_bottom = 200.0
+offset_left = -150.0
+offset_top = -100.0
+offset_right = 150.0
+offset_bottom = 100.0
 mouse_filter = 2
 color = Color(0.3, 0.5, 0.9, 0.6)
 
 [node name="Name" type="Label" parent="." unique_id=1742093710]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 10.0
-offset_bottom = 10.0
+offset_left = -140.0
+offset_top = -90.0
+offset_right = -140.0
+offset_bottom = -90.0
 theme_override_font_sizes/font_size = 36
 text = "GearRack"
 
 [node name="SlotContainer" type="Node2D" parent="." unique_id=1742093711]
 
 [node name="SlotMarker0" type="Node2D" parent="SlotContainer" unique_id=1742093720]
-position = Vector2(37.5, 50)
+position = Vector2(-112.5, -50)
 
 [node name="SlotMarker1" type="Node2D" parent="SlotContainer" unique_id=1742093721]
-position = Vector2(112.5, 50)
+position = Vector2(-37.5, -50)
 
 [node name="SlotMarker2" type="Node2D" parent="SlotContainer" unique_id=1742093722]
-position = Vector2(187.5, 50)
+position = Vector2(37.5, -50)
 
 [node name="SlotMarker3" type="Node2D" parent="SlotContainer" unique_id=1742093723]
-position = Vector2(262.5, 50)
+position = Vector2(112.5, -50)
 
 [node name="SlotMarker4" type="Node2D" parent="SlotContainer" unique_id=1742093724]
-position = Vector2(37.5, 150)
+position = Vector2(-112.5, 50)
 
 [node name="SlotMarker5" type="Node2D" parent="SlotContainer" unique_id=1742093725]
-position = Vector2(112.5, 150)
+position = Vector2(-37.5, 50)
 
 [node name="SlotMarker6" type="Node2D" parent="SlotContainer" unique_id=1742093726]
-position = Vector2(187.5, 150)
+position = Vector2(37.5, 50)
 
 [node name="SlotMarker7" type="Node2D" parent="SlotContainer" unique_id=1742093727]
-position = Vector2(262.5, 150)
+position = Vector2(112.5, 50)
 
 [node name="DropTarget" type="Area2D" parent="." unique_id=1742093712]
 monitoring = false
 monitorable = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DropTarget" unique_id=1742093713]
-position = Vector2(150, 100)
 shape = SubResource("RectangleShape2D_gear_rack_drop")

--- a/scenes/shipment_mat.tscn
+++ b/scenes/shipment_mat.tscn
@@ -6,15 +6,17 @@ z_as_relative = false
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1427717404]
-offset_right = 400.0
-offset_bottom = 150.0
+offset_left = -200.0
+offset_top = -75.0
+offset_right = 200.0
+offset_bottom = 75.0
 mouse_filter = 2
 color = Color(0.6, 0.4, 0.25, 0.6)
 
 [node name="Name" type="Label" parent="." unique_id=1599350400]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 10.0
-offset_bottom = 10.0
+offset_left = -190.0
+offset_top = -65.0
+offset_right = -190.0
+offset_bottom = -65.0
 theme_override_font_sizes/font_size = 36
 text = "ShipmentMat"

--- a/scenes/workshop.tscn
+++ b/scenes/workshop.tscn
@@ -6,15 +6,17 @@ z_as_relative = false
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1882650834]
-offset_right = 500.0
-offset_bottom = 400.0
+offset_left = -250.0
+offset_top = -200.0
+offset_right = 250.0
+offset_bottom = 200.0
 mouse_filter = 2
 color = Color(0.6, 0.3, 0.8, 0.6)
 
 [node name="Name" type="Label" parent="." unique_id=258133050]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 10.0
-offset_bottom = 10.0
+offset_left = -240.0
+offset_top = -190.0
+offset_right = -240.0
+offset_bottom = -190.0
 theme_override_font_sizes/font_size = 36
 text = "Workshop"


### PR DESCRIPTION
Each container's `position` now marks its visual centre rather than its top-left, so the rack/shipment-mat/workshop scenes have a real spatial home instead of an offset rectangle. Drop targets align to that centre, and racks shift onto the venue floor outside the court's lateral extent.

Wall-removal aspects of the AC (no top wall under the friendship-bound apex rule, sides as pure miss bands without solid colliders) are deferred until friendship-bound apex physics ships; removing the colliders now would let the ball escape the court with no apex return, regressing the rally.