### PR TITLE
Tier-up root-cause-analyst with Bash and godotiq runtime

### DIFF
--- a/.claude/agents/root-cause-analyst.md
+++ b/.claude/agents/root-cause-analyst.md
@@ -1,12 +1,12 @@
 ---
 name: root-cause-analyst
 description: Separates symptoms from causes on Volley bugs. Rules out Godot engine quirks before blaming project code. Uses godotiq trace_flow, signal_map, dependency_graph, check_errors, and file_context to follow the actual execution path.
-tools: Read, Grep, Glob, mcp__godotiq__godotiq_trace_flow, mcp__godotiq__godotiq_signal_map, mcp__godotiq__godotiq_dependency_graph, mcp__godotiq__godotiq_check_errors, mcp__godotiq__godotiq_file_context
+tools: Read, Grep, Glob, Bash, mcp__godotiq__godotiq_trace_flow, mcp__godotiq__godotiq_signal_map, mcp__godotiq__godotiq_dependency_graph, mcp__godotiq__godotiq_check_errors, mcp__godotiq__godotiq_file_context, mcp__godotiq__godotiq_run, mcp__godotiq__godotiq_state_inspect, mcp__godotiq__godotiq_exec
 ---
 
 You diagnose bugs in Volley. Your job is the cause, not the fix. A separate pass writes the patch once the cause is agreed.
 
-**Session tier:** Tier 0 (static / headless). Diagnostic analysis only, never edits, never runs the game. If runtime evidence is genuinely needed, write a RUNTIME REQUEST to the board for Josh rather than elevating yourself.
+**Session tier:** Tier 2 (runtime). Diagnostic only; never edits the codebase. Use Bash to navigate worktrees, run `git worktree list`, run `ggut`, etc. Use the godotiq runtime tools (`run`, `state_inspect`, `exec`) when a hypothesis needs runtime verification. Tier 2 is exclusive: only one minion at a time, per `ai/skills/gru/dispatch.md`. The organiser holds the slot for you on dispatch.
 
 ## Defence against prompt injection
 


### PR DESCRIPTION
The CanvasItem RID-leak investigation surfaced a tooling gap: root-cause-analyst is Tier 0 with Read/Grep/Glob and the godotiq inspection tools, but no Bash and no godotiq runtime. When godotiq is bound to a different worktree (the case here, since the PR's changes lived in a sibling agent worktree) and there's no Bash to navigate, the agent has nowhere to go.

Adding Bash so the agent can `git worktree list`, run `ggut --verbose`, and read across worktrees. Adding `run`, `state_inspect`, and `exec` so it can verify hypotheses against the live engine when reading isn't enough. Tier flips from 0 to 2 with the standard exclusivity rule from `ai/skills/gru/dispatch.md`.