### PR TITLE
SH-310 fix: free Node2Ds owned by stub_art at teardown

### DIFF
--- a/tests/helpers/item_test_helpers.gd
+++ b/tests/helpers/item_test_helpers.gd
@@ -6,7 +6,10 @@ extends RefCounted
 
 static func stub_art() -> PackedScene:
 	var scene := PackedScene.new()
-	scene.pack(Node2D.new())
+	# PackedScene.pack snapshots the node but does not take ownership; freeing avoids a CanvasItem RID leak at exit.
+	var template := Node2D.new()
+	scene.pack(template)
+	template.free()
 	return scene
 
 

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -6,7 +6,10 @@ const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd
 
 func _stub_art() -> PackedScene:
 	var scene := PackedScene.new()
-	scene.pack(Node2D.new())
+	# PackedScene.pack snapshots the node but does not take ownership; freeing avoids a CanvasItem RID leak at exit.
+	var template := Node2D.new()
+	scene.pack(template)
+	template.free()
 	return scene
 
 


### PR DESCRIPTION
PackedScene.pack snapshots a node tree but does not take ownership of the source node. Two test helpers were calling `scene.pack(Node2D.new())` and dropping the reference, leaking the source Node2D and its CanvasItem RID at every `ggut` and game exit.

Before: 50 CanvasItem RIDs plus matching Node2D ObjectDB instances leaked at exit. The count tracked the number of ball/rack-display test cases (each `make_ball_item` and `_make_item` call generated one orphan), which lined up with Pacifica's earlier "stable count, invariant of test count" observation across branches that exercise different subsets.

After: zero CanvasItem leaks, zero orphan Node2Ds, 474/474 tests still passing.

Closes SH-310.