### PR TITLE
Hydrate before any recap or status claim

### DIFF
--- a/ai/skills/gru/dispatch.md
+++ b/ai/skills/gru/dispatch.md
@@ -55,6 +55,12 @@ If consensus is still split 2-2, that's a sign the question itself isn't decidab
 
 At most one `spike` issue per swarm dispatch. Run additional spikes sequentially.
 
+## Hydrate before recap
+
+Before any recap, status report, or claim about challenge state, run `gh pr list --state open --json number,state,mergeable,labels,headRefOid` (or `gh pr view <n> --json ...` for a specific challenge). Don't recap from in-context memory of the last dispatch; dispatches and merges can happen between turns. The first action of any state-summary turn is the hydrate command, not text.
+
+Same rule for inline-comment threads: before claiming a thread is replied or unaddressed, run `gh api repos/.../pulls/<n>/comments` and read.
+
 ## Challenge sweep
 
 On every challenge sweep, check `gh pr view <n> --json state,mergedAt,mergeable,labels` for each challenge in scope. Read `state` first; `mergeable` is unreliable on merged challenges and reads `UNKNOWN` post-merge.


### PR DESCRIPTION
The hydrate-PR-state rule lived in memory only and slipped three times this session — recaps quoted stale labels, mergeable reads, and even merged-vs-open state. Lifting it into the dispatch skill as the first item of the challenge-sweep section so future-Gru reads it on every dispatch.

The rule: before any recap, status report, or claim about challenge state, run the gh query. Don't recap from in-context memory of the last dispatch; dispatches and merges can happen between turns.