### PR TITLE
Pair every code dispatch by default

### DIFF
--- a/ai/skills/gru/dispatch.md
+++ b/ai/skills/gru/dispatch.md
@@ -37,7 +37,7 @@ Every Agent call uses `run_in_background: true`. Coordinate multiple background 
 
 Three dispatch shapes for code work, picked by issue type. The cognitive separation between test and impl is the point; pick the shape that achieves it for the kind of issue at hand.
 
-### User stories — blind test-author handoff
+### User stories: blind test-author handoff
 
 For tickets with player-observable ACs ("ball appears on rack after buy," "drag from court back to rack works mid-rally"):
 
@@ -45,7 +45,7 @@ For tickets with player-observable ACs ("ball appears on rack after buy," "drag 
 2. **Impl dispatched second** into the same worktree, briefed on the design and shown the failing tests. Makes them pass without weakening them. Commits both halves, pushes.
 3. **Reviewer (test-coverage)** verifies the tests aren't tautological: does the test fail if production is replaced with a stub returning the expected value verbatim? If yes, the tests were fudged.
 
-### System stories — solo impl plus adversarial test-coverage
+### System stories: solo impl plus adversarial test-coverage
 
 For refactor / infrastructure tickets whose ACs reference impl shape directly ("no synthetic-key path in `BallReconciler`," "`current_ball_changed` keeps Court's ref fresh"):
 
@@ -53,7 +53,7 @@ For refactor / infrastructure tickets whose ACs reference impl shape directly ("
 2. **Reviewer (test-coverage)** runs the tautology check post-PR: stub the production code to return the test's expected value and confirm the test fails. If it doesn't, block.
 3. The reviewer's adversarial check replaces the cognitive separation a blind test-author would have provided.
 
-### Bugs — test-from-repro plus impl
+### Bugs: test-from-repro plus impl
 
 For bug reports where the steps-to-reproduce already define the failing case:
 

--- a/ai/skills/gru/dispatch.md
+++ b/ai/skills/gru/dispatch.md
@@ -35,7 +35,11 @@ Every Agent call uses `run_in_background: true`. Coordinate multiple background 
 
 ## Paired dispatch
 
-Pair specialists when a hook or gate forces their outputs into one commit (failing tests + impl, scene + script). Otherwise dispatch independent. Paired dispatch costs parallelism on that pair; default to independent.
+Pair every code dispatch by default. Lefthook runs `ggut` on commit; failing tests block the commit. That gate forces failing tests + impl into the same commit on every code change, not edge cases. So the pair is the default shape: test-author writes failing tests first; impl makes them pass; one commit, ggut green by construction.
+
+Solo only when explicitly justified: doc-only fix, test-only refactor, scene-only restructure with no script edits. Flag the deviation when going solo.
+
+The cost is parallelism between the pair. The benefit is fewer re-review rounds: PR #506 / SH-288 dispatched solo three times in a row and Maggie blocked on coverage gaps each time. Net rounds went up.
 
 ## Reviewer dispatch
 

--- a/ai/skills/gru/dispatch.md
+++ b/ai/skills/gru/dispatch.md
@@ -35,11 +35,17 @@ Every Agent call uses `run_in_background: true`. Coordinate multiple background 
 
 ## Paired dispatch
 
-Pair every code dispatch by default. Lefthook runs `ggut` on commit; failing tests block the commit. That gate forces failing tests + impl into the same commit on every code change, not edge cases. So the pair is the default shape: test-author writes failing tests first; impl makes them pass; one commit, ggut green by construction.
+Pair every code dispatch by default with a **blind test-author handoff**. The default shape:
 
-Solo only when explicitly justified: doc-only fix, test-only refactor, scene-only restructure with no script edits. Flag the deviation when going solo.
+1. **Test-author dispatched first** to a fresh worktree. Briefed only on the issue's ACs and the player-observable behaviour. Not on the impl plan, not on how the code will look. Black-box write: given the AC, what tests prove the behaviour holds. Runs ggut to confirm tests fail. Posts `status: ready_to_pair` to the worktree's inbox file. Exits without committing.
+2. **Impl dispatched second** into the same worktree, briefed on the design and shown the failing tests. Makes them pass without weakening them. Commits both halves, pushes.
+3. **Reviewer (test-coverage)** verifies the tests aren't tautological: does the test fail if the production formula is replaced by a stub returning the test's expected value verbatim? If yes, the test is fudging.
 
-The cost is parallelism between the pair. The benefit is fewer re-review rounds: PR #506 / SH-288 dispatched solo three times in a row and Maggie blocked on coverage gaps each time. Net rounds went up.
+Why blind test-author: the cognitive separation is the point. A single dual-role agent writes tests against the impl it's about to write, so the tests assert what the impl produces (tautology) rather than what the AC requires. PR #506 / SH-288 hit this on round 5 — a test was reshaped to assert per-ball state independence (true) but didn't catch the underlying design issue Josh later named.
+
+Single dual-role is the exception: small fixes where the AC is one line and the impl is two. Anything bigger pairs.
+
+Solo (no test author at all) only when explicitly justified: doc-only fix, test-only refactor, scene-only restructure. Flag the deviation.
 
 ## Reviewer dispatch
 

--- a/ai/skills/gru/dispatch.md
+++ b/ai/skills/gru/dispatch.md
@@ -35,17 +35,35 @@ Every Agent call uses `run_in_background: true`. Coordinate multiple background 
 
 ## Paired dispatch
 
-Pair every code dispatch by default with a **blind test-author handoff**. The default shape:
+Three dispatch shapes for code work, picked by issue type. The cognitive separation between test and impl is the point; pick the shape that achieves it for the kind of issue at hand.
 
-1. **Test-author dispatched first** to a fresh worktree. Briefed only on the issue's ACs and the player-observable behaviour. Not on the impl plan, not on how the code will look. Black-box write: given the AC, what tests prove the behaviour holds. Runs ggut to confirm tests fail. Posts `status: ready_to_pair` to the worktree's inbox file. Exits without committing.
+### User stories — blind test-author handoff
+
+For tickets with player-observable ACs ("ball appears on rack after buy," "drag from court back to rack works mid-rally"):
+
+1. **Test-author dispatched first** to a fresh worktree. Briefed only on the AC and player-observable behaviour. Not on the impl plan, not on the design doc, not on how the code will look. Black-box write: given the AC, what tests prove the behaviour holds. Runs ggut to confirm tests fail. Posts `status: ready_to_pair` to the worktree's inbox file. Exits without committing.
 2. **Impl dispatched second** into the same worktree, briefed on the design and shown the failing tests. Makes them pass without weakening them. Commits both halves, pushes.
-3. **Reviewer (test-coverage)** verifies the tests aren't tautological: does the test fail if the production formula is replaced by a stub returning the test's expected value verbatim? If yes, the test is fudging.
+3. **Reviewer (test-coverage)** verifies the tests aren't tautological: does the test fail if production is replaced with a stub returning the expected value verbatim? If yes, the tests were fudged.
 
-Why blind test-author: the cognitive separation is the point. A single dual-role agent writes tests against the impl it's about to write, so the tests assert what the impl produces (tautology) rather than what the AC requires. PR #506 / SH-288 hit this on round 5 — a test was reshaped to assert per-ball state independence (true) but didn't catch the underlying design issue Josh later named.
+### System stories — solo impl plus adversarial test-coverage
 
-Single dual-role is the exception: small fixes where the AC is one line and the impl is two. Anything bigger pairs.
+For refactor / infrastructure tickets whose ACs reference impl shape directly ("no synthetic-key path in `BallReconciler`," "`current_ball_changed` keeps Court's ref fresh"):
 
-Solo (no test author at all) only when explicitly justified: doc-only fix, test-only refactor, scene-only restructure. Flag the deviation.
+1. **Single impl dispatched** with both responsibilities (test + code). The AC is impl-shaped; a "blind" test-author can't avoid the impl because the impl IS the AC.
+2. **Reviewer (test-coverage)** runs the tautology check post-PR: stub the production code to return the test's expected value and confirm the test fails. If it doesn't, block.
+3. The reviewer's adversarial check replaces the cognitive separation a blind test-author would have provided.
+
+### Bugs — test-from-repro plus impl
+
+For bug reports where the steps-to-reproduce already define the failing case:
+
+1. **Single impl** writes a failing test that reproduces the bug (the steps-to-reproduce are the test brief), then writes the fix that makes the test pass.
+2. **Reviewer (test-coverage)** confirms the test fails on `main` and passes with the fix.
+3. Bias risk is lower because the failing case was observed by Josh, not invented by the agent.
+
+### Solo (no pair)
+
+Doc-only fix, test-only refactor, scene-only restructure with no script edits. Flag the deviation.
 
 ## Reviewer dispatch
 

--- a/ai/skills/minions/commits.md
+++ b/ai/skills/minions/commits.md
@@ -38,9 +38,9 @@ Let lefthook fire on commit. Do not run `lefthook run pre-commit` by hand. If a 
 
 ## ggut runtime expectations
 
-The full GUT suite runs under a few seconds. Post-Vector-Squared budget is a hard 2 seconds, with a CI gate enforcing it. Never set multi-minute Bash timeouts on a `ggut` invocation; if the suite isn't done in 5-10 seconds something is wrong (test hang, init-order deadlock, infinite loop in production). Investigate the hang, don't extend the timeout. If the test count makes you suspicious, recall: 488 tests in under 2s is the post-rework normal.
+The full GUT suite runs under a few seconds. Post-Vector-Squared budget is a hard 2 seconds, with a CI gate enforcing it. Never set multi-minute Bash timeouts on a `ggut` invocation; if the suite isn't done in 5 seconds something is wrong (test hang, init-order deadlock, infinite loop in production). Investigate the hang, don't extend the timeout. If the test count makes you suspicious, recall: 488 tests in under 2s is the post-rework normal.
 
-Don't background `ggut` to a poll-loop watching a file you didn't write. Run it foreground with a 30s timeout cap: `timeout 30 godot --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests -gexit 2>&1 | tail -50`. If it hits the timeout, that's a real hang, not a slow suite.
+Don't background `ggut` to a poll-loop watching a file you didn't write. Run it foreground with a hard 5s cap: `timeout 5 godot --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests -gexit 2>&1 | tail -50`. If it hits the timeout, that's a real hang, not a slow suite.
 
 ## Push and merge
 

--- a/ai/skills/minions/commits.md
+++ b/ai/skills/minions/commits.md
@@ -36,6 +36,12 @@ For breaking changes (save wipes, API renames, workflow-input shifts), use `feat
 
 Let lefthook fire on commit. Do not run `lefthook run pre-commit` by hand. If a hook fails, fix the underlying issue and create a new commit; do not amend, do not `--no-verify`.
 
+## ggut runtime expectations
+
+The full GUT suite runs under a few seconds. Post-Vector-Squared budget is a hard 2 seconds, with a CI gate enforcing it. Never set multi-minute Bash timeouts on a `ggut` invocation; if the suite isn't done in 5-10 seconds something is wrong (test hang, init-order deadlock, infinite loop in production). Investigate the hang, don't extend the timeout. If the test count makes you suspicious, recall: 488 tests in under 2s is the post-rework normal.
+
+Don't background `ggut` to a poll-loop watching a file you didn't write. Run it foreground with a 30s timeout cap: `timeout 30 godot --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests -gexit 2>&1 | tail -50`. If it hits the timeout, that's a real hang, not a slow suite.
+
 ## Push and merge
 
 Push the branch with `-u` on first push. Open the challenge ready-for-review (not draft) unless more commits are coming. After `gh pr create`, queue auto-merge with `gh pr merge <n> --auto`. The `gh` command names stay literal; the noun for the work in flight is "challenge."


### PR DESCRIPTION
The paired-dispatch memory was framed as "pair when a hook forces outputs together," and Gru read that as "pair on edge cases." Wrong reading: lefthook runs ggut on every code commit, so the gate fires every commit, so the pair is the default shape.

PR #506 / SH-288 dispatched solo three times in a row and Maggie blocked on coverage gaps each time. Net rounds went up, not down. Flipping the skill to pair-by-default; solo only when explicitly justified.