### PR TITLE
SH-287 drag drops validated by body projection

### DIFF
--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -124,6 +124,7 @@ The Active table on `origin/main` is the source of truth. A fresh worktree reads
 | Feldspar | SH-107 | sh-107-court-bounds-and-miss | designs/01-prototype/08-court-bounds.md | 2026-04-21 | spike: bounds, miss, rest, upgrade path |
 | Ford | SH-169 | sh-169-prefix-pr-comments-with-commenter-name | ai/PARALLEL.md, ai/swarm/README.md, scripts/swarm/post-review.sh | 2026-04-21 | commenter-name prefix on PR comments |
 | Slartibartfast | SH-100 | feature/sh-100-shop-arrivals-inactive | tests/integration/test_shop_arrivals_inactive.gd, ai/PARALLEL.md | 2026-04-23 | shop arrivals land inactive on rack |
+| Manny | SH-287 | feature/sh-287-drag-drops-validated-by-body-projection | scripts/items/{ball_drag_controller,item_definition,drop_target}.gd, scripts/items/drop_targets/*.gd, scripts/shop/{shop,shop_item}.gd, resources/items/{base_ball,training_ball}.tres, tests/unit/items/test_drop_targets.gd, tests/unit/items/test_ball_drag_controller_sh287.gd, tests/integration/test_shop_drag_drop.gd | 2026-04-28 | DropTarget interface + body-projection refactor; SH-320 closed |
 
 ## Done (recent)
 
@@ -143,6 +144,7 @@ The Active table on `origin/main` is the source of truth. A fresh worktree reads
 Newest at top. One line per event.
 
 ```
+[SH-287] manny: claimed; DropTarget interface + CourtDropTarget body projection + RackDropTarget + ShopDropTarget + VenueDropTarget; expansion-ring fallback wired; ItemDefinition.at_rest_shape authored on base_ball/training_ball; SH-320 covered by spawn_purchased_at hand-off
 [SH-100] slartibartfast: claimed; SH-96 activate/deactivate and SH-99 rack display already land the behavior, adding integration tests to pin shop->rack and dev-panel purchase flows
 [SH-80] glottis: claimed; drafting tech-pipeline.md partner doc to the bible
 [SH-88] Riebeck: claim; drafting ball speed tier design doc

--- a/resources/items/base_ball.tres
+++ b/resources/items/base_ball.tres
@@ -23,6 +23,9 @@ trigger = SubResource("trigger_1")
 outcomes = Array[ExtResource("4_outcome")]([SubResource("outcome_1")])
 max_active_level = null
 
+[sub_resource type="CircleShape2D" id="at_rest_shape_1"]
+radius = 7.2
+
 [resource]
 script = ExtResource("1_item")
 key = "base_ball"
@@ -35,3 +38,4 @@ base_cost = 40
 max_level = 10
 effects = Array[ExtResource("2_effect")]([SubResource("effect_1")])
 purchasable = false
+at_rest_shape = SubResource("at_rest_shape_1")

--- a/resources/items/training_ball.tres
+++ b/resources/items/training_ball.tres
@@ -23,6 +23,9 @@ trigger = SubResource("trigger_1")
 outcomes = Array[ExtResource("4_outcome")]([SubResource("outcome_1")])
 max_active_level = null
 
+[sub_resource type="CircleShape2D" id="at_rest_shape_1"]
+radius = 7.2
+
 [resource]
 script = ExtResource("1_item")
 key = "training_ball"
@@ -34,3 +37,4 @@ descriptions = Array[String](["Already moving", "Starts fast. Stays fast", "Neve
 base_cost = 40
 max_level = 10
 effects = Array[ExtResource("2_effect")]([SubResource("effect_1")])
+at_rest_shape = SubResource("at_rest_shape_1")

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -76,10 +76,10 @@ var _held_preserved_speed: float = PRESERVED_SPEED_NONE
 ## (i.e. mouse-up with strict projection failing). Negative means not yet timing.
 var _expansion_started_at: float = -1.0
 
-var _drop_targets: Array = []
+var _drop_targets: Array[DropTarget] = []
 ## Targets the controller authored from its own exports; rebuilt on `_ready` and not
 ## removed by the public `unregister_target` API.
-var _builtin_targets: Array = []
+var _builtin_targets: Array[DropTarget] = []
 
 
 func configure(
@@ -180,7 +180,7 @@ func unregister_target(target: DropTarget) -> void:
 	_drop_targets.erase(target)
 
 
-func get_registered_targets() -> Array:
+func get_registered_targets() -> Array[DropTarget]:
 	return _drop_targets.duplicate()
 
 
@@ -325,10 +325,9 @@ func _apply_preserved_speed_after_accept(item_key: String) -> void:
 ## Returns the first registered target whose `can_accept` succeeds, or null. Targets are
 ## polled in registration order; built-ins register in priority order (court before venue).
 func _find_accepting_target(item_key: String, position: Vector2, scale_factor: float) -> DropTarget:
-	for target in _drop_targets:
-		var dt: DropTarget = target
-		if dt.can_accept(item_key, position, scale_factor):
-			return dt
+	for target: DropTarget in _drop_targets:
+		if target.can_accept(item_key, position, scale_factor):
+			return target
 	return null
 
 

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -234,19 +234,21 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 
 
 ## Shop-purchase entry: the shop just took payment for `item_key` and wants the new ball
-## to spawn on the court at `position` (SH-320). Runs the standard target poll; if a
+## to spawn on the court at `world_position` (SH-320). Runs the standard target poll; if a
 ## court/venue target accepts, the ball spawns and we return true. Otherwise the item
 ## stays a rack-only token (the rack regrows it via `_on_court_changed` defaults).
-func spawn_purchased_at(item_key: String, position: Vector2, gesture_velocity: Vector2) -> bool:
+func spawn_purchased_at(
+	item_key: String, world_position: Vector2, gesture_velocity: Vector2
+) -> bool:
 	# No venue clamp here: the shop has already paid for the item, and a release outside
 	# the venue means the rack should take the new token. Returning false lets the caller
 	# fall back to its own rack/no-court path.
-	var target: DropTarget = _find_accepting_target(item_key, position, 1.0)
+	var target: DropTarget = _find_accepting_target(item_key, world_position, 1.0)
 	if target == null:
 		return false
 	if not (target is CourtDropTarget or target is VenueDropTarget):
 		return false
-	target.accept(item_key, position, gesture_velocity)
+	target.accept(item_key, world_position, gesture_velocity)
 	return true
 
 
@@ -324,18 +326,20 @@ func _apply_preserved_speed_after_accept(item_key: String) -> void:
 
 ## Returns the first registered target whose `can_accept` succeeds, or null. Targets are
 ## polled in registration order; built-ins register in priority order (court before venue).
-func _find_accepting_target(item_key: String, position: Vector2, scale_factor: float) -> DropTarget:
+func _find_accepting_target(
+	item_key: String, world_position: Vector2, scale_factor: float
+) -> DropTarget:
 	for target: DropTarget in _drop_targets:
-		if target.can_accept(item_key, position, scale_factor):
+		if target.can_accept(item_key, world_position, scale_factor):
 			return target
 	return null
 
 
 ## Hover-feedback bump applied to the held token while a target accepts the current pos.
-func _update_hover_feedback(position: Vector2) -> void:
+func _update_hover_feedback(world_position: Vector2) -> void:
 	if _held_token == null:
 		return
-	var hovering: bool = _find_accepting_target(_held_key, position, 1.0) != null
+	var hovering: bool = _find_accepting_target(_held_key, world_position, 1.0) != null
 	var definition: ItemDefinition = _get_item_definition(_held_key)
 	var base_scale: Vector2 = definition.token_scale if definition != null else Vector2.ONE
 	if hovering:
@@ -348,7 +352,7 @@ func _update_hover_feedback(position: Vector2) -> void:
 
 ## After mouse-up: maintain the expansion-ring timer. Cancels back to source if the
 ## widened poll has also failed for the same hold window.
-func _update_expansion_state(position: Vector2) -> void:
+func _update_expansion_state(world_position: Vector2) -> void:
 	if _held_token == null:
 		return
 	if _expansion_started_at < 0.0:
@@ -362,11 +366,13 @@ func _update_expansion_state(position: Vector2) -> void:
 	# Strict pass already ran in attempt_release; try the widened pass now. If it succeeds,
 	# attempt_release picks it up next frame. If the widened pass has also been failing for
 	# another full hold window, cancel back to source.
-	var widened: DropTarget = _find_accepting_target(_held_key, position, EXPANSION_RING_SCALE)
+	var widened: DropTarget = _find_accepting_target(
+		_held_key, world_position, EXPANSION_RING_SCALE
+	)
 	if widened != null:
 		# attempt_release on the next frame will use the widened scale because the timer
 		# crossed the threshold; re-running it now lets us commit immediately.
-		attempt_release(position)
+		attempt_release(world_position)
 		return
 
 	if held_duration >= EXPANSION_RING_HOLD_S * 2.0:

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -30,8 +30,7 @@ var _held_key: String = ""
 var _held_is_temporary: bool = false
 ## Was the item on-court before the gesture? Rack pickups defer activation, so a click-without-movement is a no-op.
 var _held_was_on_court: bool = false
-## Origin tag for the current gesture: &"rack" (default), &"live" (mid-rally grab).
-## Drives the SH-252 click-without-movement no-op gate (rack-only) and future hooks.
+## &"rack" or &"live"; rack origins gate the SH-252 click-without-movement no-op.
 var _held_origin: StringName = &"rack"
 var _cursor_samples: Array = []
 ## Cursor position when the held token spawned; gates the SH-252 a click-without-movement no-op.
@@ -39,16 +38,13 @@ var _press_position: Vector2 = Vector2.ZERO
 var _gesture_below_threshold: bool = true
 ## SH-287: tracks mouse-button state so _process can poll for valid targets when mouse is up.
 var _mouse_button_down: bool = false
-## SH-288: friendship energy captured at mid-rally grab; forwarded to bring_into_play so the
-## released ball inherits the rally speed. Negative means no preserved energy.
+## Mid-rally rally speed inherited by the released ball; negative means none preserved.
 var _held_preserved_speed: float = PRESERVED_SPEED_NONE
-## SH-287: monotonic time in seconds when the controller began trying expansion-ring polling
-## (i.e. mouse-up with strict projection failing). Negative means not yet timing.
+## Monotonic seconds when expansion-ring polling started; negative means not yet timing.
 var _expansion_started_at: float = -1.0
 
 var _drop_targets: Array[DropTarget] = []
-## Targets the controller authored from its own exports; rebuilt on `_ready` and not
-## removed by the public `unregister_target` API.
+## Built-ins are rebuilt on `_ready` and ignored by `unregister_target`.
 var _builtin_targets: Array[DropTarget] = []
 
 
@@ -68,8 +64,7 @@ func _ready() -> void:
 	if _item_manager == null:
 		_item_manager = ItemManager
 
-	# Group lookup so Shop (and any future origin) can hand presses to the controller
-	# without an explicit NodePath in court.tscn.
+	# Group lookup so Shop can hand presses to the controller without a NodePath.
 	add_to_group(&"drag_controller")
 
 	if rack != null and not rack.slot_pressed.is_connected(_on_rack_slot_pressed):
@@ -96,8 +91,6 @@ func _process(_delta: float) -> void:
 		if follow_position.distance_to(_press_position) >= COMMIT_MOVEMENT_THRESHOLD_PX:
 			_gesture_below_threshold = false
 
-	# SH-287: when mouse is up and the held position is over a valid target, commit.
-	# Otherwise keep the held token following the cursor and update hover feedback.
 	if not _mouse_button_down:
 		if not attempt_release(follow_position):
 			_update_expansion_state(follow_position)
@@ -217,8 +210,7 @@ func spawn_purchased_at(
 	return true
 
 
-## Try to commit the held gesture at the given position. Returns true on commit (held token
-## freed, gesture ends), false on no valid target (held token stays, gesture continues).
+## Returns false on no valid target so the held token stays with the cursor.
 func attempt_release(release_position: Vector2) -> bool:
 	if _held_token == null:
 		return false
@@ -239,8 +231,6 @@ func attempt_release(release_position: Vector2) -> bool:
 		_finalise_gesture(item_key, clamped_position, false)
 		return true
 
-	# Strict pass first; on miss the caller (process loop) decides whether to start the
-	# expansion-ring timer.
 	var target: DropTarget = _find_accepting_target(item_key, clamped_position, 1.0)
 	if target == null and _expansion_started_at >= 0.0:
 		var held_duration: float = _now_seconds() - _expansion_started_at
@@ -282,8 +272,7 @@ func _apply_preserved_speed_after_accept(item_key: String) -> void:
 		ball.linear_velocity = ball.linear_velocity.normalized() * _held_preserved_speed
 
 
-## Returns the first registered target whose `can_accept` succeeds, or null. Targets are
-## polled in registration order; built-ins register in priority order (court before venue).
+## Polled in registration order; built-ins register court before venue.
 func _find_accepting_target(
 	item_key: String, world_position: Vector2, scale_factor: float
 ) -> DropTarget:
@@ -308,8 +297,7 @@ func _update_hover_feedback(world_position: Vector2) -> void:
 		_held_token.modulate = NEUTRAL_MODULATE
 
 
-## After mouse-up: maintain the expansion-ring timer. Cancels back to source if the
-## widened poll has also failed for the same hold window.
+## Cancels back to source after the widened poll has also failed for one full hold window.
 func _update_expansion_state(world_position: Vector2) -> void:
 	if _held_token == null:
 		return
@@ -321,15 +309,11 @@ func _update_expansion_state(world_position: Vector2) -> void:
 	if held_duration < expansion_ring_hold_s:
 		return
 
-	# Strict pass already ran in attempt_release; try the widened pass now. If it succeeds,
-	# attempt_release picks it up next frame. If the widened pass has also been failing for
-	# another full hold window, cancel back to source.
 	var widened: DropTarget = _find_accepting_target(
 		_held_key, world_position, expansion_ring_scale
 	)
 	if widened != null:
-		# attempt_release on the next frame will use the widened scale because the timer
-		# crossed the threshold; re-running it now lets us commit immediately.
+		# Re-run now so the commit lands this frame instead of waiting for the next attempt_release.
 		attempt_release(world_position)
 		return
 
@@ -337,8 +321,7 @@ func _update_expansion_state(world_position: Vector2) -> void:
 		_cancel_to_source()
 
 
-## Two-window expansion fail -> cancel-to-source. Free the held token; deactivate any
-## on-court placement that a live-ball grab would have moved so the rack regrows it.
+## Live-ball grabs that cancel must deactivate the on-court placement so the rack regrows it.
 func _cancel_to_source() -> void:
 	var item_key: String = _held_key
 	var was_on_court: bool = _held_was_on_court

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -3,20 +3,48 @@ extends Node2D
 
 ## Owns the held-token visual during a ball or equipment drag gesture.
 ##
-## Press starts a hold (held token follows cursor); release commits only at a valid target.
-## No-restore principle (SH-287): mouse-up over an invalid spot does not end the gesture;
-## the held token keeps following the cursor and the controller polls per frame for a valid
-## target. The source rack is itself a target, giving the player a no-teleport escape valve.
+## SH-287 (designs/01-prototype/21-ball-dynamics.md, "Drop validation by body projection"
+## and "No restore on invalid release"; designs/01-prototype/22-equip-loop-regime.md,
+## "Failure modes"):
+##
+## * Press starts a hold (held token follows cursor).
+## * The controller polls every registered `DropTarget` each physics frame on the held
+##   token's world position; the first target whose `can_accept` returns true commits.
+## * Mouse-up over an invalid spot does not end the gesture; the held token keeps following
+##   the cursor and the controller keeps polling. The source rack/shop is itself a target,
+##   giving the player a no-teleport escape valve.
+## * Expansion-ring fallback: if strict projection fails for ~250 ms after mouse-up, retry
+##   with a 1.5x scaled shape; if that also fails, cancel the gesture back to the source.
+## * Hover feedback: the held token's modulation/scale lifts when over a valid target.
+## * Shop releases call `spawn_purchased_at` after committing the purchase, threading the
+##   new ball through the same target-poll so shop-to-court drag spawns a live ball at the
+##   release point instead of routing to the rack (SH-320).
 
 signal pickup_started(item_key: String)
 signal drop_completed(item_key: String, release_position: Vector2, over_court: bool)
+
+const CourtDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/court_drop_target.gd"
+)
+const RackDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/rack_drop_target.gd"
+)
+const VenueDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/venue_drop_target.gd"
+)
 
 const CURSOR_SAMPLE_WINDOW: float = 0.08
 const PRESERVED_SPEED_NONE: float = -1.0
 ## Minimum cursor travel before a rack-origin gesture counts as a real drag (SH-252 a).
 const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
-## SH-287 patch: probe radius for the pre-spawn body projection; slightly larger than authored ball radius.
-const COURT_BLOCKED_PROBE_RADIUS_PX: float = 14.0
+## Seconds the controller waits with the strict projection failing before widening to
+## the expansion ring. Tuned per `22-equip-loop-regime.md` "Failure modes".
+const EXPANSION_RING_HOLD_S: float = 0.25
+const EXPANSION_RING_SCALE: float = 1.5
+## Held-token visual lift when hovering a valid target.
+const HOVER_SCALE_BUMP: Vector2 = Vector2(1.08, 1.08)
+const HOVER_MODULATE: Color = Color(1.15, 1.15, 1.15, 1.0)
+const NEUTRAL_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
 
 @export var rack: RackDisplay
 @export var rack_drop_target: Area2D
@@ -32,6 +60,9 @@ var _held_key: String = ""
 var _held_is_temporary: bool = false
 ## Was the item on-court before the gesture? Rack pickups defer activation, so a click-without-movement is a no-op.
 var _held_was_on_court: bool = false
+## Origin tag for the current gesture: &"rack" (default), &"live" (mid-rally grab).
+## Drives the SH-252 click-without-movement no-op gate (rack-only) and future hooks.
+var _held_origin: StringName = &"rack"
 var _cursor_samples: Array = []
 ## Cursor position when the held token spawned; gates the SH-252 a click-without-movement no-op.
 var _press_position: Vector2 = Vector2.ZERO
@@ -39,8 +70,16 @@ var _gesture_below_threshold: bool = true
 ## SH-287: tracks mouse-button state so _process can poll for valid targets when mouse is up.
 var _mouse_button_down: bool = false
 ## SH-288: friendship energy captured at mid-rally grab; forwarded to bring_into_play so the
-## released ball inherits the rally speed. Negative means no preserved energy (rack-origin gesture).
+## released ball inherits the rally speed. Negative means no preserved energy.
 var _held_preserved_speed: float = PRESERVED_SPEED_NONE
+## SH-287: monotonic time in seconds when the controller began trying expansion-ring polling
+## (i.e. mouse-up with strict projection failing). Negative means not yet timing.
+var _expansion_started_at: float = -1.0
+
+var _drop_targets: Array = []
+## Targets the controller authored from its own exports; rebuilt on `_ready` and not
+## removed by the public `unregister_target` API.
+var _builtin_targets: Array = []
 
 
 func configure(
@@ -59,6 +98,10 @@ func _ready() -> void:
 	if _item_manager == null:
 		_item_manager = ItemManager
 
+	# Group lookup so Shop (and any future origin) can hand presses to the controller
+	# without an explicit NodePath in court.tscn.
+	add_to_group(&"drag_controller")
+
 	if rack != null and not rack.slot_pressed.is_connected(_on_rack_slot_pressed):
 		rack.slot_pressed.connect(_on_rack_slot_pressed)
 
@@ -68,6 +111,8 @@ func _ready() -> void:
 	if reconciler != null:
 		if not reconciler.ball_spawned.is_connected(_on_reconciler_ball_spawned):
 			reconciler.ball_spawned.connect(_on_reconciler_ball_spawned)
+
+	_register_builtin_targets()
 
 
 func _process(_delta: float) -> void:
@@ -82,8 +127,12 @@ func _process(_delta: float) -> void:
 			_gesture_below_threshold = false
 
 	# SH-287: when mouse is up and the held position is over a valid target, commit.
+	# Otherwise keep the held token following the cursor and update hover feedback.
 	if not _mouse_button_down:
-		attempt_release(follow_position)
+		if not attempt_release(follow_position):
+			_update_expansion_state(follow_position)
+	else:
+		_update_hover_feedback(follow_position)
 
 
 func _input(event: InputEvent) -> void:
@@ -99,7 +148,8 @@ func _input(event: InputEvent) -> void:
 		return
 
 	# Use the event's own position so a Camera2D in the venue doesn't break rack hit-testing.
-	attempt_release(_clamp_to_venue(_event_world_position(mouse_button)))
+	if not attempt_release(_clamp_to_venue(_event_world_position(mouse_button))):
+		_expansion_started_at = _now_seconds()
 
 
 func is_dragging() -> bool:
@@ -112,6 +162,26 @@ func get_held_key() -> String:
 
 func get_held_token() -> Node2D:
 	return _held_token
+
+
+## Public registration so subsystems with their own area resources (Shop) can join the
+## target poll without owning the held token.
+func register_target(target: DropTarget) -> void:
+	if target == null:
+		return
+	if _drop_targets.has(target):
+		return
+	_drop_targets.append(target)
+
+
+func unregister_target(target: DropTarget) -> void:
+	if _builtin_targets.has(target):
+		return
+	_drop_targets.erase(target)
+
+
+func get_registered_targets() -> Array:
+	return _drop_targets.duplicate()
 
 
 ## Test seam / production entry for rack-origin pickups. Activation defers to release-over-court (SH-245).
@@ -128,6 +198,7 @@ func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
 	)
 	_spawn_held_token(item_key, spawn_position, false)
 	_held_was_on_court = false
+	_held_origin = &"rack"
 	# A grab only happens on a press; assume mouse is down so polling waits for mouse-up.
 	_mouse_button_down = true
 	pickup_started.emit(item_key)
@@ -156,21 +227,38 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 
 	_spawn_held_token(item_key, spawn_position, is_temporary)
 	_held_was_on_court = not is_temporary
+	_held_origin = &"live"
 	_mouse_button_down = true
 	pickup_started.emit(item_key)
 	return true
 
 
-## Try to commit the held gesture at the given position. Returns true on commit (held token freed,
-## gesture ends), false on no valid target (held token stays, gesture continues).
+## Shop-purchase entry: the shop just took payment for `item_key` and wants the new ball
+## to spawn on the court at `position` (SH-320). Runs the standard target poll; if a
+## court/venue target accepts, the ball spawns and we return true. Otherwise the item
+## stays a rack-only token (the rack regrows it via `_on_court_changed` defaults).
+func spawn_purchased_at(item_key: String, position: Vector2, gesture_velocity: Vector2) -> bool:
+	# No venue clamp here: the shop has already paid for the item, and a release outside
+	# the venue means the rack should take the new token. Returning false lets the caller
+	# fall back to its own rack/no-court path.
+	var target: DropTarget = _find_accepting_target(item_key, position, 1.0)
+	if target == null:
+		return false
+	if not (target is CourtDropTarget or target is VenueDropTarget):
+		return false
+	target.accept(item_key, position, gesture_velocity)
+	return true
+
+
+## Try to commit the held gesture at the given position. Returns true on commit (held token
+## freed, gesture ends), false on no valid target (held token stays, gesture continues).
 func attempt_release(release_position: Vector2) -> bool:
 	if _held_token == null:
 		return false
 
 	var clamped_position: Vector2 = _clamp_to_venue(release_position)
 	var item_key: String = _held_key
-	var item_role: StringName = _get_item_role(item_key)
-	var over_rack_for_role: bool = _position_over_rack_for_role(clamped_position, item_role)
+	var was_temporary: bool = _held_is_temporary
 
 	# Direct callers bypass _process, so re-check distance here to keep the no-op gate honest.
 	var below_threshold: bool = _gesture_below_threshold
@@ -178,44 +266,129 @@ func attempt_release(release_position: Vector2) -> bool:
 		below_threshold = (
 			clamped_position.distance_to(_press_position) < COMMIT_MOVEMENT_THRESHOLD_PX
 		)
-	var was_temporary: bool = _held_is_temporary
-	var was_on_court: bool = _held_was_on_court
 
 	# SH-252 a: a press-and-release without movement on a rack-origin gesture cancels back to source.
-	if below_threshold and not was_on_court and not was_temporary:
+	if below_threshold and _held_origin == &"rack" and not _held_was_on_court and not was_temporary:
 		_finalise_gesture(item_key, clamped_position, false)
 		return true
 
-	if over_rack_for_role:
-		if not was_temporary and was_on_court and _item_manager.is_on_court(item_key):
-			_item_manager.deactivate(item_key)
-		_finalise_gesture(item_key, clamped_position, false)
-		return true
+	# Strict pass first; on miss the caller (process loop) decides whether to start the
+	# expansion-ring timer.
+	var target: DropTarget = _find_accepting_target(item_key, clamped_position, 1.0)
+	if target == null and _expansion_started_at >= 0.0:
+		var held_duration: float = _now_seconds() - _expansion_started_at
+		if held_duration >= EXPANSION_RING_HOLD_S:
+			target = _find_accepting_target(item_key, clamped_position, EXPANSION_RING_SCALE)
 
-	# Court target only accepts ball-role items at a position clear of other bodies.
-	if item_role == &"ball":
-		var court_position: Vector2 = _clamp_to_court(clamped_position)
-		if _release_position_clear(court_position):
-			var release_velocity: Vector2 = _compute_release_velocity()
-			_release_onto_court(item_key, court_position, release_velocity, was_temporary)
-			_finalise_gesture(item_key, clamped_position, true)
-			return true
+	if target == null:
+		return false
 
-	# No valid target. Held token stays following the cursor; gesture continues.
-	return false
+	if target is CourtDropTarget or target is VenueDropTarget:
+		var velocity: Vector2 = _compute_release_velocity()
+		if was_temporary:
+			# Temporary balls bypass the reconciler; calling target.accept would spawn a
+			# permanent ball through the reconciler. Drop the held token cleanly instead.
+			pass
+		else:
+			target.accept(item_key, clamped_position, velocity)
+			# Reconciler.bring_into_play takes a preserved-speed argument; the simpler
+			# route here is to re-apply it after the spawn so the target signature stays
+			# narrow.
+			_apply_preserved_speed_after_accept(item_key)
+	else:
+		target.accept(item_key, clamped_position, Vector2.ZERO)
+
+	var over_court: bool = target is CourtDropTarget or target is VenueDropTarget
+	# Suppress the over_court flag for temporary balls so downstream listeners don't double-spawn.
+	if was_temporary:
+		over_court = false
+	_finalise_gesture(item_key, clamped_position, over_court)
+	return true
 
 
-func _release_onto_court(
-	item_key: String,
-	release_position: Vector2,
-	release_velocity: Vector2,
-	is_temporary: bool,
-) -> void:
-	if is_temporary:
+## After a court/venue accept, ensure preserved rally speed lands on the spawned ball.
+## bring_into_play is what runs inside accept; this re-applies for the case where speed
+## was set after the spawn (mid-rally grab path).
+func _apply_preserved_speed_after_accept(item_key: String) -> void:
+	if _held_preserved_speed < 0.0:
 		return
 	if reconciler == null:
 		return
-	reconciler.bring_into_play(item_key, release_position, release_velocity, _held_preserved_speed)
+	var ball: Ball = reconciler.get_ball_for_key(item_key)
+	if ball == null:
+		return
+	ball.speed = _held_preserved_speed
+	if ball.linear_velocity.length() > 0.0:
+		ball.linear_velocity = ball.linear_velocity.normalized() * _held_preserved_speed
+
+
+## Returns the first registered target whose `can_accept` succeeds, or null. Targets are
+## polled in registration order; built-ins register in priority order (court before venue).
+func _find_accepting_target(item_key: String, position: Vector2, scale_factor: float) -> DropTarget:
+	for target in _drop_targets:
+		var dt: DropTarget = target
+		if dt.can_accept(item_key, position, scale_factor):
+			return dt
+	return null
+
+
+## Hover-feedback bump applied to the held token while a target accepts the current pos.
+func _update_hover_feedback(position: Vector2) -> void:
+	if _held_token == null:
+		return
+	var hovering: bool = _find_accepting_target(_held_key, position, 1.0) != null
+	var definition: ItemDefinition = _get_item_definition(_held_key)
+	var base_scale: Vector2 = definition.token_scale if definition != null else Vector2.ONE
+	if hovering:
+		_held_token.scale = base_scale * HOVER_SCALE_BUMP
+		_held_token.modulate = HOVER_MODULATE
+	else:
+		_held_token.scale = base_scale
+		_held_token.modulate = NEUTRAL_MODULATE
+
+
+## After mouse-up: maintain the expansion-ring timer. Cancels back to source if the
+## widened poll has also failed for the same hold window.
+func _update_expansion_state(position: Vector2) -> void:
+	if _held_token == null:
+		return
+	if _expansion_started_at < 0.0:
+		_expansion_started_at = _now_seconds()
+		return
+
+	var held_duration: float = _now_seconds() - _expansion_started_at
+	if held_duration < EXPANSION_RING_HOLD_S:
+		return
+
+	# Strict pass already ran in attempt_release; try the widened pass now. If it succeeds,
+	# attempt_release picks it up next frame. If the widened pass has also been failing for
+	# another full hold window, cancel back to source.
+	var widened: DropTarget = _find_accepting_target(_held_key, position, EXPANSION_RING_SCALE)
+	if widened != null:
+		# attempt_release on the next frame will use the widened scale because the timer
+		# crossed the threshold; re-running it now lets us commit immediately.
+		attempt_release(position)
+		return
+
+	if held_duration >= EXPANSION_RING_HOLD_S * 2.0:
+		_cancel_to_source()
+
+
+## Two-window expansion fail -> cancel-to-source. Free the held token; deactivate any
+## on-court placement that a live-ball grab would have moved so the rack regrows it.
+func _cancel_to_source() -> void:
+	var item_key: String = _held_key
+	var was_on_court: bool = _held_was_on_court
+	var origin: StringName = _held_origin
+	var release_position: Vector2 = (
+		_held_token.global_position if _held_token != null else _press_position
+	)
+
+	if origin == &"live" and was_on_court:
+		if _item_manager != null and _item_manager.is_on_court(item_key):
+			_item_manager.deactivate(item_key)
+
+	_finalise_gesture(item_key, release_position, false)
 
 
 ## Clear held-token state after a successful commit (rack accept or court spawn).
@@ -226,30 +399,13 @@ func _finalise_gesture(item_key: String, release_position: Vector2, over_court: 
 	_held_key = ""
 	_held_is_temporary = false
 	_held_was_on_court = false
+	_held_origin = &"rack"
 	_held_preserved_speed = PRESERVED_SPEED_NONE
 	_cursor_samples.clear()
 	_press_position = Vector2.ZERO
 	_gesture_below_threshold = true
+	_expansion_started_at = -1.0
 	drop_completed.emit(item_key, release_position, over_court)
-
-
-## SH-287 patch: pre-spawn body projection. Returns true if a ball-sized circle at the position would not overlap any physics body.
-func _release_position_clear(candidate_position: Vector2) -> bool:
-	var world: World2D = get_world_2d()
-	if world == null:
-		return true
-	var space: PhysicsDirectSpaceState2D = world.direct_space_state
-	if space == null:
-		return true
-	var shape: CircleShape2D = CircleShape2D.new()
-	shape.radius = COURT_BLOCKED_PROBE_RADIUS_PX
-	var params: PhysicsShapeQueryParameters2D = PhysicsShapeQueryParameters2D.new()
-	params.shape = shape
-	params.transform = Transform2D(0.0, candidate_position)
-	params.collide_with_bodies = true
-	params.collide_with_areas = false
-	var hits: Array = space.intersect_shape(params, 1)
-	return hits.is_empty()
 
 
 func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: bool) -> void:
@@ -270,8 +426,42 @@ func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: 
 	_held_is_temporary = is_temporary
 	_press_position = spawn_position
 	_gesture_below_threshold = true
+	_expansion_started_at = -1.0
 	_cursor_samples.clear()
 	_track_cursor_motion(spawn_position)
+
+
+## Registers the controller's authored targets in priority order: court strict projection
+## first, then the role-aware racks, then the venue catch-all. Subsystems with their own
+## area resources (Shop) `register_target` after `_ready`.
+func _register_builtin_targets() -> void:
+	_drop_targets.clear()
+	_builtin_targets.clear()
+
+	if reconciler != null:
+		var court_target: CourtDropTarget = CourtDropTargetScript.new()
+		var world: World2D = get_world_2d()
+		court_target.configure(_item_manager, reconciler, world, court_bounds)
+		_drop_targets.append(court_target)
+		_builtin_targets.append(court_target)
+
+	if rack_drop_target != null:
+		var ball_rack_target: RackDropTarget = RackDropTargetScript.new()
+		ball_rack_target.configure(_item_manager, rack_drop_target, &"ball")
+		_drop_targets.append(ball_rack_target)
+		_builtin_targets.append(ball_rack_target)
+
+	if gear_rack_drop_target != null:
+		var gear_rack_target: RackDropTarget = RackDropTargetScript.new()
+		gear_rack_target.configure(_item_manager, gear_rack_drop_target, &"equipment")
+		_drop_targets.append(gear_rack_target)
+		_builtin_targets.append(gear_rack_target)
+
+	if reconciler != null:
+		var venue_target: VenueDropTarget = VenueDropTargetScript.new()
+		venue_target.configure(_item_manager, reconciler, venue_bounds, court_bounds)
+		_drop_targets.append(venue_target)
+		_builtin_targets.append(venue_target)
 
 
 ## Records cursor positions across a short rolling window so release velocity can be derived from recent motion.
@@ -316,29 +506,6 @@ func _event_world_position(event: InputEventMouseButton) -> Vector2:
 	return canvas_transform.affine_inverse() * event.position
 
 
-## Returns true if the position is over a rack whose role accepts the held item's role.
-func _position_over_rack_for_role(world_position: Vector2, item_role: StringName) -> bool:
-	if item_role == &"ball" and _position_over_area(world_position, rack_drop_target):
-		return true
-	if item_role != &"ball" and _position_over_area(world_position, gear_rack_drop_target):
-		return true
-	return false
-
-
-func _position_over_area(world_position: Vector2, area: Area2D) -> bool:
-	if area == null:
-		return false
-	var shape_owner: CollisionShape2D = _first_collision_shape(area)
-	if shape_owner == null:
-		return false
-	var rect: Rect2 = _world_rect_for_shape(area, shape_owner)
-	return rect.has_point(world_position)
-
-
-func _clamp_to_court(world_position: Vector2) -> Vector2:
-	return _clamp_to_rect(world_position, court_bounds)
-
-
 func _clamp_to_venue(world_position: Vector2) -> Vector2:
 	return _clamp_to_rect(world_position, venue_bounds)
 
@@ -352,22 +519,6 @@ func _clamp_to_rect(world_position: Vector2, bounds: Rect2) -> Vector2:
 	)
 
 
-func _first_collision_shape(area: Area2D) -> CollisionShape2D:
-	for child in area.get_children():
-		if child is CollisionShape2D:
-			return child
-	return null
-
-
-func _world_rect_for_shape(area: Area2D, shape_node: CollisionShape2D) -> Rect2:
-	var rectangle: RectangleShape2D = shape_node.shape as RectangleShape2D
-	if rectangle == null:
-		return Rect2()
-	var half_extents: Vector2 = rectangle.size * 0.5
-	var center: Vector2 = area.global_position + shape_node.position
-	return Rect2(center - half_extents, rectangle.size)
-
-
 func _get_item_definition(item_key: String) -> ItemDefinition:
 	for item: ItemDefinition in _item_manager.items:
 		if item.key == item_key:
@@ -375,11 +526,8 @@ func _get_item_definition(item_key: String) -> ItemDefinition:
 	return null
 
 
-func _get_item_role(item_key: String) -> StringName:
-	var definition: ItemDefinition = _get_item_definition(item_key)
-	if definition == null:
-		return &"ball"
-	return definition.role
+func _now_seconds() -> float:
+	return float(Time.get_ticks_msec()) / 1000.0
 
 
 func _on_rack_slot_pressed(item_key: String, press_position: Vector2) -> void:

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -23,16 +23,6 @@ extends Node2D
 signal pickup_started(item_key: String)
 signal drop_completed(item_key: String, release_position: Vector2, over_court: bool)
 
-const CourtDropTargetScript: GDScript = preload(
-	"res://scripts/items/drop_targets/court_drop_target.gd"
-)
-const RackDropTargetScript: GDScript = preload(
-	"res://scripts/items/drop_targets/rack_drop_target.gd"
-)
-const VenueDropTargetScript: GDScript = preload(
-	"res://scripts/items/drop_targets/venue_drop_target.gd"
-)
-
 const CURSOR_SAMPLE_WINDOW: float = 0.08
 const PRESERVED_SPEED_NONE: float = -1.0
 ## Minimum cursor travel before a rack-origin gesture counts as a real drag (SH-252 a).
@@ -444,26 +434,26 @@ func _register_builtin_targets() -> void:
 	_builtin_targets.clear()
 
 	if reconciler != null:
-		var court_target: CourtDropTarget = CourtDropTargetScript.new()
+		var court_target: CourtDropTarget = CourtDropTarget.new()
 		var world: World2D = get_world_2d()
 		court_target.configure(_item_manager, reconciler, world, court_bounds)
 		_drop_targets.append(court_target)
 		_builtin_targets.append(court_target)
 
 	if rack_drop_target != null:
-		var ball_rack_target: RackDropTarget = RackDropTargetScript.new()
+		var ball_rack_target: RackDropTarget = RackDropTarget.new()
 		ball_rack_target.configure(_item_manager, rack_drop_target, &"ball")
 		_drop_targets.append(ball_rack_target)
 		_builtin_targets.append(ball_rack_target)
 
 	if gear_rack_drop_target != null:
-		var gear_rack_target: RackDropTarget = RackDropTargetScript.new()
+		var gear_rack_target: RackDropTarget = RackDropTarget.new()
 		gear_rack_target.configure(_item_manager, gear_rack_drop_target, &"equipment")
 		_drop_targets.append(gear_rack_target)
 		_builtin_targets.append(gear_rack_target)
 
 	if reconciler != null:
-		var venue_target: VenueDropTarget = VenueDropTargetScript.new()
+		var venue_target: VenueDropTarget = VenueDropTarget.new()
 		venue_target.configure(_item_manager, reconciler, venue_bounds, court_bounds)
 		_drop_targets.append(venue_target)
 		_builtin_targets.append(venue_target)
@@ -512,16 +502,7 @@ func _event_world_position(event: InputEventMouseButton) -> Vector2:
 
 
 func _clamp_to_venue(world_position: Vector2) -> Vector2:
-	return _clamp_to_rect(world_position, venue_bounds)
-
-
-func _clamp_to_rect(world_position: Vector2, bounds: Rect2) -> Vector2:
-	if bounds.size == Vector2.ZERO:
-		return world_position
-	return Vector2(
-		clampf(world_position.x, bounds.position.x, bounds.position.x + bounds.size.x),
-		clampf(world_position.y, bounds.position.y, bounds.position.y + bounds.size.y),
-	)
+	return DropTarget.clamp_to_rect(world_position, venue_bounds)
 
 
 func _get_item_definition(item_key: String) -> ItemDefinition:

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -1,24 +1,7 @@
 class_name BallDragController
 extends Node2D
 
-## Owns the held-token visual during a ball or equipment drag gesture.
-##
-## SH-287 (designs/01-prototype/21-ball-dynamics.md, "Drop validation by body projection"
-## and "No restore on invalid release"; designs/01-prototype/22-equip-loop-regime.md,
-## "Failure modes"):
-##
-## * Press starts a hold (held token follows cursor).
-## * The controller polls every registered `DropTarget` each physics frame on the held
-##   token's world position; the first target whose `can_accept` returns true commits.
-## * Mouse-up over an invalid spot does not end the gesture; the held token keeps following
-##   the cursor and the controller keeps polling. The source rack/shop is itself a target,
-##   giving the player a no-teleport escape valve.
-## * Expansion-ring fallback: if strict projection fails for ~250 ms after mouse-up, retry
-##   with a 1.5x scaled shape; if that also fails, cancel the gesture back to the source.
-## * Hover feedback: the held token's modulation/scale lifts when over a valid target.
-## * Shop releases call `spawn_purchased_at` after committing the purchase, threading the
-##   new ball through the same target-poll so shop-to-court drag spawns a live ball at the
-##   release point instead of routing to the rack (SH-320).
+## Owns the held-token visual during a ball or equipment drag gesture and polls every registered DropTarget for a valid commit.
 
 signal pickup_started(item_key: String)
 signal drop_completed(item_key: String, release_position: Vector2, over_court: bool)
@@ -27,11 +10,6 @@ const CURSOR_SAMPLE_WINDOW: float = 0.08
 const PRESERVED_SPEED_NONE: float = -1.0
 ## Minimum cursor travel before a rack-origin gesture counts as a real drag (SH-252 a).
 const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
-## Seconds the controller waits with the strict projection failing before widening to
-## the expansion ring. Tuned per `22-equip-loop-regime.md` "Failure modes".
-const EXPANSION_RING_HOLD_S: float = 0.25
-const EXPANSION_RING_SCALE: float = 1.5
-## Held-token visual lift when hovering a valid target.
 const HOVER_SCALE_BUMP: Vector2 = Vector2(1.08, 1.08)
 const HOVER_MODULATE: Color = Color(1.15, 1.15, 1.15, 1.0)
 const NEUTRAL_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
@@ -43,6 +21,8 @@ const NEUTRAL_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
 @export var court_bounds: Rect2 = Rect2()
 @export var venue_bounds: Rect2 = Rect2()
 @export var reconciler: BallReconciler
+@export var expansion_ring_hold_s: float = 0.25
+@export var expansion_ring_scale: float = 1.5
 
 var _item_manager: Node
 var _held_token: Node2D = null
@@ -223,16 +203,11 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 	return true
 
 
-## Shop-purchase entry: the shop just took payment for `item_key` and wants the new ball
-## to spawn on the court at `world_position` (SH-320). Runs the standard target poll; if a
-## court/venue target accepts, the ball spawns and we return true. Otherwise the item
-## stays a rack-only token (the rack regrows it via `_on_court_changed` defaults).
+## Shop-purchase entry: returns true if a court/venue target accepted; false routes the new token to the rack.
 func spawn_purchased_at(
 	item_key: String, world_position: Vector2, gesture_velocity: Vector2
 ) -> bool:
-	# No venue clamp here: the shop has already paid for the item, and a release outside
-	# the venue means the rack should take the new token. Returning false lets the caller
-	# fall back to its own rack/no-court path.
+	# No venue clamp: a release outside the venue should fall through to the rack.
 	var target: DropTarget = _find_accepting_target(item_key, world_position, 1.0)
 	if target == null:
 		return false
@@ -269,8 +244,8 @@ func attempt_release(release_position: Vector2) -> bool:
 	var target: DropTarget = _find_accepting_target(item_key, clamped_position, 1.0)
 	if target == null and _expansion_started_at >= 0.0:
 		var held_duration: float = _now_seconds() - _expansion_started_at
-		if held_duration >= EXPANSION_RING_HOLD_S:
-			target = _find_accepting_target(item_key, clamped_position, EXPANSION_RING_SCALE)
+		if held_duration >= expansion_ring_hold_s:
+			target = _find_accepting_target(item_key, clamped_position, expansion_ring_scale)
 
 	if target == null:
 		return false
@@ -278,29 +253,22 @@ func attempt_release(release_position: Vector2) -> bool:
 	if target is CourtDropTarget or target is VenueDropTarget:
 		var velocity: Vector2 = _compute_release_velocity()
 		if was_temporary:
-			# Temporary balls bypass the reconciler; calling target.accept would spawn a
-			# permanent ball through the reconciler. Drop the held token cleanly instead.
+			# Temporary balls bypass the reconciler so they don't survive the gesture.
 			pass
 		else:
 			target.accept(item_key, clamped_position, velocity)
-			# Reconciler.bring_into_play takes a preserved-speed argument; the simpler
-			# route here is to re-apply it after the spawn so the target signature stays
-			# narrow.
 			_apply_preserved_speed_after_accept(item_key)
 	else:
 		target.accept(item_key, clamped_position, Vector2.ZERO)
 
 	var over_court: bool = target is CourtDropTarget or target is VenueDropTarget
-	# Suppress the over_court flag for temporary balls so downstream listeners don't double-spawn.
 	if was_temporary:
 		over_court = false
 	_finalise_gesture(item_key, clamped_position, over_court)
 	return true
 
 
-## After a court/venue accept, ensure preserved rally speed lands on the spawned ball.
-## bring_into_play is what runs inside accept; this re-applies for the case where speed
-## was set after the spawn (mid-rally grab path).
+## Re-applies mid-rally preserved speed to the freshly spawned ball after a court/venue accept.
 func _apply_preserved_speed_after_accept(item_key: String) -> void:
 	if _held_preserved_speed < 0.0:
 		return
@@ -350,14 +318,14 @@ func _update_expansion_state(world_position: Vector2) -> void:
 		return
 
 	var held_duration: float = _now_seconds() - _expansion_started_at
-	if held_duration < EXPANSION_RING_HOLD_S:
+	if held_duration < expansion_ring_hold_s:
 		return
 
 	# Strict pass already ran in attempt_release; try the widened pass now. If it succeeds,
 	# attempt_release picks it up next frame. If the widened pass has also been failing for
 	# another full hold window, cancel back to source.
 	var widened: DropTarget = _find_accepting_target(
-		_held_key, world_position, EXPANSION_RING_SCALE
+		_held_key, world_position, expansion_ring_scale
 	)
 	if widened != null:
 		# attempt_release on the next frame will use the widened scale because the timer
@@ -365,7 +333,7 @@ func _update_expansion_state(world_position: Vector2) -> void:
 		attempt_release(world_position)
 		return
 
-	if held_duration >= EXPANSION_RING_HOLD_S * 2.0:
+	if held_duration >= expansion_ring_hold_s * 2.0:
 		_cancel_to_source()
 
 
@@ -426,37 +394,45 @@ func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: 
 	_track_cursor_motion(spawn_position)
 
 
-## Registers the controller's authored targets in priority order: court strict projection
-## first, then the role-aware racks, then the venue catch-all. Subsystems with their own
-## area resources (Shop) `register_target` after `_ready`.
+## Registers the controller's authored targets in priority order: court strict projection first, role-aware racks, venue catch-all.
 func _register_builtin_targets() -> void:
 	_drop_targets.clear()
 	_builtin_targets.clear()
 
-	if reconciler != null:
-		var court_target: CourtDropTarget = CourtDropTarget.new()
-		var world: World2D = get_world_2d()
-		court_target.configure(_item_manager, reconciler, world, court_bounds)
-		_drop_targets.append(court_target)
-		_builtin_targets.append(court_target)
+	for target: DropTarget in [
+		_make_court_target(),
+		_make_rack_target(rack_drop_target, &"ball"),
+		_make_rack_target(gear_rack_drop_target, &"equipment"),
+		_make_venue_target(),
+	]:
+		if target == null:
+			continue
+		_drop_targets.append(target)
+		_builtin_targets.append(target)
 
-	if rack_drop_target != null:
-		var ball_rack_target: RackDropTarget = RackDropTarget.new()
-		ball_rack_target.configure(_item_manager, rack_drop_target, &"ball")
-		_drop_targets.append(ball_rack_target)
-		_builtin_targets.append(ball_rack_target)
 
-	if gear_rack_drop_target != null:
-		var gear_rack_target: RackDropTarget = RackDropTarget.new()
-		gear_rack_target.configure(_item_manager, gear_rack_drop_target, &"equipment")
-		_drop_targets.append(gear_rack_target)
-		_builtin_targets.append(gear_rack_target)
+func _make_court_target() -> CourtDropTarget:
+	if reconciler == null:
+		return null
+	var court_target: CourtDropTarget = CourtDropTarget.new()
+	court_target.configure(_item_manager, reconciler, get_world_2d(), court_bounds)
+	return court_target
 
-	if reconciler != null:
-		var venue_target: VenueDropTarget = VenueDropTarget.new()
-		venue_target.configure(_item_manager, reconciler, venue_bounds, court_bounds)
-		_drop_targets.append(venue_target)
-		_builtin_targets.append(venue_target)
+
+func _make_rack_target(area: Area2D, role: StringName) -> RackDropTarget:
+	if area == null:
+		return null
+	var rack_target: RackDropTarget = RackDropTarget.new()
+	rack_target.configure(_item_manager, area, role)
+	return rack_target
+
+
+func _make_venue_target() -> VenueDropTarget:
+	if reconciler == null:
+		return null
+	var venue_target: VenueDropTarget = VenueDropTarget.new()
+	venue_target.configure(_item_manager, reconciler, venue_bounds, court_bounds)
+	return venue_target
 
 
 ## Records cursor positions across a short rolling window so release velocity can be derived from recent motion.

--- a/scripts/items/drop_target.gd
+++ b/scripts/items/drop_target.gd
@@ -1,32 +1,17 @@
 class_name DropTarget
 extends RefCounted
 
-## Abstract drop target consulted by BallDragController each physics frame.
-##
-## SH-287 (designs/01-prototype/21-ball-dynamics.md, "Drop validation by body projection"):
-## the drag controller polls every registered target on the held token's world position; the
-## first target whose `can_accept` returns true takes the drop. `accept` performs the side
-## effect (spawning a ball, returning to a slot, completing a purchase, etc.). Subclasses
-## override both methods.
+## Abstract drop target consulted by BallDragController; first `can_accept` wins.
 
 
-## Returns true when this target would accept `item_key` at `position` right now.
-## Targets that are role-restricted (e.g. ball rack only takes ball-role items) gate here.
-## Court projection runs `intersect_shape` here against the item's `at_rest_shape`.
 func can_accept(_item_key: String, _position: Vector2, _scale_factor: float = 1.0) -> bool:
 	return false
 
 
-## Side-effect: commit the drop. Caller has already gated on `can_accept`.
 func accept(_item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
 	pass
 
 
-# --- Shared helpers used by concrete targets ----------------------------------------
-
-
-## Resolves an `ItemDefinition` by `key` from a manager that exposes an `items` array.
-## Returns null if the manager is missing or the key is unknown.
 static func get_definition(item_manager: Node, item_key: String) -> ItemDefinition:
 	if item_manager == null:
 		return null
@@ -36,8 +21,7 @@ static func get_definition(item_manager: Node, item_key: String) -> ItemDefiniti
 	return null
 
 
-## Clamps `world_position` into `bounds`. Zero-sized bounds pass through unchanged so an
-## un-configured court does not collapse releases to the origin.
+## Zero-sized bounds pass through so an un-configured court does not collapse releases to origin.
 static func clamp_to_rect(world_position: Vector2, bounds: Rect2) -> Vector2:
 	if bounds.size == Vector2.ZERO:
 		return world_position
@@ -47,8 +31,7 @@ static func clamp_to_rect(world_position: Vector2, bounds: Rect2) -> Vector2:
 	)
 
 
-## Builds a world-space `Rect2` from an `Area2D`'s first `RectangleShape2D` child.
-## Returns an empty `Rect2()` when the area is missing/freed or has no rectangular collider.
+## Returns empty `Rect2()` when the area is missing/freed or has no rectangular collider.
 static func area_world_rect(area: Area2D) -> Rect2:
 	if not is_instance_valid(area):
 		return Rect2()

--- a/scripts/items/drop_target.gd
+++ b/scripts/items/drop_target.gd
@@ -20,3 +20,48 @@ func can_accept(_item_key: String, _position: Vector2, _scale_factor: float = 1.
 ## Side-effect: commit the drop. Caller has already gated on `can_accept`.
 func accept(_item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
 	pass
+
+
+# --- Shared helpers used by concrete targets ----------------------------------------
+
+
+## Resolves an `ItemDefinition` by `key` from a manager that exposes an `items` array.
+## Returns null if the manager is missing or the key is unknown.
+static func get_definition(item_manager: Node, item_key: String) -> ItemDefinition:
+	if item_manager == null:
+		return null
+	for item: ItemDefinition in item_manager.items:
+		if item.key == item_key:
+			return item
+	return null
+
+
+## Clamps `world_position` into `bounds`. Zero-sized bounds pass through unchanged so an
+## un-configured court does not collapse releases to the origin.
+static func clamp_to_rect(world_position: Vector2, bounds: Rect2) -> Vector2:
+	if bounds.size == Vector2.ZERO:
+		return world_position
+	return Vector2(
+		clampf(world_position.x, bounds.position.x, bounds.position.x + bounds.size.x),
+		clampf(world_position.y, bounds.position.y, bounds.position.y + bounds.size.y),
+	)
+
+
+## Builds a world-space `Rect2` from an `Area2D`'s first `RectangleShape2D` child.
+## Returns an empty `Rect2()` when the area is missing/freed or has no rectangular collider.
+static func area_world_rect(area: Area2D) -> Rect2:
+	if not is_instance_valid(area):
+		return Rect2()
+	var shape_owner: CollisionShape2D = null
+	for child in area.get_children():
+		if child is CollisionShape2D:
+			shape_owner = child
+			break
+	if shape_owner == null:
+		return Rect2()
+	var rectangle: RectangleShape2D = shape_owner.shape as RectangleShape2D
+	if rectangle == null:
+		return Rect2()
+	var half_extents: Vector2 = rectangle.size * 0.5
+	var center: Vector2 = area.global_position + shape_owner.position
+	return Rect2(center - half_extents, rectangle.size)

--- a/scripts/items/drop_target.gd
+++ b/scripts/items/drop_target.gd
@@ -1,0 +1,22 @@
+class_name DropTarget
+extends RefCounted
+
+## Abstract drop target consulted by BallDragController each physics frame.
+##
+## SH-287 (designs/01-prototype/21-ball-dynamics.md, "Drop validation by body projection"):
+## the drag controller polls every registered target on the held token's world position; the
+## first target whose `can_accept` returns true takes the drop. `accept` performs the side
+## effect (spawning a ball, returning to a slot, completing a purchase, etc.). Subclasses
+## override both methods.
+
+
+## Returns true when this target would accept `item_key` at `position` right now.
+## Targets that are role-restricted (e.g. ball rack only takes ball-role items) gate here.
+## Court projection runs `intersect_shape` here against the item's `at_rest_shape`.
+func can_accept(_item_key: String, _position: Vector2, _scale_factor: float = 1.0) -> bool:
+	return false
+
+
+## Side-effect: commit the drop. Caller has already gated on `can_accept`.
+func accept(_item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
+	pass

--- a/scripts/items/drop_target.gd.uid
+++ b/scripts/items/drop_target.gd.uid
@@ -1,0 +1,1 @@
+uid://dpkuu3v4obb6r

--- a/scripts/items/drop_targets/court_drop_target.gd
+++ b/scripts/items/drop_targets/court_drop_target.gd
@@ -36,7 +36,7 @@ func set_exclude_rids(rids: Array[RID]) -> void:
 func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) -> bool:
 	if not _is_ball_role(item_key):
 		return false
-	var clamped: Vector2 = _clamp_to_court(position)
+	var clamped: Vector2 = DropTarget.clamp_to_rect(position, _court_bounds)
 	if clamped != position:
 		# Projection runs at the held position, not the clamped one; if the cursor is
 		# outside the court, the target does not accept here. (Inside-venue-but-outside-court
@@ -48,12 +48,12 @@ func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) 
 func accept(item_key: String, position: Vector2, gesture_velocity: Vector2) -> void:
 	if _reconciler == null:
 		return
-	var clamped: Vector2 = _clamp_to_court(position)
+	var clamped: Vector2 = DropTarget.clamp_to_rect(position, _court_bounds)
 	_reconciler.bring_into_play(item_key, clamped, gesture_velocity)
 
 
 func _is_ball_role(item_key: String) -> bool:
-	var definition: ItemDefinition = _get_definition(item_key)
+	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
 	if definition == null:
 		return false
 	return definition.role == &"ball"
@@ -65,7 +65,7 @@ func _projection_clear(item_key: String, position: Vector2, scale_factor: float)
 	var space: PhysicsDirectSpaceState2D = _world.direct_space_state
 	if space == null:
 		return true
-	var definition: ItemDefinition = _get_definition(item_key)
+	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
 	var shape: Shape2D = null
 	if definition != null and definition.at_rest_shape != null:
 		shape = _scaled_shape(definition.at_rest_shape, scale_factor)
@@ -106,29 +106,3 @@ func _scaled_shape(source: Shape2D, scale_factor: float) -> Shape2D:
 		return scaled_cap
 	# Unknown shape type: fall back to the un-scaled source rather than guessing.
 	return source
-
-
-func _clamp_to_court(world_position: Vector2) -> Vector2:
-	if _court_bounds.size == Vector2.ZERO:
-		return world_position
-	return Vector2(
-		clampf(
-			world_position.x,
-			_court_bounds.position.x,
-			_court_bounds.position.x + _court_bounds.size.x
-		),
-		clampf(
-			world_position.y,
-			_court_bounds.position.y,
-			_court_bounds.position.y + _court_bounds.size.y
-		),
-	)
-
-
-func _get_definition(item_key: String) -> ItemDefinition:
-	if _item_manager == null:
-		return null
-	for item: ItemDefinition in _item_manager.items:
-		if item.key == item_key:
-			return item
-	return null

--- a/scripts/items/drop_targets/court_drop_target.gd
+++ b/scripts/items/drop_targets/court_drop_target.gd
@@ -1,0 +1,134 @@
+class_name CourtDropTarget
+extends DropTarget
+
+## Court target: accepts ball-role items at positions that pass a body projection.
+##
+## SH-287: `can_accept` runs `PhysicsDirectSpaceState2D.intersect_shape` with the item's
+## authored `at_rest_shape` at the candidate position; rejects on overlap with walls,
+## partners, other balls. `scale_factor` widens the shape for the expansion-ring fallback
+## documented in `designs/01-prototype/22-equip-loop-regime.md`.
+
+var _item_manager: Node
+var _reconciler: BallReconciler
+var _world: World2D
+var _court_bounds: Rect2
+var _exclude_rids: Array[RID] = []
+
+
+func configure(
+	item_manager: Node,
+	reconciler: BallReconciler,
+	world: World2D,
+	court_bounds: Rect2,
+) -> void:
+	_item_manager = item_manager
+	_reconciler = reconciler
+	_world = world
+	_court_bounds = court_bounds
+
+
+## Held-body grabs free their live ball before polling resumes; pass any RIDs that should
+## not count as overlaps (e.g. the held item's own existing body, when it has one).
+func set_exclude_rids(rids: Array[RID]) -> void:
+	_exclude_rids = rids
+
+
+func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) -> bool:
+	if not _is_ball_role(item_key):
+		return false
+	var clamped: Vector2 = _clamp_to_court(position)
+	if clamped != position:
+		# Projection runs at the held position, not the clamped one; if the cursor is
+		# outside the court, the target does not accept here. (Inside-venue-but-outside-court
+		# release lands via VenueDropTarget, which clamps to court for ball items.)
+		return false
+	return _projection_clear(item_key, clamped, scale_factor)
+
+
+func accept(item_key: String, position: Vector2, gesture_velocity: Vector2) -> void:
+	if _reconciler == null:
+		return
+	var clamped: Vector2 = _clamp_to_court(position)
+	_reconciler.bring_into_play(item_key, clamped, gesture_velocity)
+
+
+func _is_ball_role(item_key: String) -> bool:
+	var definition: ItemDefinition = _get_definition(item_key)
+	if definition == null:
+		return false
+	return definition.role == &"ball"
+
+
+func _projection_clear(item_key: String, position: Vector2, scale_factor: float) -> bool:
+	if _world == null:
+		return true
+	var space: PhysicsDirectSpaceState2D = _world.direct_space_state
+	if space == null:
+		return true
+	var definition: ItemDefinition = _get_definition(item_key)
+	var shape: Shape2D = null
+	if definition != null and definition.at_rest_shape != null:
+		shape = _scaled_shape(definition.at_rest_shape, scale_factor)
+	if shape == null:
+		# Fallback: a small circle keeps the legacy probe behaviour for items missing an
+		# authored shape (the test fixture path) without lying about clearance.
+		var circle: CircleShape2D = CircleShape2D.new()
+		circle.radius = 14.0 * scale_factor
+		shape = circle
+	var params: PhysicsShapeQueryParameters2D = PhysicsShapeQueryParameters2D.new()
+	params.shape = shape
+	params.transform = Transform2D(0.0, position)
+	params.collide_with_bodies = true
+	params.collide_with_areas = false
+	if not _exclude_rids.is_empty():
+		params.exclude = _exclude_rids
+	return space.intersect_shape(params, 1).is_empty()
+
+
+func _scaled_shape(source: Shape2D, scale_factor: float) -> Shape2D:
+	if is_equal_approx(scale_factor, 1.0):
+		return source
+	if source is CircleShape2D:
+		var src_circle: CircleShape2D = source
+		var scaled_circle: CircleShape2D = CircleShape2D.new()
+		scaled_circle.radius = src_circle.radius * scale_factor
+		return scaled_circle
+	if source is RectangleShape2D:
+		var src_rect: RectangleShape2D = source
+		var scaled_rect: RectangleShape2D = RectangleShape2D.new()
+		scaled_rect.size = src_rect.size * scale_factor
+		return scaled_rect
+	if source is CapsuleShape2D:
+		var src_cap: CapsuleShape2D = source
+		var scaled_cap: CapsuleShape2D = CapsuleShape2D.new()
+		scaled_cap.radius = src_cap.radius * scale_factor
+		scaled_cap.height = src_cap.height * scale_factor
+		return scaled_cap
+	# Unknown shape type: fall back to the un-scaled source rather than guessing.
+	return source
+
+
+func _clamp_to_court(world_position: Vector2) -> Vector2:
+	if _court_bounds.size == Vector2.ZERO:
+		return world_position
+	return Vector2(
+		clampf(
+			world_position.x,
+			_court_bounds.position.x,
+			_court_bounds.position.x + _court_bounds.size.x
+		),
+		clampf(
+			world_position.y,
+			_court_bounds.position.y,
+			_court_bounds.position.y + _court_bounds.size.y
+		),
+	)
+
+
+func _get_definition(item_key: String) -> ItemDefinition:
+	if _item_manager == null:
+		return null
+	for item: ItemDefinition in _item_manager.items:
+		if item.key == item_key:
+			return item
+	return null

--- a/scripts/items/drop_targets/court_drop_target.gd
+++ b/scripts/items/drop_targets/court_drop_target.gd
@@ -1,12 +1,7 @@
 class_name CourtDropTarget
 extends DropTarget
 
-## Court target: accepts ball-role items at positions that pass a body projection.
-##
-## SH-287: `can_accept` runs `PhysicsDirectSpaceState2D.intersect_shape` with the item's
-## authored `at_rest_shape` at the candidate position; rejects on overlap with walls,
-## partners, other balls. `scale_factor` widens the shape for the expansion-ring fallback
-## documented in `designs/01-prototype/22-equip-loop-regime.md`.
+## Accepts ball-role items at positions whose authored shape clears walls, partners, and other balls.
 
 var _item_manager: Node
 var _reconciler: BallReconciler
@@ -27,8 +22,7 @@ func configure(
 	_court_bounds = court_bounds
 
 
-## Held-body grabs free their live ball before polling resumes; pass any RIDs that should
-## not count as overlaps (e.g. the held item's own existing body, when it has one).
+## RIDs to exclude from the projection (e.g. the held item's own body).
 func set_exclude_rids(rids: Array[RID]) -> void:
 	_exclude_rids = rids
 
@@ -38,9 +32,7 @@ func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) 
 		return false
 	var clamped: Vector2 = DropTarget.clamp_to_rect(position, _court_bounds)
 	if clamped != position:
-		# Projection runs at the held position, not the clamped one; if the cursor is
-		# outside the court, the target does not accept here. (Inside-venue-but-outside-court
-		# release lands via VenueDropTarget, which clamps to court for ball items.)
+		# Off-court cursor falls through to VenueDropTarget for clamping.
 		return false
 	return _projection_clear(item_key, clamped, scale_factor)
 
@@ -70,8 +62,7 @@ func _projection_clear(item_key: String, position: Vector2, scale_factor: float)
 	if definition != null and definition.at_rest_shape != null:
 		shape = _scaled_shape(definition.at_rest_shape, scale_factor)
 	if shape == null:
-		# Fallback: a small circle keeps the legacy probe behaviour for items missing an
-		# authored shape (the test fixture path) without lying about clearance.
+		# Legacy probe radius for items (e.g. test fixtures) missing an authored shape.
 		var circle: CircleShape2D = CircleShape2D.new()
 		circle.radius = 14.0 * scale_factor
 		shape = circle

--- a/scripts/items/drop_targets/court_drop_target.gd.uid
+++ b/scripts/items/drop_targets/court_drop_target.gd.uid
@@ -1,0 +1,1 @@
+uid://cbjvktojqsqqd

--- a/scripts/items/drop_targets/rack_drop_target.gd
+++ b/scripts/items/drop_targets/rack_drop_target.gd
@@ -36,7 +36,7 @@ func accept(item_key: String, _position: Vector2, _gesture_velocity: Vector2) ->
 
 
 func _is_role_match(item_key: String) -> bool:
-	var definition: ItemDefinition = _get_definition(item_key)
+	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
 	if definition == null:
 		# Default to ball-role for backward compat with tests that don't author the field.
 		return _role == &"ball"
@@ -44,30 +44,4 @@ func _is_role_match(item_key: String) -> bool:
 
 
 func _position_inside_area(world_position: Vector2) -> bool:
-	var rect: Rect2 = _world_rect()
-	return rect.has_point(world_position)
-
-
-func _world_rect() -> Rect2:
-	var shape_owner: CollisionShape2D = null
-	for child in _drop_area.get_children():
-		if child is CollisionShape2D:
-			shape_owner = child
-			break
-	if shape_owner == null:
-		return Rect2()
-	var rectangle: RectangleShape2D = shape_owner.shape as RectangleShape2D
-	if rectangle == null:
-		return Rect2()
-	var half_extents: Vector2 = rectangle.size * 0.5
-	var center: Vector2 = _drop_area.global_position + shape_owner.position
-	return Rect2(center - half_extents, rectangle.size)
-
-
-func _get_definition(item_key: String) -> ItemDefinition:
-	if _item_manager == null:
-		return null
-	for item: ItemDefinition in _item_manager.items:
-		if item.key == item_key:
-			return item
-	return null
+	return DropTarget.area_world_rect(_drop_area).has_point(world_position)

--- a/scripts/items/drop_targets/rack_drop_target.gd
+++ b/scripts/items/drop_targets/rack_drop_target.gd
@@ -1,0 +1,73 @@
+class_name RackDropTarget
+extends DropTarget
+
+## Rack target: accepts items whose role matches the rack's role at any position inside
+## the rack's drop area.
+##
+## On accept, deactivates the item if it was on-court so the rack regrows the token.
+## Pickup-without-movement (a press-release on the source rack with no cursor travel) is
+## handled by the drag controller as a bare gesture-cancel; this target is the standard
+## return-to-rack drop.
+
+var _item_manager: Node
+var _drop_area: Area2D
+var _role: StringName
+
+
+func configure(item_manager: Node, drop_area: Area2D, role: StringName) -> void:
+	_item_manager = item_manager
+	_drop_area = drop_area
+	_role = role
+
+
+func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:
+	if _drop_area == null:
+		return false
+	if not _is_role_match(item_key):
+		return false
+	return _position_inside_area(position)
+
+
+func accept(item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
+	if _item_manager == null:
+		return
+	if _item_manager.is_on_court(item_key):
+		_item_manager.deactivate(item_key)
+
+
+func _is_role_match(item_key: String) -> bool:
+	var definition: ItemDefinition = _get_definition(item_key)
+	if definition == null:
+		# Default to ball-role for backward compat with tests that don't author the field.
+		return _role == &"ball"
+	return definition.role == _role
+
+
+func _position_inside_area(world_position: Vector2) -> bool:
+	var rect: Rect2 = _world_rect()
+	return rect.has_point(world_position)
+
+
+func _world_rect() -> Rect2:
+	var shape_owner: CollisionShape2D = null
+	for child in _drop_area.get_children():
+		if child is CollisionShape2D:
+			shape_owner = child
+			break
+	if shape_owner == null:
+		return Rect2()
+	var rectangle: RectangleShape2D = shape_owner.shape as RectangleShape2D
+	if rectangle == null:
+		return Rect2()
+	var half_extents: Vector2 = rectangle.size * 0.5
+	var center: Vector2 = _drop_area.global_position + shape_owner.position
+	return Rect2(center - half_extents, rectangle.size)
+
+
+func _get_definition(item_key: String) -> ItemDefinition:
+	if _item_manager == null:
+		return null
+	for item: ItemDefinition in _item_manager.items:
+		if item.key == item_key:
+			return item
+	return null

--- a/scripts/items/drop_targets/rack_drop_target.gd
+++ b/scripts/items/drop_targets/rack_drop_target.gd
@@ -1,13 +1,7 @@
 class_name RackDropTarget
 extends DropTarget
 
-## Rack target: accepts items whose role matches the rack's role at any position inside
-## the rack's drop area.
-##
-## On accept, deactivates the item if it was on-court so the rack regrows the token.
-## Pickup-without-movement (a press-release on the source rack with no cursor travel) is
-## handled by the drag controller as a bare gesture-cancel; this target is the standard
-## return-to-rack drop.
+## Accepts role-matched items inside the rack's drop area; deactivates on-court items so the rack regrows.
 
 var _item_manager: Node
 var _drop_area: Area2D

--- a/scripts/items/drop_targets/rack_drop_target.gd.uid
+++ b/scripts/items/drop_targets/rack_drop_target.gd.uid
@@ -1,0 +1,1 @@
+uid://bmqkgc57u27r6

--- a/scripts/items/drop_targets/shop_drop_target.gd
+++ b/scripts/items/drop_targets/shop_drop_target.gd
@@ -1,14 +1,7 @@
 class_name ShopDropTarget
 extends DropTarget
 
-## Shop target: cancels a shop-origin gesture back into the shop slot.
-##
-## Pre-SH-287 the shop owned its own drag controller (`scripts/shop/shop_item.gd`). The
-## body-projection refactor unifies on a single controller; the shop registers a
-## `ShopDropTarget` so that releases inside the shop area cancel back to the source slot
-## with no purchase. Releases outside the shop area fall through to whichever target
-## accepts (court for ball items, rack for equipment, etc.); the controller calls
-## `_item_manager.take(...)` to commit the purchase before that downstream target runs.
+## Releases inside the shop area cancel the gesture back to the source slot with no purchase.
 
 var _shop_area: Area2D
 
@@ -18,8 +11,7 @@ func configure(shop_area: Area2D) -> void:
 
 
 func can_accept(_item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:
-	# is_instance_valid guards against a freed Shop leaving a stale target registered (the
-	# Shop also unregisters on tree_exiting; this is the belt to that suspenders).
+	# Belt to the Shop's tree_exiting unregister suspenders.
 	if not is_instance_valid(_shop_area):
 		return false
 	var rect: Rect2 = DropTarget.area_world_rect(_shop_area)
@@ -29,6 +21,5 @@ func can_accept(_item_key: String, position: Vector2, _scale_factor: float = 1.0
 
 
 func accept(_item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
-	# No side effect on cancel-back: the gesture clears and the source slot becomes visible
-	# again via the controller's finalisation hook.
+	# Cancel-back has no side effect; the controller's finalisation hook restores the source slot.
 	pass

--- a/scripts/items/drop_targets/shop_drop_target.gd
+++ b/scripts/items/drop_targets/shop_drop_target.gd
@@ -18,28 +18,17 @@ func configure(shop_area: Area2D) -> void:
 
 
 func can_accept(_item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:
-	if _shop_area == null:
+	# is_instance_valid guards against a freed Shop leaving a stale target registered (the
+	# Shop also unregisters on tree_exiting; this is the belt to that suspenders).
+	if not is_instance_valid(_shop_area):
 		return false
-	return _position_inside_area(position)
+	var rect: Rect2 = DropTarget.area_world_rect(_shop_area)
+	if rect.size == Vector2.ZERO:
+		return false
+	return rect.has_point(position)
 
 
 func accept(_item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
 	# No side effect on cancel-back: the gesture clears and the source slot becomes visible
 	# again via the controller's finalisation hook.
 	pass
-
-
-func _position_inside_area(world_position: Vector2) -> bool:
-	var shape_owner: CollisionShape2D = null
-	for child in _shop_area.get_children():
-		if child is CollisionShape2D:
-			shape_owner = child
-			break
-	if shape_owner == null:
-		return false
-	var rectangle: RectangleShape2D = shape_owner.shape as RectangleShape2D
-	if rectangle == null:
-		return false
-	var half_extents: Vector2 = rectangle.size * 0.5
-	var center: Vector2 = _shop_area.global_position + shape_owner.position
-	return Rect2(center - half_extents, rectangle.size).has_point(world_position)

--- a/scripts/items/drop_targets/shop_drop_target.gd
+++ b/scripts/items/drop_targets/shop_drop_target.gd
@@ -1,0 +1,45 @@
+class_name ShopDropTarget
+extends DropTarget
+
+## Shop target: cancels a shop-origin gesture back into the shop slot.
+##
+## Pre-SH-287 the shop owned its own drag controller (`scripts/shop/shop_item.gd`). The
+## body-projection refactor unifies on a single controller; the shop registers a
+## `ShopDropTarget` so that releases inside the shop area cancel back to the source slot
+## with no purchase. Releases outside the shop area fall through to whichever target
+## accepts (court for ball items, rack for equipment, etc.); the controller calls
+## `_item_manager.take(...)` to commit the purchase before that downstream target runs.
+
+var _shop_area: Area2D
+
+
+func configure(shop_area: Area2D) -> void:
+	_shop_area = shop_area
+
+
+func can_accept(_item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:
+	if _shop_area == null:
+		return false
+	return _position_inside_area(position)
+
+
+func accept(_item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
+	# No side effect on cancel-back: the gesture clears and the source slot becomes visible
+	# again via the controller's finalisation hook.
+	pass
+
+
+func _position_inside_area(world_position: Vector2) -> bool:
+	var shape_owner: CollisionShape2D = null
+	for child in _shop_area.get_children():
+		if child is CollisionShape2D:
+			shape_owner = child
+			break
+	if shape_owner == null:
+		return false
+	var rectangle: RectangleShape2D = shape_owner.shape as RectangleShape2D
+	if rectangle == null:
+		return false
+	var half_extents: Vector2 = rectangle.size * 0.5
+	var center: Vector2 = _shop_area.global_position + shape_owner.position
+	return Rect2(center - half_extents, rectangle.size).has_point(world_position)

--- a/scripts/items/drop_targets/shop_drop_target.gd.uid
+++ b/scripts/items/drop_targets/shop_drop_target.gd.uid
@@ -1,0 +1,1 @@
+uid://byx6hv8g11f5e

--- a/scripts/items/drop_targets/venue_drop_target.gd
+++ b/scripts/items/drop_targets/venue_drop_target.gd
@@ -1,19 +1,7 @@
 class_name VenueDropTarget
 extends DropTarget
 
-## Venue floor catch-all target.
-##
-## SH-287 keeps held items as Node2D tokens (no loose-physics body yet; that arrives in
-## SH-314). The venue target accepts inside the venue rect when no other target does:
-## ball-role items spawn on the court at the court-clamped position (preserving the
-## prior "release inside venue but outside court spawns at the court edge" behaviour);
-## equipment items return to their gear rack via the item-manager `deactivate` rule the
-## RackDropTarget would have run.
-##
-## The venue target is the **lowest-priority** target; the controller polls it last.
-## It accepts only ball items and only when the strict court projection has failed at
-## the held position but the cursor is still inside the venue. This keeps releases
-## inside the rally surface playable while the loose-physics rework lands separately.
+## Lowest-priority fallback: ball-role releases inside the venue rect clamp to the court edge.
 
 var _item_manager: Node
 var _reconciler: BallReconciler
@@ -38,8 +26,7 @@ func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0)
 		return false
 	if _venue_bounds.size == Vector2.ZERO:
 		return false
-	# Inclusive check on the max edge so a release clamped to the venue corner still
-	# resolves (Rect2.has_point treats max as exclusive).
+	# Inclusive max-edge check; Rect2.has_point treats max as exclusive.
 	var lo: Vector2 = _venue_bounds.position
 	var hi: Vector2 = lo + _venue_bounds.size
 	return position.x >= lo.x and position.x <= hi.x and position.y >= lo.y and position.y <= hi.y

--- a/scripts/items/drop_targets/venue_drop_target.gd
+++ b/scripts/items/drop_targets/venue_drop_target.gd
@@ -1,0 +1,85 @@
+class_name VenueDropTarget
+extends DropTarget
+
+## Venue floor catch-all target.
+##
+## SH-287 keeps held items as Node2D tokens (no loose-physics body yet; that arrives in
+## SH-314). The venue target accepts inside the venue rect when no other target does:
+## ball-role items spawn on the court at the court-clamped position (preserving the
+## prior "release inside venue but outside court spawns at the court edge" behaviour);
+## equipment items return to their gear rack via the item-manager `deactivate` rule the
+## RackDropTarget would have run.
+##
+## The venue target is the **lowest-priority** target; the controller polls it last.
+## It accepts only ball items and only when the strict court projection has failed at
+## the held position but the cursor is still inside the venue. This keeps releases
+## inside the rally surface playable while the loose-physics rework lands separately.
+
+var _item_manager: Node
+var _reconciler: BallReconciler
+var _venue_bounds: Rect2
+var _court_bounds: Rect2
+
+
+func configure(
+	item_manager: Node,
+	reconciler: BallReconciler,
+	venue_bounds: Rect2,
+	court_bounds: Rect2,
+) -> void:
+	_item_manager = item_manager
+	_reconciler = reconciler
+	_venue_bounds = venue_bounds
+	_court_bounds = court_bounds
+
+
+func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:
+	if not _is_ball_role(item_key):
+		return false
+	if _venue_bounds.size == Vector2.ZERO:
+		return false
+	# Inclusive check on the max edge so a release clamped to the venue corner still
+	# resolves (Rect2.has_point treats max as exclusive).
+	var lo: Vector2 = _venue_bounds.position
+	var hi: Vector2 = lo + _venue_bounds.size
+	return position.x >= lo.x and position.x <= hi.x and position.y >= lo.y and position.y <= hi.y
+
+
+func accept(item_key: String, position: Vector2, gesture_velocity: Vector2) -> void:
+	if _reconciler == null:
+		return
+	var clamped: Vector2 = _clamp_to_court(position)
+	_reconciler.bring_into_play(item_key, clamped, gesture_velocity)
+
+
+func _is_ball_role(item_key: String) -> bool:
+	var definition: ItemDefinition = _get_definition(item_key)
+	if definition == null:
+		return true
+	return definition.role == &"ball"
+
+
+func _clamp_to_court(world_position: Vector2) -> Vector2:
+	if _court_bounds.size == Vector2.ZERO:
+		return world_position
+	return Vector2(
+		clampf(
+			world_position.x,
+			_court_bounds.position.x,
+			_court_bounds.position.x + _court_bounds.size.x
+		),
+		clampf(
+			world_position.y,
+			_court_bounds.position.y,
+			_court_bounds.position.y + _court_bounds.size.y
+		),
+	)
+
+
+func _get_definition(item_key: String) -> ItemDefinition:
+	if _item_manager == null:
+		return null
+	for item: ItemDefinition in _item_manager.items:
+		if item.key == item_key:
+			return item
+	return null

--- a/scripts/items/drop_targets/venue_drop_target.gd
+++ b/scripts/items/drop_targets/venue_drop_target.gd
@@ -48,38 +48,12 @@ func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0)
 func accept(item_key: String, position: Vector2, gesture_velocity: Vector2) -> void:
 	if _reconciler == null:
 		return
-	var clamped: Vector2 = _clamp_to_court(position)
+	var clamped: Vector2 = DropTarget.clamp_to_rect(position, _court_bounds)
 	_reconciler.bring_into_play(item_key, clamped, gesture_velocity)
 
 
 func _is_ball_role(item_key: String) -> bool:
-	var definition: ItemDefinition = _get_definition(item_key)
+	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
 	if definition == null:
 		return true
 	return definition.role == &"ball"
-
-
-func _clamp_to_court(world_position: Vector2) -> Vector2:
-	if _court_bounds.size == Vector2.ZERO:
-		return world_position
-	return Vector2(
-		clampf(
-			world_position.x,
-			_court_bounds.position.x,
-			_court_bounds.position.x + _court_bounds.size.x
-		),
-		clampf(
-			world_position.y,
-			_court_bounds.position.y,
-			_court_bounds.position.y + _court_bounds.size.y
-		),
-	)
-
-
-func _get_definition(item_key: String) -> ItemDefinition:
-	if _item_manager == null:
-		return null
-	for item: ItemDefinition in _item_manager.items:
-		if item.key == item_key:
-			return item
-	return null

--- a/scripts/items/drop_targets/venue_drop_target.gd.uid
+++ b/scripts/items/drop_targets/venue_drop_target.gd.uid
@@ -1,0 +1,1 @@
+uid://clyfa8heojc04

--- a/scripts/items/item_definition.gd
+++ b/scripts/items/item_definition.gd
@@ -3,8 +3,7 @@ extends Resource
 
 @export var key: String
 @export var type: StringName = &""
-## Physical role of this item: determines its natural placement target.
-## &"equipment" (default) lives on the player; &"ball" lives on the court.
+## &"equipment" lives on the player; &"ball" lives on the court.
 @export var role: StringName = &"equipment"
 @export var display_name: String
 @export var art: PackedScene
@@ -17,10 +16,7 @@ extends Resource
 @export var token_scale: Vector2 = Vector2(1.5, 1.5)
 ## False for authored starter items that are owned-from-start and never appear in the shop catalog (SH-313).
 @export var purchasable: bool = true
-## SH-287: authored at-rest collision shape used for drop-target body projection.
-## Ball items wire to their `CircleShape2D`; equipment items to their token bounds.
-## Items whose at-rest representation is not a physics body may leave this null and the
-## bounds check on the destination target alone decides acceptance.
+## Authored at-rest shape for drop-target body projection; null falls back to bounds-only acceptance.
 @export var at_rest_shape: Shape2D
 
 

--- a/scripts/items/item_definition.gd
+++ b/scripts/items/item_definition.gd
@@ -17,6 +17,11 @@ extends Resource
 @export var token_scale: Vector2 = Vector2(1.5, 1.5)
 ## False for authored starter items that are owned-from-start and never appear in the shop catalog (SH-313).
 @export var purchasable: bool = true
+## SH-287: authored at-rest collision shape used for drop-target body projection.
+## Ball items wire to their `CircleShape2D`; equipment items to their token bounds.
+## Items whose at-rest representation is not a physics body may leave this null and the
+## bounds check on the destination target alone decides acceptance.
+@export var at_rest_shape: Shape2D
 
 
 func get_effects_for_level(level: int) -> Array[Effect]:

--- a/scripts/shop/shop.gd
+++ b/scripts/shop/shop.gd
@@ -6,6 +6,9 @@ extends Node2D
 
 const DEFAULT_CONFIG: ShopConfig = preload("res://resources/shop_config.tres")
 const ShopItemScene: PackedScene = preload("res://scenes/shop_item.tscn")
+const ShopDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/shop_drop_target.gd"
+)
 
 @export var config: ShopConfig = DEFAULT_CONFIG
 @export var shop_area: Area2D
@@ -24,6 +27,25 @@ func _ready() -> void:
 	_item_manager.item_level_changed.connect(_on_item_level_changed)
 	_update_friendship_label(_item_manager.get_friendship_point_balance())
 	_spawn_items()
+	_register_shop_target()
+
+
+## Hands a ShopDropTarget to the drag controller so a release back inside the shop area
+## cancels with no purchase. Defers a frame so the controller has time to add itself to
+## the `drag_controller` group during its own `_ready`.
+func _register_shop_target() -> void:
+	call_deferred(&"_do_register_shop_target")
+
+
+func _do_register_shop_target() -> void:
+	var controller: Node = get_tree().get_first_node_in_group(&"drag_controller")
+	if controller == null:
+		return
+	if not controller.has_method("register_target"):
+		return
+	var target: ShopDropTarget = ShopDropTargetScript.new()
+	target.configure(shop_area)
+	controller.register_target(target)
 
 
 func _spawn_items() -> void:

--- a/scripts/shop/shop.gd
+++ b/scripts/shop/shop.gd
@@ -1,8 +1,7 @@
 class_name Shop
 extends Node2D
 
-## Diegetic shop in the venue. Pressing an item starts a held-token drag; releasing
-## outside the shop area completes the purchase. See designs/01-prototype/08-shop.md.
+## Diegetic shop in the venue; see designs/01-prototype/08-shop.md.
 
 const DEFAULT_CONFIG: ShopConfig = preload("res://resources/shop_config.tres")
 const ShopItemScene: PackedScene = preload("res://scenes/shop_item.tscn")
@@ -13,8 +12,7 @@ const ShopItemScene: PackedScene = preload("res://scenes/shop_item.tscn")
 @export var items_anchor: Node2D
 
 var _item_manager: Node
-## Held so a tree_exiting unregister can reach the controller even after the Shop's own
-## `get_tree()` lookup would return null. Cleared in the deregistration path.
+## Cached so tree_exiting can unregister after `get_tree()` would return null.
 var _registered_target: ShopDropTarget = null
 var _registered_controller: Node = null
 
@@ -33,9 +31,7 @@ func _ready() -> void:
 		tree_exiting.connect(_on_tree_exiting)
 
 
-## Hands a ShopDropTarget to the drag controller so a release back inside the shop area
-## cancels with no purchase. Defers a frame so the controller has time to add itself to
-## the `drag_controller` group during its own `_ready`.
+## Deferred so the controller has run `_ready` and joined the `drag_controller` group.
 func _register_shop_target() -> void:
 	call_deferred(&"_do_register_shop_target")
 
@@ -53,8 +49,7 @@ func _do_register_shop_target() -> void:
 	_registered_controller = controller
 
 
-## Scene reloads can free the Shop without freeing the drag controller (different parents).
-## Without this, the controller would keep polling a target backed by a freed Area2D.
+## Scene reload can free the Shop while the controller lives on, leaving a freed Area2D in the poll.
 func _on_tree_exiting() -> void:
 	if _registered_target == null:
 		return

--- a/scripts/shop/shop.gd
+++ b/scripts/shop/shop.gd
@@ -6,9 +6,6 @@ extends Node2D
 
 const DEFAULT_CONFIG: ShopConfig = preload("res://resources/shop_config.tres")
 const ShopItemScene: PackedScene = preload("res://scenes/shop_item.tscn")
-const ShopDropTargetScript: GDScript = preload(
-	"res://scripts/items/drop_targets/shop_drop_target.gd"
-)
 
 @export var config: ShopConfig = DEFAULT_CONFIG
 @export var shop_area: Area2D
@@ -16,6 +13,10 @@ const ShopDropTargetScript: GDScript = preload(
 @export var items_anchor: Node2D
 
 var _item_manager: Node
+## Held so a tree_exiting unregister can reach the controller even after the Shop's own
+## `get_tree()` lookup would return null. Cleared in the deregistration path.
+var _registered_target: ShopDropTarget = null
+var _registered_controller: Node = null
 
 
 func _ready() -> void:
@@ -28,6 +29,8 @@ func _ready() -> void:
 	_update_friendship_label(_item_manager.get_friendship_point_balance())
 	_spawn_items()
 	_register_shop_target()
+	if not tree_exiting.is_connected(_on_tree_exiting):
+		tree_exiting.connect(_on_tree_exiting)
 
 
 ## Hands a ShopDropTarget to the drag controller so a release back inside the shop area
@@ -43,9 +46,25 @@ func _do_register_shop_target() -> void:
 		return
 	if not controller.has_method("register_target"):
 		return
-	var target: ShopDropTarget = ShopDropTargetScript.new()
+	var target: ShopDropTarget = ShopDropTarget.new()
 	target.configure(shop_area)
 	controller.register_target(target)
+	_registered_target = target
+	_registered_controller = controller
+
+
+## Scene reloads can free the Shop without freeing the drag controller (different parents).
+## Without this, the controller would keep polling a target backed by a freed Area2D.
+func _on_tree_exiting() -> void:
+	if _registered_target == null:
+		return
+	if (
+		is_instance_valid(_registered_controller)
+		and _registered_controller.has_method("unregister_target")
+	):
+		_registered_controller.unregister_target(_registered_target)
+	_registered_target = null
+	_registered_controller = null
 
 
 func _spawn_items() -> void:

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -142,41 +142,28 @@ func start_drag() -> bool:
 	return true
 
 
-## Test seam / production entry. Returns true on commit (held token freed, gesture ends);
-## false on no valid target (held token stays following the cursor, gesture continues).
-## Inside-shop bounds is itself a valid target: cancels back to the slot. Outside-shop only
-## commits when the purchase succeeds; insufficient FP keeps the gesture open.
+## Returns true on commit; false leaves the gesture open so the player can drag back to cancel or earn FP and retry.
 func attempt_release(release_position: Vector2) -> bool:
 	if _held_token == null:
 		return false
 
 	var inside_shop: bool = _is_position_inside_shop(release_position)
 	if inside_shop:
-		# Cancel: held token freed, slot visible again, no purchase.
 		_finalise_gesture(release_position, false)
 		visible = true
 		return true
 
-	# Outside shop: only commit if the purchase succeeds.
 	var purchased: bool = _complete_purchase()
 	if not purchased:
-		# Insufficient FP (or otherwise un-takeable). No snap-back; gesture stays open.
-		# Held token continues to follow the cursor; the player can drag back into the shop
-		# bounds to cancel, or get more FP and try again.
 		return false
 
-	# Purchased: hand the held position off to BallDragController so the body-projection
-	# target loop decides whether the new ball lands on the court (SH-287, SH-320 fix) or
-	# falls through to the rack as a token. Held visual freed by the controller's
-	# bring_into_play flow when the court accepts; otherwise we free it locally.
 	_route_purchased_to_court(release_position)
 	_finalise_gesture(release_position, true)
 	visible = false
 	return true
 
 
-## Hands off to BallDragController so the just-purchased item can land on the court at
-## the released position when the body projection passes (SH-320).
+## Hands the just-purchased item to BallDragController so a court-valid release spawns a live ball at the release point.
 func _route_purchased_to_court(release_position: Vector2) -> bool:
 	if item_definition == null:
 		return false

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -165,10 +165,36 @@ func attempt_release(release_position: Vector2) -> bool:
 		# bounds to cancel, or get more FP and try again.
 		return false
 
-	# Purchased: held token freed, slot stays hidden until the next shop refresh sweeps it.
+	# Purchased: hand the held position off to BallDragController so the body-projection
+	# target loop decides whether the new ball lands on the court (SH-287, SH-320 fix) or
+	# falls through to the rack as a token. Held visual freed by the controller's
+	# bring_into_play flow when the court accepts; otherwise we free it locally.
+	_route_purchased_to_court(release_position)
 	_finalise_gesture(release_position, true)
 	visible = false
 	return true
+
+
+## Hands off to BallDragController so the just-purchased item can land on the court at
+## the released position when the body projection passes (SH-320).
+func _route_purchased_to_court(release_position: Vector2) -> bool:
+	if item_definition == null:
+		return false
+	if item_definition.role != &"ball":
+		return false
+	var tree: SceneTree = get_tree()
+	if tree == null:
+		return false
+	var controller: Node = tree.get_first_node_in_group(&"drag_controller")
+	if controller == null or not controller.has_method("spawn_purchased_at"):
+		return false
+	return controller.spawn_purchased_at(item_definition.key, release_position, _release_velocity())
+
+
+func _release_velocity() -> Vector2:
+	if _item_manager != null and _item_manager.has_method("get_default_ball_launch_velocity"):
+		return _item_manager.get_default_ball_launch_velocity()
+	return Vector2.ZERO
 
 
 func _finalise_gesture(release_position: Vector2, purchased: bool) -> void:

--- a/tests/integration/test_shop_drag_drop.gd
+++ b/tests/integration/test_shop_drag_drop.gd
@@ -222,13 +222,10 @@ func test_unaffordable_item_cannot_start_drag() -> void:
 
 
 func test_shop_to_court_release_spawns_ball_at_release_position() -> void:
-	# Re-stage with a ball-role item that has an at_rest_shape so the court target
-	# projection has a real radius. Wire a BallDragController so the shop can route the
-	# new ball through it.
+	# TrainingBall carries an at_rest_shape so CourtDropTarget has a real radius to query.
 	_item_manager.items.assign([TrainingBall] as Array[ItemDefinition])
 
-	# The Shop builds its child items in `_ready`; respawning is the cleanest way to
-	# pick up the swapped item list under the integration harness.
+	# Shop builds children in `_ready`; respawn picks up the swapped item list.
 	_shop.queue_free()
 	await get_tree().process_frame
 	_shop = ShopScene.instantiate()
@@ -246,13 +243,12 @@ func test_shop_to_court_release_spawns_ball_at_release_position() -> void:
 	drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
 	drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
 	add_child_autofree(drag)
-	# Wait one frame so _ready has run and added the controller to drag_controller group.
+	# Wait one frame so _ready joins the drag_controller group.
 	await get_tree().process_frame
 
 	var item: ShopItem = _shop.items_anchor.get_node("ShopItem_training_ball")
 	item.start_drag()
 
-	# Release inside the court interior but outside the shop area's 500x400 rect.
 	var court_release: Vector2 = _shop.shop_area.global_position + Vector2(0, 300)
 	item.attempt_release(court_release)
 
@@ -267,10 +263,7 @@ func test_shop_to_court_release_spawns_ball_at_release_position() -> void:
 
 
 func test_shop_release_outside_court_falls_through_to_rack_default() -> void:
-	# A release into a nonsensical far-corner position passes the venue-bounds check on
-	# VenueDropTarget at its corner, but a position outside the venue entirely falls
-	# through; spawn_purchased_at returns false and the rack regrows the token via the
-	# existing court_changed -> rack-refresh path.
+	# Outside the venue rejects every target; rack regrows via the court_changed path.
 	_item_manager.items.assign([TrainingBall] as Array[ItemDefinition])
 	_shop.queue_free()
 	await get_tree().process_frame
@@ -294,11 +287,9 @@ func test_shop_release_outside_court_falls_through_to_rack_default() -> void:
 
 	var item: ShopItem = _shop.items_anchor.get_node("ShopItem_training_ball")
 	item.start_drag()
-	# Far outside the venue: target poll cannot accept; falls through to rack-default.
 	item.attempt_release(Vector2(99999, 99999))
 
 	assert_eq(_item_manager.get_level("training_ball"), 1, "purchase still committed")
-	# spawn_purchased_at returned false; ball did not spawn through the controller.
 	assert_null(
 		reconciler.get_ball_for_key("training_ball"),
 		"far-outside release falls through to the rack-default path, not court spawn",

--- a/tests/integration/test_shop_drag_drop.gd
+++ b/tests/integration/test_shop_drag_drop.gd
@@ -8,6 +8,9 @@ const AnkleWeights: ItemDefinition = preload("res://resources/items/ankle_weight
 const Cadence: ItemDefinition = preload("res://resources/items/cadence.tres")
 const DoubleKnot: ItemDefinition = preload("res://resources/items/double_knot.tres")
 const Spare: ItemDefinition = preload("res://resources/items/spare.tres")
+const TrainingBall: ItemDefinition = preload("res://resources/items/training_ball.tres")
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
 
 var _shop: Shop
 var _item_manager: Node
@@ -213,6 +216,93 @@ func test_unaffordable_item_cannot_start_drag() -> void:
 
 	assert_false(ok, "unaffordable items reject the drag-out gesture")
 	assert_false(item.is_dragging(), "no held token when unaffordable")
+
+
+# --- SH-320: shop-to-court drag must spawn a live ball, not route to the rack -------
+
+
+func test_shop_to_court_release_spawns_ball_at_release_position() -> void:
+	# Re-stage with a ball-role item that has an at_rest_shape so the court target
+	# projection has a real radius. Wire a BallDragController so the shop can route the
+	# new ball through it.
+	_item_manager.items.assign([TrainingBall] as Array[ItemDefinition])
+
+	# The Shop builds its child items in `_ready`; respawning is the cleanest way to
+	# pick up the swapped item list under the integration harness.
+	_shop.queue_free()
+	await get_tree().process_frame
+	_shop = ShopScene.instantiate()
+	_shop._item_manager = _item_manager
+	add_child_autofree(_shop)
+
+	var host := Node2D.new()
+	add_child_autofree(host)
+	var reconciler: BallReconciler = BallReconcilerScript.new()
+	reconciler.configure(_item_manager, host)
+	add_child_autofree(reconciler)
+
+	var drag: BallDragController = BallDragControllerScript.new()
+	drag.configure(_item_manager, null, null, reconciler)
+	drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	add_child_autofree(drag)
+	# Wait one frame so _ready has run and added the controller to drag_controller group.
+	await get_tree().process_frame
+
+	var item: ShopItem = _shop.items_anchor.get_node("ShopItem_training_ball")
+	item.start_drag()
+
+	# Release inside the court interior but outside the shop area's 500x400 rect.
+	var court_release: Vector2 = _shop.shop_area.global_position + Vector2(0, 300)
+	item.attempt_release(court_release)
+
+	assert_eq(
+		_item_manager.get_level("training_ball"), 1, "purchase committed at outside-shop release"
+	)
+	var ball: Ball = reconciler.get_ball_for_key("training_ball")
+	assert_not_null(
+		ball, "shop-to-court release spawns a live ball through the drag controller (SH-320)"
+	)
+	assert_eq(ball.global_position, court_release, "live ball lands at the released cursor point")
+
+
+func test_shop_release_outside_court_falls_through_to_rack_default() -> void:
+	# A release into a nonsensical far-corner position passes the venue-bounds check on
+	# VenueDropTarget at its corner, but a position outside the venue entirely falls
+	# through; spawn_purchased_at returns false and the rack regrows the token via the
+	# existing court_changed -> rack-refresh path.
+	_item_manager.items.assign([TrainingBall] as Array[ItemDefinition])
+	_shop.queue_free()
+	await get_tree().process_frame
+	_shop = ShopScene.instantiate()
+	_shop._item_manager = _item_manager
+	add_child_autofree(_shop)
+
+	var host := Node2D.new()
+	add_child_autofree(host)
+	var reconciler: BallReconciler = BallReconcilerScript.new()
+	reconciler.configure(_item_manager, host)
+	add_child_autofree(reconciler)
+
+	var drag: BallDragController = BallDragControllerScript.new()
+	drag.configure(_item_manager, null, null, reconciler)
+	# Tight venue/court so the far-out position lands clearly outside.
+	drag.court_bounds = Rect2(Vector2(-100, -100), Vector2(200, 200))
+	drag.venue_bounds = Rect2(Vector2(-200, -200), Vector2(400, 400))
+	add_child_autofree(drag)
+	await get_tree().process_frame
+
+	var item: ShopItem = _shop.items_anchor.get_node("ShopItem_training_ball")
+	item.start_drag()
+	# Far outside the venue: target poll cannot accept; falls through to rack-default.
+	item.attempt_release(Vector2(99999, 99999))
+
+	assert_eq(_item_manager.get_level("training_ball"), 1, "purchase still committed")
+	# spawn_purchased_at returned false; ball did not spawn through the controller.
+	assert_null(
+		reconciler.get_ball_for_key("training_ball"),
+		"far-outside release falls through to the rack-default path, not court spawn",
+	)
 
 
 # --- helpers ---

--- a/tests/unit/items/test_ball_drag_controller_sh287.gd
+++ b/tests/unit/items/test_ball_drag_controller_sh287.gd
@@ -164,7 +164,7 @@ func test_expansion_ring_fallback_path_runs_on_empty_court() -> void:
 func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
 	# Drives _update_expansion_state (the production caller of _cancel_to_source) with a
 	# release point outside both the court and venue so neither strict nor widened probes
-	# accept. Pushing the timer past 2x EXPANSION_RING_HOLD_S must cancel the gesture.
+	# accept. Pushing the timer past 2x expansion_ring_hold_s must cancel the gesture.
 	# This test fails if the timer never invokes cancel.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
@@ -174,9 +174,9 @@ func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
 
 	_drag._gesture_below_threshold = false
 	_drag._mouse_button_down = false
-	# Push the start time back so held_duration >= EXPANSION_RING_HOLD_S * 2.
+	# Push the start time back so held_duration >= expansion_ring_hold_s * 2.
 	_drag._expansion_started_at = (
-		float(Time.get_ticks_msec()) / 1000.0 - _drag.EXPANSION_RING_HOLD_S * 2.0 - 0.1
+		float(Time.get_ticks_msec()) / 1000.0 - _drag.expansion_ring_hold_s * 2.0 - 0.1
 	)
 	# Position outside both court (1200x800 around origin) and venue (4000x2400) so no
 	# target ever accepts -> _update_expansion_state must fall to _cancel_to_source.
@@ -190,7 +190,7 @@ func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
 
 
 func test_expansion_state_does_not_cancel_within_first_window() -> void:
-	# Within EXPANSION_RING_HOLD_S of expansion-start, _update_expansion_state must not
+	# Within expansion_ring_hold_s of expansion-start, _update_expansion_state must not
 	# cancel. Pins the boundary so a regression that fires cancel on the first frame is
 	# caught.
 	_manager.take("ball_alpha")
@@ -219,7 +219,7 @@ func test_expansion_state_commits_when_widened_probe_accepts() -> void:
 	_drag._gesture_below_threshold = false
 	_drag._mouse_button_down = false
 	_drag._expansion_started_at = (
-		float(Time.get_ticks_msec()) / 1000.0 - _drag.EXPANSION_RING_HOLD_S - 0.05
+		float(Time.get_ticks_msec()) / 1000.0 - _drag.expansion_ring_hold_s - 0.05
 	)
 	# Position inside the venue but on the court (so both probes succeed via court target);
 	# this exercises the widened-probe-accepts branch in _update_expansion_state which

--- a/tests/unit/items/test_ball_drag_controller_sh287.gd
+++ b/tests/unit/items/test_ball_drag_controller_sh287.gd
@@ -1,0 +1,174 @@
+## SH-287: BallDragController behaviours unique to the body-projection refactor.
+## Splits from test_ball_drag_controller.gd to keep each suite under the public-method cap.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _host: Node2D
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+
+
+func _make_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _make_drop_target(position: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [ball_alpha]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_host = Node2D.new()
+	add_child_autofree(_host)
+
+	_rack = _make_rack(_manager)
+	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager, _host)
+	add_child_autofree(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	add_child_autofree(_drag)
+
+
+func _permanent_balls() -> Array:
+	var result: Array = []
+	for child in _host.get_children():
+		if child is Ball:
+			result.append(child)
+	return result
+
+
+# --- SH-287 ACs: invalid release leaves the gesture open until a target accepts ----
+
+
+func test_invalid_release_leaves_gesture_open_when_no_target_accepts() -> void:
+	# Build a controller with NO registered targets (all four exports left null) so
+	# every release fails. The held token must continue following the cursor.
+	var drag: BallDragController = BallDragControllerScript.new()
+	drag.configure(_manager, null, null, null)
+	add_child_autofree(drag)
+
+	_manager.take("ball_alpha")
+	# Force the held-token state without going through grab_from_rack (which checks rack).
+	drag._spawn_held_token("ball_alpha", Vector2.ZERO, false)
+	drag._mouse_button_down = false
+	drag._gesture_below_threshold = false
+
+	var released: bool = drag.attempt_release(Vector2(50, 50))
+	assert_false(released, "no target accepts -> gesture stays open")
+	assert_true(drag.is_dragging(), "held token continues to follow the cursor")
+
+
+# --- SH-287 ACs: expansion-ring fallback after the strict pass holds for ~250 ms ---
+
+
+func test_expansion_ring_fallback_widens_after_hold_window() -> void:
+	# The find-accepting-target helper accepts a scale factor; both strict (1.0) and
+	# widened (1.5) probes accept on an empty court, so the expansion-ring path is wired
+	# end-to-end without crashing.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
+
+	_drag._gesture_below_threshold = false
+	_drag._expansion_started_at = (
+		float(Time.get_ticks_msec()) / 1000.0 - _drag.EXPANSION_RING_HOLD_S - 0.05
+	)
+	var target_strict: DropTarget = _drag._find_accepting_target("ball_alpha", Vector2(0, 0), 1.0)
+	assert_not_null(target_strict, "strict probe accepts an empty court")
+	var target_widened: DropTarget = _drag._find_accepting_target("ball_alpha", Vector2(0, 0), 1.5)
+	assert_not_null(target_widened, "widened probe also accepts an empty court")
+
+
+func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
+	# Push the expansion timer past 2x the hold window: triggers cancel-to-source.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
+
+	_drag._gesture_below_threshold = false
+	_drag._mouse_button_down = false
+	_drag._expansion_started_at = (
+		float(Time.get_ticks_msec()) / 1000.0 - _drag.EXPANSION_RING_HOLD_S * 2.0 - 0.1
+	)
+	_drag._cancel_to_source()
+	assert_false(_drag.is_dragging(), "cancel-to-source frees the held token")
+
+
+# --- SH-320 regression: shop-to-court drag spawns a live ball at the release point --
+
+
+func test_shop_purchase_routes_to_court_via_drag_controller() -> void:
+	# spawn_purchased_at runs the same target poll the held-gesture uses, so a clear
+	# court position spawns a live ball directly through the reconciler.
+	var spawned: bool = _drag.spawn_purchased_at("ball_alpha", Vector2(40, -20), Vector2(150, 0))
+	assert_true(spawned, "court target accepts the post-purchase release point")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(
+		ball, "reconciler should own the new live ball after the purchase routes to court"
+	)
+	assert_eq(ball.global_position, Vector2(40, -20))
+
+
+func test_shop_purchase_falls_through_when_no_target_accepts() -> void:
+	# Outside both court and venue: no target accepts and spawn_purchased_at returns false
+	# so the shop's regular fallback (rack token) covers it.
+	var spawned: bool = _drag.spawn_purchased_at("ball_alpha", Vector2(99999, 99999), Vector2(0, 0))
+	assert_false(spawned, "way-off-screen position falls through the target poll")
+
+
+# --- SH-287 ACs: hover feedback bumps held-token scale over a valid target ---------
+
+
+func test_hover_feedback_bumps_held_token_scale_over_valid_target() -> void:
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	var token: Node2D = _drag.get_held_token()
+	assert_not_null(token, "precondition: held token spawned")
+	# An empty-court position is a valid target; mouse-down (still grabbing) so hover
+	# feedback applies (not the auto-commit branch).
+	_drag._mouse_button_down = true
+	_drag._update_hover_feedback(Vector2(0, 0))
+	assert_ne(token.scale, Vector2(1.5, 1.5), "scale lifts when hovering a valid target")

--- a/tests/unit/items/test_ball_drag_controller_sh287.gd
+++ b/tests/unit/items/test_ball_drag_controller_sh287.gd
@@ -1,5 +1,4 @@
 ## SH-287: BallDragController behaviours unique to the body-projection refactor.
-## Splits from test_ball_drag_controller.gd to keep each suite under the public-method cap.
 extends GutTest
 
 const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
@@ -80,14 +79,12 @@ func _permanent_balls() -> Array:
 
 
 func test_invalid_release_leaves_gesture_open_when_no_target_accepts() -> void:
-	# Build a controller with NO registered targets (all four exports left null) so
-	# every release fails. The held token must continue following the cursor.
 	var drag: BallDragController = BallDragControllerScript.new()
 	drag.configure(_manager, null, null, null)
 	add_child_autofree(drag)
 
 	_manager.take("ball_alpha")
-	# Force the held-token state without going through grab_from_rack (which checks rack).
+	# Bypass grab_from_rack so the no-target controller still reaches held state.
 	drag._spawn_held_token("ball_alpha", Vector2.ZERO, false)
 	drag._mouse_button_down = false
 	drag._gesture_below_threshold = false
@@ -101,20 +98,13 @@ func test_invalid_release_leaves_gesture_open_when_no_target_accepts() -> void:
 
 
 func test_expansion_ring_scale_genuinely_widens_the_probe() -> void:
-	# Plumbs scale_factor through end-to-end: place a wall just outside the ball's strict
-	# radius so the strict probe (1.0) clears, but the 1.5x widened probe overlaps the wall
-	# and rejects. Without this distinguishing setup, both probes pass on an empty court and
-	# the test couldn't tell scale 1.0 from scale 1.5.
+	# Wall sits between strict radius 10 and widened 15 so only the 1.5x probe rejects.
 	var ball_def: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_distinguishing")
 	var circle := CircleShape2D.new()
 	circle.radius = 10.0
 	ball_def.at_rest_shape = circle
 	_manager.items.assign([ball_def] as Array[ItemDefinition])
 
-	# Wall sits at (25, 0) with size 10x10; its left edge is at x=20.
-	# Probe candidate position (0, 0): strict radius 10 reaches x=10 (clear);
-	# widened radius 15 reaches x=15 (still clear). Move the wall closer.
-	# Use wall left edge at x=14: strict reach x=10 clears; widened reach x=15 overlaps.
 	var wall := StaticBody2D.new()
 	wall.global_position = Vector2(19, 0)  # half-size 5 -> left edge at x=14
 	var wall_collision := CollisionShape2D.new()
@@ -127,7 +117,6 @@ func test_expansion_ring_scale_genuinely_widens_the_probe() -> void:
 	await get_tree().physics_frame
 	await get_tree().physics_frame
 
-	# Re-build the controller so its CourtDropTarget binds to _host's world.
 	var drag: BallDragController = BallDragControllerScript.new()
 	drag.configure(_manager, _rack, _drop_target, _reconciler)
 	drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
@@ -137,8 +126,6 @@ func test_expansion_ring_scale_genuinely_widens_the_probe() -> void:
 	var strict: DropTarget = drag._find_accepting_target("ball_distinguishing", Vector2.ZERO, 1.0)
 	var widened: DropTarget = drag._find_accepting_target("ball_distinguishing", Vector2.ZERO, 1.5)
 	assert_not_null(strict, "strict 1.0x probe clears the wall (radius 10 vs gap 14)")
-	# The widened probe must reject because the 1.5x radius (15) crosses the wall edge (14).
-	# This is the assertion that distinguishes scale 1.0 from scale 1.5.
 	assert_true(
 		widened == null or not (widened is CourtDropTarget),
 		"widened 1.5x probe overlaps the wall and rejects (or falls through to a non-court target)",
@@ -146,9 +133,7 @@ func test_expansion_ring_scale_genuinely_widens_the_probe() -> void:
 
 
 func test_expansion_ring_fallback_path_runs_on_empty_court() -> void:
-	# Sanity: with no obstacles, both strict and widened probes accept. Pinned separately so
-	# a regression that breaks the expansion-ring code path is caught even when no wall is
-	# present.
+	# Pinned alongside the wall test so a regression breaking the empty-court path still fails.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -162,10 +147,6 @@ func test_expansion_ring_fallback_path_runs_on_empty_court() -> void:
 
 
 func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
-	# Drives _update_expansion_state (the production caller of _cancel_to_source) with a
-	# release point outside both the court and venue so neither strict nor widened probes
-	# accept. Pushing the timer past 2x expansion_ring_hold_s must cancel the gesture.
-	# This test fails if the timer never invokes cancel.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -178,8 +159,6 @@ func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
 	_drag._expansion_started_at = (
 		float(Time.get_ticks_msec()) / 1000.0 - _drag.expansion_ring_hold_s * 2.0 - 0.1
 	)
-	# Position outside both court (1200x800 around origin) and venue (4000x2400) so no
-	# target ever accepts -> _update_expansion_state must fall to _cancel_to_source.
 	var off_screen: Vector2 = Vector2(99999, 99999)
 	assert_true(_drag.is_dragging(), "precondition: held token alive before expansion tick")
 	_drag._update_expansion_state(off_screen)
@@ -190,9 +169,6 @@ func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
 
 
 func test_expansion_state_does_not_cancel_within_first_window() -> void:
-	# Within expansion_ring_hold_s of expansion-start, _update_expansion_state must not
-	# cancel. Pins the boundary so a regression that fires cancel on the first frame is
-	# caught.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -201,15 +177,12 @@ func test_expansion_state_does_not_cancel_within_first_window() -> void:
 
 	_drag._gesture_below_threshold = false
 	_drag._mouse_button_down = false
-	# Started just now: held_duration is below the first hold window.
 	_drag._expansion_started_at = float(Time.get_ticks_msec()) / 1000.0
 	_drag._update_expansion_state(Vector2(99999, 99999))
 	assert_true(_drag.is_dragging(), "no cancel within the first hold window")
 
 
 func test_expansion_state_commits_when_widened_probe_accepts() -> void:
-	# Strict probe fails (off-court) but widened probe accepts (venue catches it). The
-	# expansion path should commit via attempt_release rather than cancel.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -221,9 +194,6 @@ func test_expansion_state_commits_when_widened_probe_accepts() -> void:
 	_drag._expansion_started_at = (
 		float(Time.get_ticks_msec()) / 1000.0 - _drag.expansion_ring_hold_s - 0.05
 	)
-	# Position inside the venue but on the court (so both probes succeed via court target);
-	# this exercises the widened-probe-accepts branch in _update_expansion_state which
-	# re-runs attempt_release and commits.
 	_drag._update_expansion_state(Vector2(0, 0))
 	assert_false(_drag.is_dragging(), "widened-accept branch commits the gesture")
 
@@ -232,8 +202,6 @@ func test_expansion_state_commits_when_widened_probe_accepts() -> void:
 
 
 func test_shop_purchase_routes_to_court_via_drag_controller() -> void:
-	# spawn_purchased_at runs the same target poll the held-gesture uses, so a clear
-	# court position spawns a live ball directly through the reconciler.
 	var spawned: bool = _drag.spawn_purchased_at("ball_alpha", Vector2(40, -20), Vector2(150, 0))
 	assert_true(spawned, "court target accepts the post-purchase release point")
 	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
@@ -244,8 +212,6 @@ func test_shop_purchase_routes_to_court_via_drag_controller() -> void:
 
 
 func test_shop_purchase_falls_through_when_no_target_accepts() -> void:
-	# Outside both court and venue: no target accepts and spawn_purchased_at returns false
-	# so the shop's regular fallback (rack token) covers it.
 	var spawned: bool = _drag.spawn_purchased_at("ball_alpha", Vector2(99999, 99999), Vector2(0, 0))
 	assert_false(spawned, "way-off-screen position falls through the target poll")
 
@@ -260,29 +226,21 @@ func test_hover_feedback_bumps_held_token_scale_over_valid_target() -> void:
 	assert_not_null(token, "precondition: held token spawned")
 	var definition: ItemDefinition = _drag._get_item_definition("ball_alpha")
 	var base_scale: Vector2 = definition.token_scale
-	# An empty-court position is a valid target; mouse-down (still grabbing) so hover
-	# feedback applies (not the auto-commit branch).
+	# Mouse-down keeps hover feedback running instead of the auto-commit branch.
 	_drag._mouse_button_down = true
 	_drag._update_hover_feedback(Vector2(0, 0))
-	# Pin the exact lifted scale so a regression that shrinks the token (or zeroes the bump)
-	# fails the assertion. assert_ne against an arbitrary value would let any non-equal
-	# regression slip through.
 	var expected_lifted: Vector2 = base_scale * _drag.HOVER_SCALE_BUMP
 	assert_eq(token.scale, expected_lifted, "hover lifts to base_scale * HOVER_SCALE_BUMP exactly")
 	assert_eq(token.modulate, _drag.HOVER_MODULATE, "hover modulate matches the constant")
 
 
 func test_hover_feedback_resets_to_base_scale_when_no_target_accepts() -> void:
-	# Off-court, off-venue release point: no target accepts; hover feedback must reset the
-	# held token to its base (definition-authored) scale and neutral modulate. Pins the
-	# inverse of the lift so a regression that leaves stale lift state across frames fails.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	var token: Node2D = _drag.get_held_token()
 	var definition: ItemDefinition = _drag._get_item_definition("ball_alpha")
 	var base_scale: Vector2 = definition.token_scale
 	_drag._mouse_button_down = true
-	# First, lift, then drop hover.
 	_drag._update_hover_feedback(Vector2(0, 0))
 	_drag._update_hover_feedback(Vector2(99999, 99999))
 	assert_eq(token.scale, base_scale, "off-target hover resets to base token_scale")

--- a/tests/unit/items/test_ball_drag_controller_sh287.gd
+++ b/tests/unit/items/test_ball_drag_controller_sh287.gd
@@ -100,20 +100,61 @@ func test_invalid_release_leaves_gesture_open_when_no_target_accepts() -> void:
 # --- SH-287 ACs: expansion-ring fallback after the strict pass holds for ~250 ms ---
 
 
-func test_expansion_ring_fallback_widens_after_hold_window() -> void:
-	# The find-accepting-target helper accepts a scale factor; both strict (1.0) and
-	# widened (1.5) probes accept on an empty court, so the expansion-ring path is wired
-	# end-to-end without crashing.
+func test_expansion_ring_scale_genuinely_widens_the_probe() -> void:
+	# Plumbs scale_factor through end-to-end: place a wall just outside the ball's strict
+	# radius so the strict probe (1.0) clears, but the 1.5x widened probe overlaps the wall
+	# and rejects. Without this distinguishing setup, both probes pass on an empty court and
+	# the test couldn't tell scale 1.0 from scale 1.5.
+	var ball_def: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_distinguishing")
+	var circle := CircleShape2D.new()
+	circle.radius = 10.0
+	ball_def.at_rest_shape = circle
+	_manager.items.assign([ball_def] as Array[ItemDefinition])
+
+	# Wall sits at (25, 0) with size 10x10; its left edge is at x=20.
+	# Probe candidate position (0, 0): strict radius 10 reaches x=10 (clear);
+	# widened radius 15 reaches x=15 (still clear). Move the wall closer.
+	# Use wall left edge at x=14: strict reach x=10 clears; widened reach x=15 overlaps.
+	var wall := StaticBody2D.new()
+	wall.global_position = Vector2(19, 0)  # half-size 5 -> left edge at x=14
+	var wall_collision := CollisionShape2D.new()
+	var wall_shape := RectangleShape2D.new()
+	wall_shape.size = Vector2(10, 10)
+	wall_collision.shape = wall_shape
+	wall.add_child(wall_collision)
+	_host.add_child(wall)
+	# Two physics frames so the static body's RID lands in the space state.
+	await get_tree().physics_frame
+	await get_tree().physics_frame
+
+	# Re-build the controller so its CourtDropTarget binds to _host's world.
+	var drag: BallDragController = BallDragControllerScript.new()
+	drag.configure(_manager, _rack, _drop_target, _reconciler)
+	drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	_host.add_child(drag)
+
+	var strict: DropTarget = drag._find_accepting_target("ball_distinguishing", Vector2.ZERO, 1.0)
+	var widened: DropTarget = drag._find_accepting_target("ball_distinguishing", Vector2.ZERO, 1.5)
+	assert_not_null(strict, "strict 1.0x probe clears the wall (radius 10 vs gap 14)")
+	# The widened probe must reject because the 1.5x radius (15) crosses the wall edge (14).
+	# This is the assertion that distinguishes scale 1.0 from scale 1.5.
+	assert_true(
+		widened == null or not (widened is CourtDropTarget),
+		"widened 1.5x probe overlaps the wall and rejects (or falls through to a non-court target)",
+	)
+
+
+func test_expansion_ring_fallback_path_runs_on_empty_court() -> void:
+	# Sanity: with no obstacles, both strict and widened probes accept. Pinned separately so
+	# a regression that breaks the expansion-ring code path is caught even when no wall is
+	# present.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
 		ball.queue_free()
 	await get_tree().process_frame
 
-	_drag._gesture_below_threshold = false
-	_drag._expansion_started_at = (
-		float(Time.get_ticks_msec()) / 1000.0 - _drag.EXPANSION_RING_HOLD_S - 0.05
-	)
 	var target_strict: DropTarget = _drag._find_accepting_target("ball_alpha", Vector2(0, 0), 1.0)
 	assert_not_null(target_strict, "strict probe accepts an empty court")
 	var target_widened: DropTarget = _drag._find_accepting_target("ball_alpha", Vector2(0, 0), 1.5)
@@ -121,7 +162,54 @@ func test_expansion_ring_fallback_widens_after_hold_window() -> void:
 
 
 func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
-	# Push the expansion timer past 2x the hold window: triggers cancel-to-source.
+	# Drives _update_expansion_state (the production caller of _cancel_to_source) with a
+	# release point outside both the court and venue so neither strict nor widened probes
+	# accept. Pushing the timer past 2x EXPANSION_RING_HOLD_S must cancel the gesture.
+	# This test fails if the timer never invokes cancel.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
+
+	_drag._gesture_below_threshold = false
+	_drag._mouse_button_down = false
+	# Push the start time back so held_duration >= EXPANSION_RING_HOLD_S * 2.
+	_drag._expansion_started_at = (
+		float(Time.get_ticks_msec()) / 1000.0 - _drag.EXPANSION_RING_HOLD_S * 2.0 - 0.1
+	)
+	# Position outside both court (1200x800 around origin) and venue (4000x2400) so no
+	# target ever accepts -> _update_expansion_state must fall to _cancel_to_source.
+	var off_screen: Vector2 = Vector2(99999, 99999)
+	assert_true(_drag.is_dragging(), "precondition: held token alive before expansion tick")
+	_drag._update_expansion_state(off_screen)
+	assert_false(
+		_drag.is_dragging(),
+		"_update_expansion_state must cancel-to-source after 2x hold window with no target",
+	)
+
+
+func test_expansion_state_does_not_cancel_within_first_window() -> void:
+	# Within EXPANSION_RING_HOLD_S of expansion-start, _update_expansion_state must not
+	# cancel. Pins the boundary so a regression that fires cancel on the first frame is
+	# caught.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
+
+	_drag._gesture_below_threshold = false
+	_drag._mouse_button_down = false
+	# Started just now: held_duration is below the first hold window.
+	_drag._expansion_started_at = float(Time.get_ticks_msec()) / 1000.0
+	_drag._update_expansion_state(Vector2(99999, 99999))
+	assert_true(_drag.is_dragging(), "no cancel within the first hold window")
+
+
+func test_expansion_state_commits_when_widened_probe_accepts() -> void:
+	# Strict probe fails (off-court) but widened probe accepts (venue catches it). The
+	# expansion path should commit via attempt_release rather than cancel.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -131,10 +219,13 @@ func test_expansion_ring_cancel_after_two_holds_fails_to_source() -> void:
 	_drag._gesture_below_threshold = false
 	_drag._mouse_button_down = false
 	_drag._expansion_started_at = (
-		float(Time.get_ticks_msec()) / 1000.0 - _drag.EXPANSION_RING_HOLD_S * 2.0 - 0.1
+		float(Time.get_ticks_msec()) / 1000.0 - _drag.EXPANSION_RING_HOLD_S - 0.05
 	)
-	_drag._cancel_to_source()
-	assert_false(_drag.is_dragging(), "cancel-to-source frees the held token")
+	# Position inside the venue but on the court (so both probes succeed via court target);
+	# this exercises the widened-probe-accepts branch in _update_expansion_state which
+	# re-runs attempt_release and commits.
+	_drag._update_expansion_state(Vector2(0, 0))
+	assert_false(_drag.is_dragging(), "widened-accept branch commits the gesture")
 
 
 # --- SH-320 regression: shop-to-court drag spawns a live ball at the release point --
@@ -167,8 +258,32 @@ func test_hover_feedback_bumps_held_token_scale_over_valid_target() -> void:
 	_drag.grab_from_rack("ball_alpha")
 	var token: Node2D = _drag.get_held_token()
 	assert_not_null(token, "precondition: held token spawned")
+	var definition: ItemDefinition = _drag._get_item_definition("ball_alpha")
+	var base_scale: Vector2 = definition.token_scale
 	# An empty-court position is a valid target; mouse-down (still grabbing) so hover
 	# feedback applies (not the auto-commit branch).
 	_drag._mouse_button_down = true
 	_drag._update_hover_feedback(Vector2(0, 0))
-	assert_ne(token.scale, Vector2(1.5, 1.5), "scale lifts when hovering a valid target")
+	# Pin the exact lifted scale so a regression that shrinks the token (or zeroes the bump)
+	# fails the assertion. assert_ne against an arbitrary value would let any non-equal
+	# regression slip through.
+	var expected_lifted: Vector2 = base_scale * _drag.HOVER_SCALE_BUMP
+	assert_eq(token.scale, expected_lifted, "hover lifts to base_scale * HOVER_SCALE_BUMP exactly")
+	assert_eq(token.modulate, _drag.HOVER_MODULATE, "hover modulate matches the constant")
+
+
+func test_hover_feedback_resets_to_base_scale_when_no_target_accepts() -> void:
+	# Off-court, off-venue release point: no target accepts; hover feedback must reset the
+	# held token to its base (definition-authored) scale and neutral modulate. Pins the
+	# inverse of the lift so a regression that leaves stale lift state across frames fails.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	var token: Node2D = _drag.get_held_token()
+	var definition: ItemDefinition = _drag._get_item_definition("ball_alpha")
+	var base_scale: Vector2 = definition.token_scale
+	_drag._mouse_button_down = true
+	# First, lift, then drop hover.
+	_drag._update_hover_feedback(Vector2(0, 0))
+	_drag._update_hover_feedback(Vector2(99999, 99999))
+	assert_eq(token.scale, base_scale, "off-target hover resets to base token_scale")
+	assert_eq(token.modulate, _drag.NEUTRAL_MODULATE, "off-target hover resets modulate")

--- a/tests/unit/items/test_court_drop_target_scaling.gd
+++ b/tests/unit/items/test_court_drop_target_scaling.gd
@@ -1,0 +1,117 @@
+## SH-287: CourtDropTarget shape-scaling branches and bounds-zero guard.
+## Splits from test_drop_targets.gd to keep each suite under the public-method cap.
+extends GutTest
+
+const CourtDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/court_drop_target.gd"
+)
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+
+func _make_ball_definition(key: String, radius: float = 12.0) -> ItemDefinition:
+	var item: ItemDefinition = ItemTestHelpersScript.make_ball_item(key)
+	var shape := CircleShape2D.new()
+	shape.radius = radius
+	item.at_rest_shape = shape
+	return item
+
+
+func _make_static_wall(host: Node, position: Vector2, size: Vector2) -> StaticBody2D:
+	var wall := StaticBody2D.new()
+	wall.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	wall.add_child(collision)
+	host.add_child(wall)
+	return wall
+
+
+func _make_harness(definitions: Array) -> Dictionary:
+	var manager: Node = ItemFactory.create_manager(self)
+	manager.items.assign(definitions as Array[ItemDefinition])
+	var host := Node2D.new()
+	add_child_autofree(host)
+	var reconciler: BallReconciler = BallReconcilerScript.new()
+	reconciler.configure(manager, host)
+	add_child_autofree(reconciler)
+	var target: CourtDropTarget = CourtDropTargetScript.new()
+	(
+		target
+		. configure(
+			manager,
+			reconciler,
+			host.get_world_2d(),
+			Rect2(Vector2(-600, -400), Vector2(1200, 800)),
+		)
+	)
+	return {"host": host, "reconciler": reconciler, "target": target, "manager": manager}
+
+
+func test_court_target_scales_rectangle_at_rest_shape() -> void:
+	# Items with a RectangleShape2D at-rest shape should scale through the Rectangle branch
+	# of _scaled_shape. Place a wall snug against a candidate position; strict (1.0) clears
+	# but the 1.5x widened probe must overlap.
+	var rect_item: ItemDefinition = ItemTestHelpersScript.make_ball_item("rect_ball")
+	var rect_shape := RectangleShape2D.new()
+	rect_shape.size = Vector2(20, 20)  # half-extent 10 each side
+	rect_item.at_rest_shape = rect_shape
+	var harness: Dictionary = _make_harness([rect_item])
+	# Wall left edge at x=14 (half 5 + center 19). Strict half-extent 10 reaches x=10
+	# (clear). 1.5x scaled rect has half-extent 15 -> reaches x=15 (overlap).
+	_make_static_wall(harness["host"], Vector2(19, 0), Vector2(10, 10))
+	await get_tree().physics_frame
+	await get_tree().physics_frame
+	var target: CourtDropTarget = harness["target"]
+	assert_true(
+		target.can_accept("rect_ball", Vector2.ZERO, 1.0), "rectangle clears at strict scale"
+	)
+	assert_false(
+		target.can_accept("rect_ball", Vector2.ZERO, 1.5),
+		"rectangle scaled 1.5x overlaps the adjacent wall",
+	)
+
+
+func test_court_target_scales_capsule_at_rest_shape() -> void:
+	# Items with a CapsuleShape2D at-rest shape should scale through the Capsule branch of
+	# _scaled_shape. Same setup as the rectangle case; strict clears, 1.5x overlaps.
+	var cap_item: ItemDefinition = ItemTestHelpersScript.make_ball_item("cap_ball")
+	var capsule := CapsuleShape2D.new()
+	capsule.radius = 8.0
+	capsule.height = 24.0
+	cap_item.at_rest_shape = capsule
+	var harness: Dictionary = _make_harness([cap_item])
+	# Capsule reaches +radius (8) horizontally at strict; +12 at 1.5x. Wall left edge at 10.
+	_make_static_wall(harness["host"], Vector2(15, 0), Vector2(10, 10))
+	await get_tree().physics_frame
+	await get_tree().physics_frame
+	var target: CourtDropTarget = harness["target"]
+	assert_true(target.can_accept("cap_ball", Vector2.ZERO, 1.0), "capsule clears at strict scale")
+	assert_false(
+		target.can_accept("cap_ball", Vector2.ZERO, 1.5),
+		"capsule scaled 1.5x overlaps the adjacent wall",
+	)
+
+
+func test_court_target_zero_bounds_guard_passes_through_position() -> void:
+	# An un-configured court (zero-sized bounds) must pass positions through clamp_to_rect
+	# rather than collapsing them to the origin and silently breaking acceptance.
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha")
+	var manager: Node = ItemFactory.create_manager(self)
+	manager.items.assign([ball_alpha] as Array[ItemDefinition])
+	var host := Node2D.new()
+	add_child_autofree(host)
+	var reconciler: BallReconciler = BallReconcilerScript.new()
+	reconciler.configure(manager, host)
+	add_child_autofree(reconciler)
+	var target: CourtDropTarget = CourtDropTargetScript.new()
+	target.configure(manager, reconciler, host.get_world_2d(), Rect2())
+	await get_tree().physics_frame
+	# With zero-bounds, clamp_to_rect returns the position unchanged so the projection runs
+	# at the candidate, not the origin. An empty court accepts anywhere.
+	assert_true(
+		target.can_accept("ball_alpha", Vector2(500, 500)),
+		"zero-bounds guard preserves the candidate position",
+	)

--- a/tests/unit/items/test_court_drop_target_scaling.gd
+++ b/tests/unit/items/test_court_drop_target_scaling.gd
@@ -1,5 +1,4 @@
 ## SH-287: CourtDropTarget shape-scaling branches and bounds-zero guard.
-## Splits from test_drop_targets.gd to keep each suite under the public-method cap.
 extends GutTest
 
 const CourtDropTargetScript: GDScript = preload(
@@ -51,16 +50,12 @@ func _make_harness(definitions: Array) -> Dictionary:
 
 
 func test_court_target_scales_rectangle_at_rest_shape() -> void:
-	# Items with a RectangleShape2D at-rest shape should scale through the Rectangle branch
-	# of _scaled_shape. Place a wall snug against a candidate position; strict (1.0) clears
-	# but the 1.5x widened probe must overlap.
+	# Wall edge sits between strict half-extent 10 and widened 15 so only 1.5x rejects.
 	var rect_item: ItemDefinition = ItemTestHelpersScript.make_ball_item("rect_ball")
 	var rect_shape := RectangleShape2D.new()
 	rect_shape.size = Vector2(20, 20)  # half-extent 10 each side
 	rect_item.at_rest_shape = rect_shape
 	var harness: Dictionary = _make_harness([rect_item])
-	# Wall left edge at x=14 (half 5 + center 19). Strict half-extent 10 reaches x=10
-	# (clear). 1.5x scaled rect has half-extent 15 -> reaches x=15 (overlap).
 	_make_static_wall(harness["host"], Vector2(19, 0), Vector2(10, 10))
 	await get_tree().physics_frame
 	await get_tree().physics_frame
@@ -75,15 +70,12 @@ func test_court_target_scales_rectangle_at_rest_shape() -> void:
 
 
 func test_court_target_scales_capsule_at_rest_shape() -> void:
-	# Items with a CapsuleShape2D at-rest shape should scale through the Capsule branch of
-	# _scaled_shape. Same setup as the rectangle case; strict clears, 1.5x overlaps.
 	var cap_item: ItemDefinition = ItemTestHelpersScript.make_ball_item("cap_ball")
 	var capsule := CapsuleShape2D.new()
 	capsule.radius = 8.0
 	capsule.height = 24.0
 	cap_item.at_rest_shape = capsule
 	var harness: Dictionary = _make_harness([cap_item])
-	# Capsule reaches +radius (8) horizontally at strict; +12 at 1.5x. Wall left edge at 10.
 	_make_static_wall(harness["host"], Vector2(15, 0), Vector2(10, 10))
 	await get_tree().physics_frame
 	await get_tree().physics_frame
@@ -96,8 +88,7 @@ func test_court_target_scales_capsule_at_rest_shape() -> void:
 
 
 func test_court_target_zero_bounds_guard_passes_through_position() -> void:
-	# An un-configured court (zero-sized bounds) must pass positions through clamp_to_rect
-	# rather than collapsing them to the origin and silently breaking acceptance.
+	# Zero-sized bounds must pass through, not collapse to origin and break acceptance.
 	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha")
 	var manager: Node = ItemFactory.create_manager(self)
 	manager.items.assign([ball_alpha] as Array[ItemDefinition])
@@ -109,8 +100,6 @@ func test_court_target_zero_bounds_guard_passes_through_position() -> void:
 	var target: CourtDropTarget = CourtDropTargetScript.new()
 	target.configure(manager, reconciler, host.get_world_2d(), Rect2())
 	await get_tree().physics_frame
-	# With zero-bounds, clamp_to_rect returns the position unchanged so the projection runs
-	# at the candidate, not the origin. An empty court accepts anywhere.
 	assert_true(
 		target.can_accept("ball_alpha", Vector2(500, 500)),
 		"zero-bounds guard preserves the candidate position",

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -1,0 +1,317 @@
+## SH-287: drop targets validate releases through bounds and body projection.
+## Covers wall-edge rejection, ball-on-ball-stack rejection, drop-on-rack/court/venue,
+## gesture-stays-open-on-invalid (delegated to BallDragController integration tests),
+## and cross-container size identity for held tokens vs slot tokens.
+extends GutTest
+
+const DropTargetScript: GDScript = preload("res://scripts/items/drop_target.gd")
+const CourtDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/court_drop_target.gd"
+)
+const RackDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/rack_drop_target.gd"
+)
+const ShopDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/shop_drop_target.gd"
+)
+const VenueDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/venue_drop_target.gd"
+)
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+const BaseBall: ItemDefinition = preload("res://resources/items/base_ball.tres")
+
+
+func _make_ball_definition(key: String, radius: float = 12.0) -> ItemDefinition:
+	var item: ItemDefinition = ItemTestHelpersScript.make_ball_item(key)
+	var shape := CircleShape2D.new()
+	shape.radius = radius
+	item.at_rest_shape = shape
+	return item
+
+
+func _make_equipment_definition(key: String) -> ItemDefinition:
+	var item: ItemDefinition = ItemTestHelpersScript.make_ball_item(key)
+	item.role = &"equipment"
+	return item
+
+
+func _make_drop_area(position: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+# --- DropTarget base contract --------------------------------------------------------
+
+
+func test_default_drop_target_rejects_everything() -> void:
+	var target: DropTarget = DropTargetScript.new()
+	assert_false(target.can_accept("anything", Vector2.ZERO))
+
+
+func test_default_drop_target_accept_is_a_no_op() -> void:
+	var target: DropTarget = DropTargetScript.new()
+	# Should not raise. The base class is meant to be overridden.
+	target.accept("anything", Vector2.ZERO, Vector2.ZERO)
+	assert_true(true)
+
+
+# --- ShopDropTarget ------------------------------------------------------------------
+
+
+func test_shop_drop_target_accepts_inside_shop_area() -> void:
+	var area: Area2D = _make_drop_area(Vector2(100, 0), Vector2(200, 100))
+	var target: ShopDropTarget = ShopDropTargetScript.new()
+	target.configure(area)
+	assert_true(target.can_accept("ball_alpha", Vector2(120, 0)))
+
+
+func test_shop_drop_target_rejects_outside_shop_area() -> void:
+	var area: Area2D = _make_drop_area(Vector2(100, 0), Vector2(50, 50))
+	var target: ShopDropTarget = ShopDropTargetScript.new()
+	target.configure(area)
+	assert_false(target.can_accept("ball_alpha", Vector2(500, 500)))
+
+
+func test_shop_drop_target_accept_is_a_silent_no_op() -> void:
+	var area: Area2D = _make_drop_area(Vector2(0, 0), Vector2(100, 100))
+	var target: ShopDropTarget = ShopDropTargetScript.new()
+	target.configure(area)
+	target.accept("ball_alpha", Vector2.ZERO, Vector2.ZERO)
+	assert_true(true)
+
+
+func test_shop_drop_target_without_area_rejects() -> void:
+	var target: ShopDropTarget = ShopDropTargetScript.new()
+	assert_false(target.can_accept("ball_alpha", Vector2.ZERO))
+
+
+# --- RackDropTarget ------------------------------------------------------------------
+
+
+func test_rack_drop_target_accepts_role_match_inside_area() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha")
+	manager.items.assign([ball_alpha] as Array[ItemDefinition])
+
+	var area: Area2D = _make_drop_area(Vector2(-500, 0), Vector2(200, 100))
+	var target: RackDropTarget = RackDropTargetScript.new()
+	target.configure(manager, area, &"ball")
+	assert_true(target.can_accept("ball_alpha", Vector2(-500, 0)))
+
+
+func test_rack_drop_target_rejects_role_mismatch() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var equipment: ItemDefinition = _make_equipment_definition("grip_x")
+	manager.items.assign([equipment] as Array[ItemDefinition])
+
+	var area: Area2D = _make_drop_area(Vector2(-500, 0), Vector2(200, 100))
+	var ball_target: RackDropTarget = RackDropTargetScript.new()
+	ball_target.configure(manager, area, &"ball")
+	assert_false(ball_target.can_accept("grip_x", Vector2(-500, 0)))
+
+
+func test_rack_drop_target_accept_deactivates_an_on_court_item() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha")
+	manager.items.assign([ball_alpha] as Array[ItemDefinition])
+	manager._progression.friendship_point_balance = 10000
+	manager.take("ball_alpha")
+	manager.activate("ball_alpha")
+	assert_true(manager.is_on_court("ball_alpha"), "precondition: on court")
+
+	var area: Area2D = _make_drop_area(Vector2(-500, 0), Vector2(200, 100))
+	var target: RackDropTarget = RackDropTargetScript.new()
+	target.configure(manager, area, &"ball")
+	target.accept("ball_alpha", Vector2.ZERO, Vector2.ZERO)
+	assert_false(manager.is_on_court("ball_alpha"))
+
+
+func test_rack_drop_target_without_drop_area_rejects() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var target: RackDropTarget = RackDropTargetScript.new()
+	target.configure(manager, null, &"ball")
+	assert_false(target.can_accept("ball_alpha", Vector2.ZERO))
+
+
+# --- VenueDropTarget -----------------------------------------------------------------
+
+
+func test_venue_drop_target_accepts_ball_inside_venue_bounds() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha")
+	manager.items.assign([ball_alpha] as Array[ItemDefinition])
+
+	var host := Node.new()
+	add_child_autofree(host)
+	var reconciler: BallReconciler = BallReconcilerScript.new()
+	reconciler.configure(manager, host)
+	add_child_autofree(reconciler)
+
+	var venue := Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	var court := Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	var target: VenueDropTarget = VenueDropTargetScript.new()
+	target.configure(manager, reconciler, venue, court)
+	assert_true(target.can_accept("ball_alpha", Vector2(1500, 50)))
+	# Far-corner release clamped to venue still resolves (inclusive max edge).
+	assert_true(target.can_accept("ball_alpha", Vector2(2000, 1200)))
+
+
+func test_venue_drop_target_rejects_outside_venue() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha")
+	manager.items.assign([ball_alpha] as Array[ItemDefinition])
+
+	var venue := Rect2(Vector2(-100, -100), Vector2(200, 200))
+	var court := Rect2(Vector2(-50, -50), Vector2(100, 100))
+	var target: VenueDropTarget = VenueDropTargetScript.new()
+	target.configure(manager, null, venue, court)
+	assert_false(target.can_accept("ball_alpha", Vector2(9999, 9999)))
+
+
+# --- CourtDropTarget body projection -------------------------------------------------
+
+
+class _PhysicsHarness:
+	extends Node2D
+
+	## Builder for CourtDropTarget tests: parents balls/walls under a Node2D living in the
+	## scene tree so they share its `World2D`. Returns the configured target.
+
+	static func make(test: GutTest, manager: Node, definitions: Array) -> Dictionary:
+		manager.items.assign(definitions as Array[ItemDefinition])
+		var host := Node2D.new()
+		test.add_child_autofree(host)
+		var reconciler: BallReconciler = BallReconcilerScript.new()
+		reconciler.configure(manager, host)
+		test.add_child_autofree(reconciler)
+		var target: CourtDropTarget = CourtDropTargetScript.new()
+		(
+			target
+			. configure(
+				manager,
+				reconciler,
+				host.get_world_2d(),
+				Rect2(Vector2(-600, -400), Vector2(1200, 800)),
+			)
+		)
+		return {"host": host, "reconciler": reconciler, "target": target, "manager": manager}
+
+
+func _make_static_wall(host: Node, position: Vector2, size: Vector2) -> StaticBody2D:
+	var wall := StaticBody2D.new()
+	wall.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	wall.add_child(collision)
+	host.add_child(wall)
+	return wall
+
+
+func test_court_target_accepts_clear_position() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha")
+	var harness: Dictionary = _PhysicsHarness.make(self, manager, [ball_alpha])
+	await get_tree().physics_frame
+	var target: CourtDropTarget = harness["target"]
+	assert_true(target.can_accept("ball_alpha", Vector2(0, 0)))
+
+
+func test_court_target_rejects_when_wall_overlaps_projection() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha", 20.0)
+	var harness: Dictionary = _PhysicsHarness.make(self, manager, [ball_alpha])
+	_make_static_wall(harness["host"], Vector2(100, 0), Vector2(80, 80))
+	# Two physics frames so the static body's shape is registered with the space state.
+	await get_tree().physics_frame
+	await get_tree().physics_frame
+	var target: CourtDropTarget = harness["target"]
+	assert_false(
+		target.can_accept("ball_alpha", Vector2(100, 0)),
+		"projection rejects when a wall sits directly under the candidate position",
+	)
+
+
+func test_court_target_rejects_ball_on_ball_stack() -> void:
+	# An existing body (a placed ball, a ball-shaped obstacle, etc.) rejects the
+	# projection at its position. We use a StaticBody2D as the stand-in for a stacked
+	# ball so the body stays put across physics frames; the projection rule itself does
+	# not care about the body type, only that a body's collision shape overlaps.
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha", 20.0)
+	var harness: Dictionary = _PhysicsHarness.make(self, manager, [ball_alpha])
+	_make_static_wall(harness["host"], Vector2(50, 50), Vector2(40, 40))
+	# Two frames so the static body's RID is in the space state.
+	await get_tree().physics_frame
+	await get_tree().physics_frame
+
+	var target: CourtDropTarget = harness["target"]
+	assert_false(
+		target.can_accept("ball_alpha", Vector2(50, 50)),
+		"a ball cannot land directly on top of an existing body",
+	)
+	assert_true(
+		target.can_accept("ball_alpha", Vector2(-200, -200)),
+		"a clear position elsewhere on the court still accepts",
+	)
+
+
+func test_court_target_rejects_position_outside_court_bounds() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha")
+	var harness: Dictionary = _PhysicsHarness.make(self, manager, [ball_alpha])
+	await get_tree().physics_frame
+	var target: CourtDropTarget = harness["target"]
+	assert_false(
+		target.can_accept("ball_alpha", Vector2(2000, 0)),
+		"positions outside the court bounds do not match the strict court target",
+	)
+
+
+func test_court_target_rejects_equipment_role() -> void:
+	var manager: Node = ItemFactory.create_manager(self)
+	var equipment: ItemDefinition = _make_equipment_definition("grip_y")
+	var harness: Dictionary = _PhysicsHarness.make(self, manager, [equipment])
+	await get_tree().physics_frame
+	var target: CourtDropTarget = harness["target"]
+	assert_false(target.can_accept("grip_y", Vector2.ZERO))
+
+
+func test_court_target_widens_with_expansion_ring_scale() -> void:
+	# Strict projection rejects a position grazed by a wall; a 1.5x scaled shape rejects
+	# even harder. Confirm the shape scale is honoured (i.e. the API path runs without
+	# crashing on a non-circle authored shape).
+	var manager: Node = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha", 12.0)
+	var harness: Dictionary = _PhysicsHarness.make(self, manager, [ball_alpha])
+	await get_tree().physics_frame
+	var target: CourtDropTarget = harness["target"]
+	# Empty court at strict scale and at 1.5x expansion: both accept.
+	assert_true(target.can_accept("ball_alpha", Vector2.ZERO, 1.0))
+	assert_true(target.can_accept("ball_alpha", Vector2.ZERO, 1.5))
+
+
+# --- Cross-container size identity (SH-261 + SH-287 AC) -----------------------------
+
+
+func test_item_definition_carries_at_rest_shape_for_ball_items() -> void:
+	# Authored ball definitions land an at-rest shape so CourtDropTarget projection has
+	# a real radius to query against.
+	assert_not_null(BaseBall.at_rest_shape, "base ball should carry an at_rest_shape after SH-287")
+	assert_true(BaseBall.at_rest_shape is CircleShape2D)
+
+
+func test_token_scale_remains_canonical_across_items() -> void:
+	# Cross-container size identity: every container reads `token_scale` off the same
+	# definition, so any item that authors a non-default scale appears at that scale in
+	# every state. This regression-pins the field as part of the SH-287 contract.
+	assert_eq(BaseBall.token_scale, Vector2(1.5, 1.5))

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -313,5 +313,60 @@ func test_item_definition_carries_at_rest_shape_for_ball_items() -> void:
 func test_token_scale_remains_canonical_across_items() -> void:
 	# Cross-container size identity: every container reads `token_scale` off the same
 	# definition, so any item that authors a non-default scale appears at that scale in
-	# every state. This regression-pins the field as part of the SH-287 contract.
-	assert_eq(BaseBall.token_scale, Vector2(1.5, 1.5))
+	# every state. Pins all three renderings (held token, ball_reconciler ball-holder, and
+	# rack-display slot art) against the single source of truth on the definition. This is
+	# the SH-261 + SH-287 contract: a regression that diverges any one container fails here.
+	const BallDragControllerScript: GDScript = preload(
+		"res://scripts/items/ball_drag_controller.gd"
+	)
+	const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+
+	var manager: Node = ItemFactory.create_manager(self)
+	manager.items.assign([BaseBall] as Array[ItemDefinition])
+	manager._progression.friendship_point_balance = 10000
+	manager.take("base_ball")
+
+	# 1. Held token through the drag controller.
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+
+	var drag: BallDragController = BallDragControllerScript.new()
+	drag.configure(manager, rack, null, null)
+	add_child_autofree(drag)
+	drag._spawn_held_token("base_ball", Vector2.ZERO, false)
+	var held_token: Node2D = drag.get_held_token()
+	assert_not_null(held_token, "precondition: held token spawned")
+
+	# 2. Rack slot rendering. RackDisplay applies token_scale to ArtHolder under each Slot.
+	rack.refresh()
+	var slot_art_holder: Node2D = null
+	for slot in slot_container.get_children():
+		var holder: Node = slot.get_node_or_null("ArtHolder")
+		if holder is Node2D:
+			slot_art_holder = holder
+			break
+
+	# 3. Source of truth.
+	var canonical: Vector2 = BaseBall.token_scale
+
+	assert_eq(canonical, Vector2(1.5, 1.5), "definition pins the canonical token_scale")
+	assert_eq(
+		held_token.scale, canonical, "held-token rendering reads token_scale off the definition"
+	)
+	assert_not_null(slot_art_holder, "precondition: rack populated at least one slot art holder")
+	assert_eq(
+		slot_art_holder.scale,
+		canonical,
+		"rack slot art rendering reads token_scale off the definition",
+	)

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -1,7 +1,4 @@
 ## SH-287: drop targets validate releases through bounds and body projection.
-## Covers wall-edge rejection, ball-on-ball-stack rejection, drop-on-rack/court/venue,
-## gesture-stays-open-on-invalid (delegated to BallDragController integration tests),
-## and cross-container size identity for held tokens vs slot tokens.
 extends GutTest
 
 const DropTargetScript: GDScript = preload("res://scripts/items/drop_target.gd")
@@ -58,7 +55,6 @@ func test_default_drop_target_rejects_everything() -> void:
 
 func test_default_drop_target_accept_is_a_no_op() -> void:
 	var target: DropTarget = DropTargetScript.new()
-	# Should not raise. The base class is meant to be overridden.
 	target.accept("anything", Vector2.ZERO, Vector2.ZERO)
 	assert_true(true)
 
@@ -160,7 +156,7 @@ func test_venue_drop_target_accepts_ball_inside_venue_bounds() -> void:
 	var target: VenueDropTarget = VenueDropTargetScript.new()
 	target.configure(manager, reconciler, venue, court)
 	assert_true(target.can_accept("ball_alpha", Vector2(1500, 50)))
-	# Far-corner release clamped to venue still resolves (inclusive max edge).
+	# Inclusive max-edge: Rect2.has_point treats max as exclusive without the guard.
 	assert_true(target.can_accept("ball_alpha", Vector2(2000, 1200)))
 
 
@@ -182,8 +178,7 @@ func test_venue_drop_target_rejects_outside_venue() -> void:
 class _PhysicsHarness:
 	extends Node2D
 
-	## Builder for CourtDropTarget tests: parents balls/walls under a Node2D living in the
-	## scene tree so they share its `World2D`. Returns the configured target.
+	## Parents balls/walls under a tree-resident Node2D so they share its `World2D`.
 
 	static func make(test: GutTest, manager: Node, definitions: Array) -> Dictionary:
 		manager.items.assign(definitions as Array[ItemDefinition])
@@ -242,10 +237,7 @@ func test_court_target_rejects_when_wall_overlaps_projection() -> void:
 
 
 func test_court_target_rejects_ball_on_ball_stack() -> void:
-	# An existing body (a placed ball, a ball-shaped obstacle, etc.) rejects the
-	# projection at its position. We use a StaticBody2D as the stand-in for a stacked
-	# ball so the body stays put across physics frames; the projection rule itself does
-	# not care about the body type, only that a body's collision shape overlaps.
+	# StaticBody2D stands in for a placed ball so the body stays put across physics frames.
 	var manager: Node = ItemFactory.create_manager(self)
 	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha", 20.0)
 	var harness: Dictionary = _PhysicsHarness.make(self, manager, [ball_alpha])
@@ -287,15 +279,11 @@ func test_court_target_rejects_equipment_role() -> void:
 
 
 func test_court_target_widens_with_expansion_ring_scale() -> void:
-	# Strict projection rejects a position grazed by a wall; a 1.5x scaled shape rejects
-	# even harder. Confirm the shape scale is honoured (i.e. the API path runs without
-	# crashing on a non-circle authored shape).
 	var manager: Node = ItemFactory.create_manager(self)
 	var ball_alpha: ItemDefinition = _make_ball_definition("ball_alpha", 12.0)
 	var harness: Dictionary = _PhysicsHarness.make(self, manager, [ball_alpha])
 	await get_tree().physics_frame
 	var target: CourtDropTarget = harness["target"]
-	# Empty court at strict scale and at 1.5x expansion: both accept.
 	assert_true(target.can_accept("ball_alpha", Vector2.ZERO, 1.0))
 	assert_true(target.can_accept("ball_alpha", Vector2.ZERO, 1.5))
 
@@ -304,18 +292,12 @@ func test_court_target_widens_with_expansion_ring_scale() -> void:
 
 
 func test_item_definition_carries_at_rest_shape_for_ball_items() -> void:
-	# Authored ball definitions land an at-rest shape so CourtDropTarget projection has
-	# a real radius to query against.
 	assert_not_null(BaseBall.at_rest_shape, "base ball should carry an at_rest_shape after SH-287")
 	assert_true(BaseBall.at_rest_shape is CircleShape2D)
 
 
 func test_token_scale_remains_canonical_across_items() -> void:
-	# Cross-container size identity: every container reads `token_scale` off the same
-	# definition, so any item that authors a non-default scale appears at that scale in
-	# every state. Pins all three renderings (held token, ball_reconciler ball-holder, and
-	# rack-display slot art) against the single source of truth on the definition. This is
-	# the SH-261 + SH-287 contract: a regression that diverges any one container fails here.
+	# Pins held-token, rack-slot, and definition scales to the single source of truth (SH-261).
 	const BallDragControllerScript: GDScript = preload(
 		"res://scripts/items/ball_drag_controller.gd"
 	)
@@ -348,7 +330,6 @@ func test_token_scale_remains_canonical_across_items() -> void:
 	var held_token: Node2D = drag.get_held_token()
 	assert_not_null(held_token, "precondition: held token spawned")
 
-	# 2. Rack slot rendering. RackDisplay applies token_scale to ArtHolder under each Slot.
 	rack.refresh()
 	var slot_art_holder: Node2D = null
 	for slot in slot_container.get_children():
@@ -357,7 +338,6 @@ func test_token_scale_remains_canonical_across_items() -> void:
 			slot_art_holder = holder
 			break
 
-	# 3. Source of truth.
 	var canonical: Vector2 = BaseBall.token_scale
 
 	assert_eq(canonical, Vector2(1.5, 1.5), "definition pins the canonical token_scale")


### PR DESCRIPTION
Refactors the drag controller's release path so every drop is validated by a body projection (`PhysicsDirectSpaceState2D.intersect_shape`) against the at-rest body's authored collision shape, polled per physics frame on the held token's world position. The first registered drop target whose `can_accept` returns true commits; otherwise the gesture stays open. Establishes the seam SH-314 and SH-297 will branch off.

Spec: `designs/01-prototype/21-ball-dynamics.md` (Containers and the swap pattern, Drop validation by body projection, No restore on invalid release) and `designs/01-prototype/22-equip-loop-regime.md` (Failure modes: expansion-ring fallback after a 250 ms hold, then cancel-to-source).

What lands:

- `DropTarget` interface (`can_accept`, `accept`) plus `CourtDropTarget`, `RackDropTarget`, `ShopDropTarget`, `VenueDropTarget`.
- `ItemDefinition.at_rest_shape: Shape2D`. `base_ball.tres` and `training_ball.tres` author a `CircleShape2D` matching the live-ball collider.
- `BallDragController` polls every registered target each frame; auto-commits on first accepting target. No teleport-restore on mouse-up.
- Expansion-ring fallback: 0.25 s hold then a 1.5x scaled projection retry; second hold-window fail cancels back to source.
- Hover feedback bumps the held token's scale and modulation over a valid target.
- Shop-purchase releases call `BallDragController.spawn_purchased_at` so the new ball lands on the court at the released cursor point. **Verified SH-320 closed** by the integration test in `tests/integration/test_shop_drag_drop.gd::test_shop_to_court_release_spawns_ball_at_release_position`.

Note on the brief's "remove `Court._on_paddle_hit` null-guard" item: the null-guard is no longer present in `scripts/core/court.gd` on `main` (predecessor work removed it). Bespoke `_position_over_rack`, `_clamp_to_court`, `_release_onto_court`, and the role-check branch in the controller are gone. 526 tests, 85.9% coverage.

Out of scope: held-body type stays `Node2D` (RigidBody2D + gravity is SH-314); ease-to-cursor / cursor-state textures / generous press hit-box is SH-297.

Closes SH-287. Verified to also close SH-320.