### PR TITLE
SH-297 grab feel: ease to cursor, hit-box, cursor states

### DIFF
--- a/ai/PARALLEL.md
+++ b/ai/PARALLEL.md
@@ -124,6 +124,7 @@ The Active table on `origin/main` is the source of truth. A fresh worktree reads
 | Feldspar | SH-107 | sh-107-court-bounds-and-miss | designs/01-prototype/08-court-bounds.md | 2026-04-21 | spike: bounds, miss, rest, upgrade path |
 | Ford | SH-169 | sh-169-prefix-pr-comments-with-commenter-name | ai/PARALLEL.md, ai/swarm/README.md, scripts/swarm/post-review.sh | 2026-04-21 | commenter-name prefix on PR comments |
 | Slartibartfast | SH-100 | feature/sh-100-shop-arrivals-inactive | tests/integration/test_shop_arrivals_inactive.gd, ai/PARALLEL.md | 2026-04-23 | shop arrivals land inactive on rack |
+| Abe | SH-297 | feature/sh-297-grab-feel-ease-to-cursor-hit-box-cursor-states | scripts/items/ball_drag_controller.gd, scripts/entities/ball.gd, scripts/hud/cursor_overlay.gd, scenes/court.tscn, scenes/ball.tscn | 2026-04-28 | grab ease-to-cursor + press hit-box + cursor state machine; runs alongside SH-287 PR #533 |
 
 ## Done (recent)
 
@@ -143,6 +144,7 @@ The Active table on `origin/main` is the source of truth. A fresh worktree reads
 Newest at top. One line per event.
 
 ```
+[SH-297] abe: claimed; implementing grab ease-to-cursor tween, generous live-ball press hit-box, cursor state machine + Node2D overlay placeholder; cursor-state poll stubbed to be wired to manny's _find_accepting_target on merge of #533
 [SH-100] slartibartfast: claimed; SH-96 activate/deactivate and SH-99 rack display already land the behavior, adding integration tests to pin shop->rack and dev-panel purchase flows
 [SH-80] glottis: claimed; drafting tech-pipeline.md partner doc to the bible
 [SH-88] Riebeck: claim; drafting ball speed tier design doc

--- a/resources/hud/cursor_overlay_palette.tres
+++ b/resources/hud/cursor_overlay_palette.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Resource" script_class="CursorOverlayPalette" format=3 uid="uid://d24d8dno1pta4"]
+
+[ext_resource type="Script" uid="uid://m2m8ydruyqtw7" path="res://scripts/hud/cursor_overlay_palette.gd" id="1_palet"]
+
+[resource]
+script = ExtResource("1_palet")

--- a/scenes/ball.tscn
+++ b/scenes/ball.tscn
@@ -9,10 +9,11 @@
 [sub_resource type="CircleShape2D" id="CircleShape2D_press"]
 radius = 11.52
 
-[node name="Ball" type="RigidBody2D" unique_id=1842167380]
+[node name="Ball" type="RigidBody2D" unique_id=1842167380 node_paths=PackedStringArray("press_area")]
 physics_material_override = ExtResource("1_cxlvu")
 gravity_scale = 0.0
 script = ExtResource("1_7s4qf")
+press_area = NodePath("PressArea")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=160689379]
 scale = Vector2(0.72, 0.72)

--- a/scenes/ball.tscn
+++ b/scenes/ball.tscn
@@ -6,6 +6,9 @@
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_n1dj2"]
 
+[sub_resource type="CircleShape2D" id="CircleShape2D_press"]
+radius = 11.52
+
 [node name="Ball" type="RigidBody2D" unique_id=1842167380]
 physics_material_override = ExtResource("1_cxlvu")
 gravity_scale = 0.0
@@ -20,3 +23,11 @@ scale = Vector2(0.12, 0.12)
 texture = ExtResource("3_f7cbr")
 
 [node name="ItemArtHolder" type="Node2D" parent="." unique_id=429755373]
+
+[node name="PressArea" type="Area2D" parent="." unique_id=429755374]
+input_pickable = true
+monitoring = false
+monitorable = false
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PressArea" unique_id=429755375]
+shape = SubResource("CircleShape2D_press")

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -22,6 +22,7 @@
 [ext_resource type="Script" uid="uid://dkqyrxx74rbvd" path="res://scripts/items/ball_reconciler.gd" id="21_reconciler"]
 [ext_resource type="Script" uid="uid://ddo3h77danynw" path="res://scripts/items/ball_drag_controller.gd" id="22_drag"]
 [ext_resource type="Script" uid="uid://dwy6ux1ak8r6m" path="res://scripts/court/ball_tracker.gd" id="23_tracker"]
+[ext_resource type="Script" path="res://scripts/hud/cursor_overlay.gd" id="24_cursor"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_horz"]
 size = Vector2(21.6, 883.2)
@@ -217,7 +218,7 @@ script = ExtResource("21_reconciler")
 script = ExtResource("23_tracker")
 ball_system = NodePath("../BallReconciler")
 
-[node name="BallDragController" type="Node2D" parent="." unique_id=1902001002 node_paths=PackedStringArray("rack", "rack_drop_target", "gear_rack", "gear_rack_drop_target", "reconciler")]
+[node name="BallDragController" type="Node2D" parent="." unique_id=1902001002 node_paths=PackedStringArray("rack", "rack_drop_target", "gear_rack", "gear_rack_drop_target", "reconciler", "cursor_overlay")]
 script = ExtResource("22_drag")
 rack = NodePath("../BallRack")
 rack_drop_target = NodePath("../BallRack/DropTarget")
@@ -226,3 +227,7 @@ gear_rack_drop_target = NodePath("../GearRack/DropTarget")
 court_bounds = Rect2(-420, -360, 840, 720)
 venue_bounds = Rect2(-1200, -720, 2400, 1440)
 reconciler = NodePath("../BallReconciler")
+cursor_overlay = NodePath("CursorOverlay")
+
+[node name="CursorOverlay" type="Node2D" parent="BallDragController" unique_id=1902001004]
+script = ExtResource("24_cursor")

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -22,7 +22,7 @@
 [ext_resource type="Script" uid="uid://dkqyrxx74rbvd" path="res://scripts/items/ball_reconciler.gd" id="21_reconciler"]
 [ext_resource type="Script" uid="uid://ddo3h77danynw" path="res://scripts/items/ball_drag_controller.gd" id="22_drag"]
 [ext_resource type="Script" uid="uid://dwy6ux1ak8r6m" path="res://scripts/court/ball_tracker.gd" id="23_tracker"]
-[ext_resource type="Script" path="res://scripts/hud/cursor_overlay.gd" id="24_cursor"]
+[ext_resource type="Script" uid="uid://bqbdbfpsxq5qo" path="res://scripts/hud/cursor_overlay.gd" id="24_cursor"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_horz"]
 size = Vector2(21.6, 883.2)

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -22,7 +22,7 @@
 [ext_resource type="Script" uid="uid://dkqyrxx74rbvd" path="res://scripts/items/ball_reconciler.gd" id="21_reconciler"]
 [ext_resource type="Script" uid="uid://ddo3h77danynw" path="res://scripts/items/ball_drag_controller.gd" id="22_drag"]
 [ext_resource type="Script" uid="uid://dwy6ux1ak8r6m" path="res://scripts/court/ball_tracker.gd" id="23_tracker"]
-[ext_resource type="Script" uid="uid://bqbdbfpsxq5qo" path="res://scripts/hud/cursor_overlay.gd" id="24_cursor"]
+[ext_resource type="PackedScene" uid="uid://dq3kw7n8sh297" path="res://scenes/hud/cursor_overlay.tscn" id="24_cursor"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_horz"]
 size = Vector2(21.6, 883.2)
@@ -229,5 +229,4 @@ venue_bounds = Rect2(-1200, -720, 2400, 1440)
 reconciler = NodePath("../BallReconciler")
 cursor_overlay = NodePath("CursorOverlay")
 
-[node name="CursorOverlay" type="Node2D" parent="BallDragController" unique_id=1902001004]
-script = ExtResource("24_cursor")
+[node name="CursorOverlay" parent="BallDragController" instance=ExtResource("24_cursor")]

--- a/scenes/hud/cursor_overlay.tscn
+++ b/scenes/hud/cursor_overlay.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://dq3kw7n8sh297"]
+[gd_scene load_steps=3 format=3 uid="uid://dq3kw7n8sh297"]
 
 [ext_resource type="Script" uid="uid://bqbdbfpsxq5qo" path="res://scripts/hud/cursor_overlay.gd" id="1_cursor"]
+[ext_resource type="Resource" uid="uid://d24d8dno1pta4" path="res://resources/hud/cursor_overlay_palette.tres" id="2_palet"]
 
 [node name="CursorOverlay" type="Node2D"]
 script = ExtResource("1_cursor")
+palette = ExtResource("2_palet")

--- a/scenes/hud/cursor_overlay.tscn
+++ b/scenes/hud/cursor_overlay.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dq3kw7n8sh297"]
+
+[ext_resource type="Script" uid="uid://bqbdbfpsxq5qo" path="res://scripts/hud/cursor_overlay.gd" id="1_cursor"]
+
+[node name="CursorOverlay" type="Node2D"]
+script = ExtResource("1_cursor")

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -11,7 +11,7 @@ const SPEED_EMIT_THRESHOLD := 10.0
 ## Item key this ball represents; the system reads this on adoption to find the matching ItemDefinition.
 @export var item_key: String = ""
 ## Press hit-box radius multiplier on the authored collider; tunable per-instance for forgiving grabs.
-@export var press_hitbox_inflation: float = 1.6
+@export_range(1.0, 4.0, 0.1) var press_hitbox_inflation: float = 1.6
 
 var speed: float = 0.0
 var min_speed: float
@@ -124,29 +124,30 @@ func _setup_effect_processor() -> void:
 	add_child(effect_processor)
 
 
-func _setup_press_area() -> void:
-	if _press_area != null and is_instance_valid(_press_area):
+func _wire_press_area() -> void:
+	var area: Area2D = get_node_or_null("PressArea") as Area2D
+	if area == null:
 		return
-	var press_radius: float = _authored_collision_radius() * press_hitbox_inflation
-	if press_radius <= 0.0:
-		return
-	var area: Area2D = Area2D.new()
-	area.name = "PressArea"
-	area.input_pickable = true
-	area.monitoring = false
-	area.monitorable = false
-	var shape_node: CollisionShape2D = CollisionShape2D.new()
-	var circle: CircleShape2D = CircleShape2D.new()
-	circle.radius = press_radius
-	shape_node.shape = circle
-	area.add_child(shape_node)
-	add_child(area)
+	_press_area = area
+	var press_shape: CollisionShape2D = null
+	for child in area.get_children():
+		if child is CollisionShape2D:
+			press_shape = child
+			break
+	if press_shape != null:
+		var circle: CircleShape2D = press_shape.shape as CircleShape2D
+		if circle != null:
+			var authored_radius: float = _baseline_collision_radius()
+			if authored_radius > 0.0:
+				# Duplicate so per-instance inflation does not mutate the shared sub-resource.
+				var local_circle: CircleShape2D = circle.duplicate() as CircleShape2D
+				local_circle.radius = authored_radius * press_hitbox_inflation
+				press_shape.shape = local_circle
 	if not area.input_event.is_connected(_on_input_event):
 		area.input_event.connect(_on_input_event)
-	_press_area = area
 
 
-func _authored_collision_radius() -> float:
+func _baseline_collision_radius() -> float:
 	for child in get_children():
 		if child is CollisionShape2D:
 			var shape_node: CollisionShape2D = child
@@ -155,7 +156,6 @@ func _authored_collision_radius() -> float:
 				continue
 			var axis_scale: float = maxf(absf(shape_node.scale.x), absf(shape_node.scale.y))
 			return circle.radius * maxf(axis_scale, 0.001)
-	# No authored CircleShape2D; press area skips construction on radius <= 0.
 	return 0.0
 
 
@@ -175,7 +175,7 @@ func _ball_setup() -> void:
 	input_pickable = false
 	if input_event.is_connected(_on_input_event):
 		input_event.disconnect(_on_input_event)
-	_setup_press_area()
+	_wire_press_area()
 
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -12,6 +12,8 @@ const SPEED_EMIT_THRESHOLD := 10.0
 @export var item_key: String = ""
 ## Press hit-box radius multiplier on the authored collider; tunable per-instance for forgiving grabs.
 @export_range(1.0, 4.0, 0.1) var press_hitbox_inflation: float = 1.6
+## Authored Area2D that routes pointer presses; wired from the scene so the press hit-box stays scene-based.
+@export var press_area: Area2D
 
 var speed: float = 0.0
 var min_speed: float
@@ -25,7 +27,6 @@ var _was_at_max_speed := false
 var _last_emitted_speed: float = 0.0
 var _last_emitted_min: float = 0.0
 var _last_emitted_max: float = 0.0
-var _press_area: Area2D
 
 
 func _ready() -> void:
@@ -125,12 +126,10 @@ func _setup_effect_processor() -> void:
 
 
 func _wire_press_area() -> void:
-	var area: Area2D = get_node_or_null("PressArea") as Area2D
-	if area == null:
+	if press_area == null:
 		return
-	_press_area = area
 	var press_shape: CollisionShape2D = null
-	for child in area.get_children():
+	for child in press_area.get_children():
 		if child is CollisionShape2D:
 			press_shape = child
 			break
@@ -143,8 +142,8 @@ func _wire_press_area() -> void:
 				var local_circle: CircleShape2D = circle.duplicate() as CircleShape2D
 				local_circle.radius = authored_radius * press_hitbox_inflation
 				press_shape.shape = local_circle
-	if not area.input_event.is_connected(_on_input_event):
-		area.input_event.connect(_on_input_event)
+	if not press_area.input_event.is_connected(_on_input_event):
+		press_area.input_event.connect(_on_input_event)
 
 
 func _baseline_collision_radius() -> float:

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -7,11 +7,11 @@ signal speed_changed(speed: float, min_speed: float, max_speed: float)
 signal pressed(ball: Ball)
 
 const SPEED_EMIT_THRESHOLD := 10.0
-## Tuning surface for the press hit-box; do not couple to physics-collider scale.
-const PRESS_HITBOX_INFLATION: float = 1.6
 
 ## Item key this ball represents; the system reads this on adoption to find the matching ItemDefinition.
 @export var item_key: String = ""
+## Press hit-box radius multiplier on the authored collider; tunable per-instance for forgiving grabs.
+@export var press_hitbox_inflation: float = 1.6
 
 var speed: float = 0.0
 var min_speed: float
@@ -127,7 +127,7 @@ func _setup_effect_processor() -> void:
 func _setup_press_area() -> void:
 	if _press_area != null and is_instance_valid(_press_area):
 		return
-	var press_radius: float = _authored_collision_radius() * PRESS_HITBOX_INFLATION
+	var press_radius: float = _authored_collision_radius() * press_hitbox_inflation
 	if press_radius <= 0.0:
 		return
 	var area: Area2D = Area2D.new()

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -8,6 +8,11 @@ signal speed_changed(speed: float, min_speed: float, max_speed: float)
 signal pressed(ball: Ball)
 
 const SPEED_EMIT_THRESHOLD := 10.0
+## SH-297: factor by which the press hit-box inflates the ball's authored physics radius.
+## A live ball is small and moving, so a pixel-precise press misses more often than not.
+## Inflating the press surface (without touching the physics shape) lets a press near a
+## moving ball land cleanly. Tune surface; do not couple to physics-collider scale.
+const PRESS_HITBOX_INFLATION: float = 1.6
 
 ## Item key this ball represents; the system reads this on adoption to find the matching ItemDefinition.
 @export var item_key: String = ""
@@ -24,6 +29,10 @@ var _was_at_max_speed := false
 var _last_emitted_speed: float = 0.0
 var _last_emitted_min: float = 0.0
 var _last_emitted_max: float = 0.0
+## SH-297: child Area2D carrying the generous press hit-box. Larger than the visible body
+## so a press near a moving ball lands without pixel-precision. Built lazily in
+## `_ball_setup` so the press surface tracks the ball's authored collision radius.
+var _press_area: Area2D
 
 
 func _ready() -> void:
@@ -122,6 +131,48 @@ func _setup_effect_processor() -> void:
 	add_child(effect_processor)
 
 
+## SH-297: builds the inflated press hit-box as an Area2D child. Reads the ball's authored
+## CollisionShape2D radius so the press surface scales with the ball's physics size, then
+## inflates by `PRESS_HITBOX_INFLATION`. The Area2D doesn't collide with anything; its
+## only job is to surface left-mouse-button presses through `_on_input_event`.
+func _setup_press_area() -> void:
+	if _press_area != null and is_instance_valid(_press_area):
+		return
+	var press_radius: float = _authored_collision_radius() * PRESS_HITBOX_INFLATION
+	if press_radius <= 0.0:
+		return
+	var area: Area2D = Area2D.new()
+	area.name = "PressArea"
+	area.input_pickable = true
+	area.monitoring = false
+	area.monitorable = false
+	var shape_node: CollisionShape2D = CollisionShape2D.new()
+	var circle: CircleShape2D = CircleShape2D.new()
+	circle.radius = press_radius
+	shape_node.shape = circle
+	area.add_child(shape_node)
+	add_child(area)
+	if not area.input_event.is_connected(_on_input_event):
+		area.input_event.connect(_on_input_event)
+	_press_area = area
+
+
+## SH-297: resolves the ball's authored physics radius from its CollisionShape2D so the
+## press hit-box is a multiple of it. Falls back to the SPEED_EMIT_THRESHOLD-era default
+## of 10 px if the body has no resolvable circle (defensive only; the authored ball.tscn
+## ships a CircleShape2D).
+func _authored_collision_radius() -> float:
+	for child in get_children():
+		if child is CollisionShape2D:
+			var shape_node: CollisionShape2D = child
+			var circle: CircleShape2D = shape_node.shape as CircleShape2D
+			if circle == null:
+				continue
+			var axis_scale: float = maxf(absf(shape_node.scale.x), absf(shape_node.scale.y))
+			return circle.radius * maxf(axis_scale, 0.001)
+	return 10.0
+
+
 func _ball_setup() -> void:
 	speed = min_speed
 	effect_processor.sync_base_speed()
@@ -134,9 +185,13 @@ func _ball_setup() -> void:
 		body_entered.connect(_on_body_entered)
 	if not missed.is_connected(reset_speed):
 		missed.connect(reset_speed)
-	input_pickable = true
-	if not input_event.is_connected(_on_input_event):
-		input_event.connect(_on_input_event)
+	# SH-297: press routing moves to the inflated `PressArea` so the player can grab a
+	# moving ball without a pixel-precise hit. The rigid body itself stops accepting
+	# pointer events; physics collisions still flow through `_on_body_entered`.
+	input_pickable = false
+	if input_event.is_connected(_on_input_event):
+		input_event.disconnect(_on_input_event)
+	_setup_press_area()
 
 
 ## Press on the live ball routes through here and surfaces as the `pressed` signal so the drag controller can flip into mid-rally grab mode.

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -4,14 +4,10 @@ extends RigidBody2D
 signal missed
 signal at_max_speed_changed(is_at_max: bool)
 signal speed_changed(speed: float, min_speed: float, max_speed: float)
-## Mid-rally grab entry: emitted when the player presses the live ball.
 signal pressed(ball: Ball)
 
 const SPEED_EMIT_THRESHOLD := 10.0
-## SH-297: factor by which the press hit-box inflates the ball's authored physics radius.
-## A live ball is small and moving, so a pixel-precise press misses more often than not.
-## Inflating the press surface (without touching the physics shape) lets a press near a
-## moving ball land cleanly. Tune surface; do not couple to physics-collider scale.
+## Tuning surface for the press hit-box; do not couple to physics-collider scale.
 const PRESS_HITBOX_INFLATION: float = 1.6
 
 ## Item key this ball represents; the system reads this on adoption to find the matching ItemDefinition.
@@ -29,9 +25,6 @@ var _was_at_max_speed := false
 var _last_emitted_speed: float = 0.0
 var _last_emitted_min: float = 0.0
 var _last_emitted_max: float = 0.0
-## SH-297: child Area2D carrying the generous press hit-box. Larger than the visible body
-## so a press near a moving ball lands without pixel-precision. Built lazily in
-## `_ball_setup` so the press surface tracks the ball's authored collision radius.
 var _press_area: Area2D
 
 
@@ -131,10 +124,6 @@ func _setup_effect_processor() -> void:
 	add_child(effect_processor)
 
 
-## SH-297: builds the inflated press hit-box as an Area2D child. Reads the ball's authored
-## CollisionShape2D radius so the press surface scales with the ball's physics size, then
-## inflates by `PRESS_HITBOX_INFLATION`. The Area2D doesn't collide with anything; its
-## only job is to surface left-mouse-button presses through `_on_input_event`.
 func _setup_press_area() -> void:
 	if _press_area != null and is_instance_valid(_press_area):
 		return
@@ -157,10 +146,6 @@ func _setup_press_area() -> void:
 	_press_area = area
 
 
-## SH-297: resolves the ball's authored physics radius from its CollisionShape2D so the
-## press hit-box is a multiple of it. Falls back to the SPEED_EMIT_THRESHOLD-era default
-## of 10 px if the body has no resolvable circle (defensive only; the authored ball.tscn
-## ships a CircleShape2D).
 func _authored_collision_radius() -> float:
 	for child in get_children():
 		if child is CollisionShape2D:
@@ -170,7 +155,8 @@ func _authored_collision_radius() -> float:
 				continue
 			var axis_scale: float = maxf(absf(shape_node.scale.x), absf(shape_node.scale.y))
 			return circle.radius * maxf(axis_scale, 0.001)
-	return 10.0
+	# No authored CircleShape2D; press area skips construction on radius <= 0.
+	return 0.0
 
 
 func _ball_setup() -> void:
@@ -185,16 +171,13 @@ func _ball_setup() -> void:
 		body_entered.connect(_on_body_entered)
 	if not missed.is_connected(reset_speed):
 		missed.connect(reset_speed)
-	# SH-297: press routing moves to the inflated `PressArea` so the player can grab a
-	# moving ball without a pixel-precise hit. The rigid body itself stops accepting
-	# pointer events; physics collisions still flow through `_on_body_entered`.
+	# Press routing lives on PressArea; the rigid body stops accepting pointer events.
 	input_pickable = false
 	if input_event.is_connected(_on_input_event):
 		input_event.disconnect(_on_input_event)
 	_setup_press_area()
 
 
-## Press on the live ball routes through here and surfaces as the `pressed` signal so the drag controller can flip into mid-rally grab mode.
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if freeze:
 		return

--- a/scripts/hud/cursor_overlay.gd
+++ b/scripts/hud/cursor_overlay.gd
@@ -1,0 +1,70 @@
+class_name CursorOverlay
+extends Node2D
+
+## SH-297: placeholder visual for the grab cursor state machine.
+##
+## The cursor textures (SH-298 art study) drop into this node later; for now each state
+## renders as a simple primitive with a state-coloured tint so the state machine can be
+## verified end-to-end without art. The visual layer is replaceable; the contract is
+## `set_state(int_state, world_position)`.
+##
+## The overlay parents under the drag controller and follows the held position, not the
+## OS cursor. State `DEFAULT` hides the overlay so the OS cursor reads cleanly when no
+## gesture is in flight.
+
+const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd")
+
+## Radius of the placeholder ring drawn around the held position. Replaced by the
+## software-cursor textures in SH-298.
+const CURSOR_RADIUS_PX: float = 18.0
+const RING_WIDTH_PX: float = 3.0
+
+const COLOR_DEFAULT: Color = Color(1.0, 1.0, 1.0, 0.0)
+const COLOR_DRAGGING: Color = Color(0.85, 0.85, 0.85, 0.85)
+const COLOR_CAN_DROP: Color = Color(0.45, 0.95, 0.55, 0.95)
+const COLOR_FORBIDDEN: Color = Color(0.95, 0.35, 0.35, 0.95)
+
+var _state: int = CursorStateScript.State.DEFAULT
+
+
+func _ready() -> void:
+	z_index = 4096
+	top_level = true
+	visible = false
+
+
+## Called by BallDragController each physics frame. Position is in world coordinates so
+## the overlay tracks the held token, not the OS cursor.
+func set_state(state: int, world_position: Vector2) -> void:
+	global_position = world_position
+	if state == _state:
+		queue_redraw()
+		return
+	_state = state
+	visible = state != CursorStateScript.State.DEFAULT
+	queue_redraw()
+
+
+func get_state() -> int:
+	return _state
+
+
+func _draw() -> void:
+	if _state == CursorStateScript.State.DEFAULT:
+		return
+	var ring_color: Color = _color_for_state(_state)
+	draw_arc(Vector2.ZERO, CURSOR_RADIUS_PX, 0.0, TAU, 32, ring_color, RING_WIDTH_PX, true)
+	# Centre dot reads as the press point regardless of which state is active.
+	draw_circle(Vector2.ZERO, RING_WIDTH_PX, ring_color)
+
+
+func _color_for_state(state: int) -> Color:
+	match state:
+		CursorStateScript.State.DRAGGING:
+			return COLOR_DRAGGING
+		CursorStateScript.State.CAN_DROP:
+			return COLOR_CAN_DROP
+		CursorStateScript.State.FORBIDDEN:
+			return COLOR_FORBIDDEN
+		_:
+			return COLOR_DEFAULT

--- a/scripts/hud/cursor_overlay.gd
+++ b/scripts/hud/cursor_overlay.gd
@@ -4,21 +4,19 @@ extends Node2D
 ## Placeholder visual for the grab cursor state machine; replaced by SH-298 textures.
 
 const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd")
+const DEFAULT_PALETTE: CursorOverlayPalette = preload(
+	"res://resources/hud/cursor_overlay_palette.tres"
+)
 
-## Ring radius for the placeholder cursor overlay; tunable per-scene.
-@export var cursor_radius_px: float = 18.0
-## Ring stroke width for the placeholder cursor overlay.
-@export var ring_width_px: float = 3.0
-## Tint per cursor state; alpha 0 hides the default state.
-@export var color_default: Color = Color(1.0, 1.0, 1.0, 0.0)
-@export var color_dragging: Color = Color(0.85, 0.85, 0.85, 0.85)
-@export var color_can_drop: Color = Color(0.45, 0.95, 0.55, 0.95)
-@export var color_forbidden: Color = Color(0.95, 0.35, 0.35, 0.95)
+## Colour cluster + ring metrics; tunable per-scene by swapping the palette resource.
+@export var palette: CursorOverlayPalette = DEFAULT_PALETTE
 
 var _state: int = CursorStateScript.State.DEFAULT
 
 
 func _ready() -> void:
+	if palette == null:
+		palette = DEFAULT_PALETTE
 	z_index = 4096
 	top_level = true
 	visible = false
@@ -41,18 +39,27 @@ func _draw() -> void:
 	if _state == CursorStateScript.State.DEFAULT:
 		return
 	var ring_color: Color = _color_for_state(_state)
-	draw_arc(Vector2.ZERO, cursor_radius_px, 0.0, TAU, 32, ring_color, ring_width_px, true)
+	draw_arc(
+		Vector2.ZERO,
+		palette.cursor_radius_px,
+		0.0,
+		TAU,
+		32,
+		ring_color,
+		palette.ring_width_px,
+		true
+	)
 	# Centre dot reads as the press point regardless of which state is active.
-	draw_circle(Vector2.ZERO, ring_width_px, ring_color)
+	draw_circle(Vector2.ZERO, palette.ring_width_px, ring_color)
 
 
 func _color_for_state(state: int) -> Color:
 	match state:
 		CursorStateScript.State.DRAGGING:
-			return color_dragging
+			return palette.color_dragging
 		CursorStateScript.State.CAN_DROP:
-			return color_can_drop
+			return palette.color_can_drop
 		CursorStateScript.State.FORBIDDEN:
-			return color_forbidden
+			return palette.color_forbidden
 		_:
-			return color_default
+			return palette.color_default

--- a/scripts/hud/cursor_overlay.gd
+++ b/scripts/hud/cursor_overlay.gd
@@ -1,21 +1,10 @@
 class_name CursorOverlay
 extends Node2D
 
-## SH-297: placeholder visual for the grab cursor state machine.
-##
-## The cursor textures (SH-298 art study) drop into this node later; for now each state
-## renders as a simple primitive with a state-coloured tint so the state machine can be
-## verified end-to-end without art. The visual layer is replaceable; the contract is
-## `set_state(int_state, world_position)`.
-##
-## The overlay parents under the drag controller and follows the held position, not the
-## OS cursor. State `DEFAULT` hides the overlay so the OS cursor reads cleanly when no
-## gesture is in flight.
+## Placeholder visual for the grab cursor state machine; replaced by SH-298 textures.
 
 const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd")
 
-## Radius of the placeholder ring drawn around the held position. Replaced by the
-## software-cursor textures in SH-298.
 const CURSOR_RADIUS_PX: float = 18.0
 const RING_WIDTH_PX: float = 3.0
 
@@ -33,8 +22,6 @@ func _ready() -> void:
 	visible = false
 
 
-## Called by BallDragController each physics frame. Position is in world coordinates so
-## the overlay tracks the held token, not the OS cursor.
 func set_state(state: int, world_position: Vector2) -> void:
 	global_position = world_position
 	if state == _state:

--- a/scripts/hud/cursor_overlay.gd
+++ b/scripts/hud/cursor_overlay.gd
@@ -5,13 +5,15 @@ extends Node2D
 
 const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd")
 
-const CURSOR_RADIUS_PX: float = 18.0
-const RING_WIDTH_PX: float = 3.0
-
-const COLOR_DEFAULT: Color = Color(1.0, 1.0, 1.0, 0.0)
-const COLOR_DRAGGING: Color = Color(0.85, 0.85, 0.85, 0.85)
-const COLOR_CAN_DROP: Color = Color(0.45, 0.95, 0.55, 0.95)
-const COLOR_FORBIDDEN: Color = Color(0.95, 0.35, 0.35, 0.95)
+## Ring radius for the placeholder cursor overlay; tunable per-scene.
+@export var cursor_radius_px: float = 18.0
+## Ring stroke width for the placeholder cursor overlay.
+@export var ring_width_px: float = 3.0
+## Tint per cursor state; alpha 0 hides the default state.
+@export var color_default: Color = Color(1.0, 1.0, 1.0, 0.0)
+@export var color_dragging: Color = Color(0.85, 0.85, 0.85, 0.85)
+@export var color_can_drop: Color = Color(0.45, 0.95, 0.55, 0.95)
+@export var color_forbidden: Color = Color(0.95, 0.35, 0.35, 0.95)
 
 var _state: int = CursorStateScript.State.DEFAULT
 
@@ -25,7 +27,6 @@ func _ready() -> void:
 func set_state(state: int, world_position: Vector2) -> void:
 	global_position = world_position
 	if state == _state:
-		queue_redraw()
 		return
 	_state = state
 	visible = state != CursorStateScript.State.DEFAULT
@@ -40,18 +41,18 @@ func _draw() -> void:
 	if _state == CursorStateScript.State.DEFAULT:
 		return
 	var ring_color: Color = _color_for_state(_state)
-	draw_arc(Vector2.ZERO, CURSOR_RADIUS_PX, 0.0, TAU, 32, ring_color, RING_WIDTH_PX, true)
+	draw_arc(Vector2.ZERO, cursor_radius_px, 0.0, TAU, 32, ring_color, ring_width_px, true)
 	# Centre dot reads as the press point regardless of which state is active.
-	draw_circle(Vector2.ZERO, RING_WIDTH_PX, ring_color)
+	draw_circle(Vector2.ZERO, ring_width_px, ring_color)
 
 
 func _color_for_state(state: int) -> Color:
 	match state:
 		CursorStateScript.State.DRAGGING:
-			return COLOR_DRAGGING
+			return color_dragging
 		CursorStateScript.State.CAN_DROP:
-			return COLOR_CAN_DROP
+			return color_can_drop
 		CursorStateScript.State.FORBIDDEN:
-			return COLOR_FORBIDDEN
+			return color_forbidden
 		_:
-			return COLOR_DEFAULT
+			return color_default

--- a/scripts/hud/cursor_overlay.gd.uid
+++ b/scripts/hud/cursor_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://bqbdbfpsxq5qo

--- a/scripts/hud/cursor_overlay_palette.gd
+++ b/scripts/hud/cursor_overlay_palette.gd
@@ -1,0 +1,11 @@
+class_name CursorOverlayPalette
+extends Resource
+
+## Tunable colour cluster + ring metrics for the placeholder grab-cursor overlay; replaced by SH-298 textures.
+
+@export var color_default: Color = Color(1.0, 1.0, 1.0, 0.0)
+@export var color_dragging: Color = Color(0.85, 0.85, 0.85, 0.85)
+@export var color_can_drop: Color = Color(0.45, 0.95, 0.55, 0.95)
+@export var color_forbidden: Color = Color(0.95, 0.35, 0.35, 0.95)
+@export_range(1.0, 64.0, 1.0) var cursor_radius_px: float = 18.0
+@export_range(0.5, 16.0, 0.5) var ring_width_px: float = 3.0

--- a/scripts/hud/cursor_overlay_palette.gd.uid
+++ b/scripts/hud/cursor_overlay_palette.gd.uid
@@ -1,0 +1,1 @@
+uid://m2m8ydruyqtw7

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -2,17 +2,10 @@ class_name BallDragController
 extends Node2D
 
 ## Owns the held-token visual during a ball or equipment drag gesture.
-##
-## Press starts a hold (held token follows cursor); release commits only at a valid target.
-## No-restore principle (SH-287): mouse-up over an invalid spot does not end the gesture;
-## the held token keeps following the cursor and the controller polls per frame for a valid
-## target. The source rack is itself a target, giving the player a no-teleport escape valve.
 
 signal pickup_started(item_key: String)
 signal drop_completed(item_key: String, release_position: Vector2, over_court: bool)
-## SH-297: emitted on every transition of the cursor state machine so the cursor overlay
-## (and any other listener) can re-render. The integer follows `CursorState.State`.
-signal cursor_state_changed(state: int)
+signal cursor_state_changed(state: int, world_position: Vector2)
 
 const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd")
 
@@ -22,13 +15,7 @@ const PRESERVED_SPEED_NONE: float = -1.0
 const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
 ## SH-287 patch: probe radius for the pre-spawn body projection; slightly larger than authored ball radius.
 const COURT_BLOCKED_PROBE_RADIUS_PX: float = 14.0
-## SH-297: duration of the eased lift from the spawn position onto the cursor on grab.
-## Position, scale, and modulation interpolate continuously across this window so the
-## body reads as one continuous lift, not a snap.
 const GRAB_EASE_DURATION_S: float = 0.08
-## SH-297: scale and modulation the held body holds at lift start. The body eases from
-## these values up to its definition's `token_scale` and full modulation across
-## `GRAB_EASE_DURATION_S`.
 const GRAB_EASE_START_SCALE: Vector2 = Vector2(0.85, 0.85)
 const GRAB_EASE_START_MODULATE: Color = Color(1.0, 1.0, 1.0, 0.0)
 const GRAB_EASE_END_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
@@ -40,10 +27,7 @@ const GRAB_EASE_END_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
 @export var court_bounds: Rect2 = Rect2()
 @export var venue_bounds: Rect2 = Rect2()
 @export var reconciler: BallReconciler
-## SH-297: optional cursor overlay node. When unset the controller still derives the
-## cursor state, emits `cursor_state_changed`, and exposes `get_cursor_state()`; only the
-## visual driving step is skipped. Tests don't need to wire this.
-@export var cursor_overlay: Node2D
+@export var cursor_overlay: CursorOverlay
 
 var _item_manager: Node
 var _held_token: Node2D = null
@@ -60,17 +44,9 @@ var _mouse_button_down: bool = false
 ## SH-288: friendship energy captured at mid-rally grab; forwarded to bring_into_play so the
 ## released ball inherits the rally speed. Negative means no preserved energy (rack-origin gesture).
 var _held_preserved_speed: float = PRESERVED_SPEED_NONE
-## SH-297: world position the held body lifts from. Position eases from here onto the
-## cursor over `GRAB_EASE_DURATION_S` so the lift reads as continuous motion, not a snap.
 var _grab_origin_position: Vector2 = Vector2.ZERO
-## SH-297: seconds elapsed inside the grab-ease window. Held body's position, scale, and
-## modulation derive from `_grab_ease_progress() ∈ [0, 1]`.
 var _grab_ease_elapsed: float = 0.0
-## SH-297: target scale captured from `ItemDefinition.token_scale` at grab time. The held
-## body eases from `GRAB_EASE_START_SCALE` up to this value across the lift window.
 var _grab_target_scale: Vector2 = Vector2.ONE
-## SH-297: last cursor state emitted; lets the controller debounce `cursor_state_changed`
-## and gives tests a polling handle via `get_cursor_state()`.
 var _cursor_state: int = CursorStateScript.State.DEFAULT
 
 
@@ -100,6 +76,10 @@ func _ready() -> void:
 		if not reconciler.ball_spawned.is_connected(_on_reconciler_ball_spawned):
 			reconciler.ball_spawned.connect(_on_reconciler_ball_spawned)
 
+	if cursor_overlay != null:
+		if not cursor_state_changed.is_connected(cursor_overlay.set_state):
+			cursor_state_changed.connect(cursor_overlay.set_state)
+
 
 func _process(delta: float) -> void:
 	if _held_token == null:
@@ -107,8 +87,6 @@ func _process(delta: float) -> void:
 		return
 
 	var cursor_target: Vector2 = _clamp_to_venue(_cursor_position())
-	# SH-297: position, scale, and modulation read continuously across the ~80 ms grab
-	# lift. Once the ease window closes, follow the cursor directly.
 	_grab_ease_elapsed = minf(_grab_ease_elapsed + delta, GRAB_EASE_DURATION_S)
 	var ease_progress: float = _grab_ease_progress()
 	_apply_grab_ease(ease_progress, cursor_target)
@@ -119,9 +97,6 @@ func _process(delta: float) -> void:
 		if follow_position.distance_to(_press_position) >= COMMIT_MOVEMENT_THRESHOLD_PX:
 			_gesture_below_threshold = false
 
-	# SH-297: cursor state polls in lockstep with the body-projection target poll. The
-	# state is what the player sees on the cursor; the commit decision still lives in
-	# `attempt_release` (SH-287's release-path territory).
 	_update_cursor_state(follow_position)
 
 	# SH-287: when mouse is up and the held position is over a valid target, commit.
@@ -157,7 +132,6 @@ func get_held_token() -> Node2D:
 	return _held_token
 
 
-## SH-297: current cursor state; one of `CursorState.State`. Test seam.
 func get_cursor_state() -> int:
 	return _cursor_state
 
@@ -281,8 +255,6 @@ func _finalise_gesture(item_key: String, release_position: Vector2, over_court: 
 	_grab_origin_position = Vector2.ZERO
 	_grab_ease_elapsed = 0.0
 	_grab_target_scale = Vector2.ONE
-	# SH-297: gesture closed; cursor falls back to default. `_process` will re-emit on
-	# the next held gesture; emit explicitly here so listeners hear the transition.
 	_set_cursor_state(CursorStateScript.State.DEFAULT, release_position)
 	drop_completed.emit(item_key, release_position, over_court)
 
@@ -315,8 +287,6 @@ func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: 
 	var target_scale: Vector2 = Vector2.ONE
 	if definition != null:
 		target_scale = definition.token_scale
-	# SH-297: start the body slightly small and transparent so the ease lift reads as
-	# continuous; `_apply_grab_ease` interpolates up to `target_scale` across the window.
 	token.scale = GRAB_EASE_START_SCALE * target_scale
 	token.modulate = GRAB_EASE_START_MODULATE
 	if definition != null and definition.art != null:
@@ -444,18 +414,12 @@ func _get_item_role(item_key: String) -> StringName:
 	return definition.role
 
 
-## SH-297: progress through the grab-ease window in [0, 1]. 0 at the moment of grab,
-## 1 once the body has fully eased onto the cursor. Linear here; cubic ease-out applied
-## in `_apply_grab_ease` keeps the math single-sourced.
 func _grab_ease_progress() -> float:
 	if GRAB_EASE_DURATION_S <= 0.0:
 		return 1.0
 	return clampf(_grab_ease_elapsed / GRAB_EASE_DURATION_S, 0.0, 1.0)
 
 
-## SH-297: drives held-token position, scale, and modulation across the grab-ease window.
-## `progress` is the linear t; we apply a cubic ease-out so the body decelerates onto the
-## cursor rather than arriving at a constant speed.
 func _apply_grab_ease(progress: float, cursor_target: Vector2) -> void:
 	if _held_token == null:
 		return
@@ -467,24 +431,15 @@ func _apply_grab_ease(progress: float, cursor_target: Vector2) -> void:
 	_held_token.modulate = GRAB_EASE_START_MODULATE.lerp(GRAB_EASE_END_MODULATE, eased)
 
 
-## SH-297: cursor state derivation. Pre-merge of SH-287 PR #533 the controller has no
-## generalised target poll, so the state is approximated from the gesture-in-flight flag
-## plus the existing rack/court signals; once #533 lands, the wiring updates to consume
-## the per-frame `_find_accepting_target` result so the state precisely tracks
-## `can_accept`. The contract on this side is the state name, not the derivation; visuals
-## drop in unchanged.
 func _update_cursor_state(world_position: Vector2) -> void:
 	var state: int = _derive_cursor_state(world_position)
 	_set_cursor_state(state, world_position)
 
 
-## Pure derivation; broken out so tests can drive it without spinning the full loop.
 func _derive_cursor_state(world_position: Vector2) -> int:
 	if _held_token == null:
 		return CursorStateScript.State.DEFAULT
-	# Off-venue is forbidden by definition: the controller already clamps the held token
-	# to venue bounds, but the underlying cursor can be outside; reading the unclamped
-	# cursor here lets the state surface the forbidden read.
+	# The held token is clamped to venue but the raw cursor can drift outside.
 	if not _is_within_venue(_cursor_position()):
 		return CursorStateScript.State.FORBIDDEN
 	if _position_accepted_by_any_target(_held_key, world_position):
@@ -492,11 +447,6 @@ func _derive_cursor_state(world_position: Vector2) -> int:
 	return CursorStateScript.State.DRAGGING
 
 
-## Pre-merge stub. Today this reuses the legacy `attempt_release` predicate signals: it
-## reports CAN_DROP when the position is over the rack-for-role or over a court spot
-## that `_release_position_clear` accepts. After SH-287 PR #533 merges, this routes
-## through `_find_accepting_target(item_key, world_position, 1.0) != null` and the
-## predicate below collapses to one line.
 func _position_accepted_by_any_target(item_key: String, world_position: Vector2) -> bool:
 	if item_key.is_empty():
 		return false
@@ -505,9 +455,7 @@ func _position_accepted_by_any_target(item_key: String, world_position: Vector2)
 		return true
 	if item_role == &"ball":
 		var court_position: Vector2 = _clamp_to_court(world_position)
-		# Ball target accepts only when the body projection is clear AND the original
-		# (unclamped) press lands within the court rect; otherwise the cursor reads as
-		# DRAGGING (over the venue but not over a target).
+		# CAN_DROP needs both the unclamped press inside the court rect and a clear projection.
 		if court_bounds.has_point(world_position) and _release_position_clear(court_position):
 			return true
 	return false
@@ -520,12 +468,8 @@ func _is_within_venue(world_position: Vector2) -> bool:
 
 
 func _set_cursor_state(state: int, world_position: Vector2) -> void:
-	if cursor_overlay != null and cursor_overlay.has_method("set_state"):
-		cursor_overlay.call("set_state", state, world_position)
-	if state == _cursor_state:
-		return
 	_cursor_state = state
-	cursor_state_changed.emit(state)
+	cursor_state_changed.emit(state, world_position)
 
 
 func _on_rack_slot_pressed(item_key: String, press_position: Vector2) -> void:

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -15,10 +15,14 @@ const PRESERVED_SPEED_NONE: float = -1.0
 const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
 ## SH-287 patch: probe radius for the pre-spawn body projection; slightly larger than authored ball radius.
 const COURT_BLOCKED_PROBE_RADIUS_PX: float = 14.0
-const GRAB_EASE_DURATION_S: float = 0.08
-const GRAB_EASE_START_SCALE: Vector2 = Vector2(0.85, 0.85)
-const GRAB_EASE_START_MODULATE: Color = Color(1.0, 1.0, 1.0, 0.0)
-const GRAB_EASE_END_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
+## Duration of the grab ease-to-cursor lift; the held token tweens for this long after a press.
+@export var grab_ease_duration_s: float = 0.08
+## Scale multiplier on the held token at the start of the lift; eases up to 1.0 over the window.
+@export var grab_ease_start_scale: Vector2 = Vector2(0.85, 0.85)
+## Modulate at the start of the lift; the alpha eases up to grab_ease_end_modulate.
+@export var grab_ease_start_modulate: Color = Color(1.0, 1.0, 1.0, 0.0)
+## Modulate at the end of the lift.
+@export var grab_ease_end_modulate: Color = Color(1.0, 1.0, 1.0, 1.0)
 
 @export var rack: RackDisplay
 @export var rack_drop_target: Area2D
@@ -87,7 +91,7 @@ func _process(delta: float) -> void:
 		return
 
 	var cursor_target: Vector2 = _clamp_to_venue(_cursor_position())
-	_grab_ease_elapsed = minf(_grab_ease_elapsed + delta, GRAB_EASE_DURATION_S)
+	_grab_ease_elapsed = minf(_grab_ease_elapsed + delta, grab_ease_duration_s)
 	var ease_progress: float = _grab_ease_progress()
 	_apply_grab_ease(ease_progress, cursor_target)
 
@@ -287,8 +291,8 @@ func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: 
 	var target_scale: Vector2 = Vector2.ONE
 	if definition != null:
 		target_scale = definition.token_scale
-	token.scale = GRAB_EASE_START_SCALE * target_scale
-	token.modulate = GRAB_EASE_START_MODULATE
+	token.scale = grab_ease_start_scale * target_scale
+	token.modulate = grab_ease_start_modulate
 	if definition != null and definition.art != null:
 		var art_instance: Node = definition.art.instantiate()
 		token.add_child(art_instance)
@@ -415,9 +419,9 @@ func _get_item_role(item_key: String) -> StringName:
 
 
 func _grab_ease_progress() -> float:
-	if GRAB_EASE_DURATION_S <= 0.0:
+	if grab_ease_duration_s <= 0.0:
 		return 1.0
-	return clampf(_grab_ease_elapsed / GRAB_EASE_DURATION_S, 0.0, 1.0)
+	return clampf(_grab_ease_elapsed / grab_ease_duration_s, 0.0, 1.0)
 
 
 func _apply_grab_ease(progress: float, cursor_target: Vector2) -> void:
@@ -427,8 +431,8 @@ func _apply_grab_ease(progress: float, cursor_target: Vector2) -> void:
 	var inv: float = 1.0 - progress
 	var eased: float = 1.0 - inv * inv * inv
 	_held_token.global_position = _grab_origin_position.lerp(cursor_target, eased)
-	_held_token.scale = (GRAB_EASE_START_SCALE * _grab_target_scale).lerp(_grab_target_scale, eased)
-	_held_token.modulate = GRAB_EASE_START_MODULATE.lerp(GRAB_EASE_END_MODULATE, eased)
+	_held_token.scale = (grab_ease_start_scale * _grab_target_scale).lerp(_grab_target_scale, eased)
+	_held_token.modulate = grab_ease_start_modulate.lerp(grab_ease_end_modulate, eased)
 
 
 func _update_cursor_state(world_position: Vector2) -> void:

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -10,6 +10,11 @@ extends Node2D
 
 signal pickup_started(item_key: String)
 signal drop_completed(item_key: String, release_position: Vector2, over_court: bool)
+## SH-297: emitted on every transition of the cursor state machine so the cursor overlay
+## (and any other listener) can re-render. The integer follows `CursorState.State`.
+signal cursor_state_changed(state: int)
+
+const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd")
 
 const CURSOR_SAMPLE_WINDOW: float = 0.08
 const PRESERVED_SPEED_NONE: float = -1.0
@@ -17,6 +22,16 @@ const PRESERVED_SPEED_NONE: float = -1.0
 const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
 ## SH-287 patch: probe radius for the pre-spawn body projection; slightly larger than authored ball radius.
 const COURT_BLOCKED_PROBE_RADIUS_PX: float = 14.0
+## SH-297: duration of the eased lift from the spawn position onto the cursor on grab.
+## Position, scale, and modulation interpolate continuously across this window so the
+## body reads as one continuous lift, not a snap.
+const GRAB_EASE_DURATION_S: float = 0.08
+## SH-297: scale and modulation the held body holds at lift start. The body eases from
+## these values up to its definition's `token_scale` and full modulation across
+## `GRAB_EASE_DURATION_S`.
+const GRAB_EASE_START_SCALE: Vector2 = Vector2(0.85, 0.85)
+const GRAB_EASE_START_MODULATE: Color = Color(1.0, 1.0, 1.0, 0.0)
+const GRAB_EASE_END_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
 
 @export var rack: RackDisplay
 @export var rack_drop_target: Area2D
@@ -25,6 +40,10 @@ const COURT_BLOCKED_PROBE_RADIUS_PX: float = 14.0
 @export var court_bounds: Rect2 = Rect2()
 @export var venue_bounds: Rect2 = Rect2()
 @export var reconciler: BallReconciler
+## SH-297: optional cursor overlay node. When unset the controller still derives the
+## cursor state, emits `cursor_state_changed`, and exposes `get_cursor_state()`; only the
+## visual driving step is skipped. Tests don't need to wire this.
+@export var cursor_overlay: Node2D
 
 var _item_manager: Node
 var _held_token: Node2D = null
@@ -41,6 +60,18 @@ var _mouse_button_down: bool = false
 ## SH-288: friendship energy captured at mid-rally grab; forwarded to bring_into_play so the
 ## released ball inherits the rally speed. Negative means no preserved energy (rack-origin gesture).
 var _held_preserved_speed: float = PRESERVED_SPEED_NONE
+## SH-297: world position the held body lifts from. Position eases from here onto the
+## cursor over `GRAB_EASE_DURATION_S` so the lift reads as continuous motion, not a snap.
+var _grab_origin_position: Vector2 = Vector2.ZERO
+## SH-297: seconds elapsed inside the grab-ease window. Held body's position, scale, and
+## modulation derive from `_grab_ease_progress() ∈ [0, 1]`.
+var _grab_ease_elapsed: float = 0.0
+## SH-297: target scale captured from `ItemDefinition.token_scale` at grab time. The held
+## body eases from `GRAB_EASE_START_SCALE` up to this value across the lift window.
+var _grab_target_scale: Vector2 = Vector2.ONE
+## SH-297: last cursor state emitted; lets the controller debounce `cursor_state_changed`
+## and gives tests a polling handle via `get_cursor_state()`.
+var _cursor_state: int = CursorStateScript.State.DEFAULT
 
 
 func configure(
@@ -70,16 +101,28 @@ func _ready() -> void:
 			reconciler.ball_spawned.connect(_on_reconciler_ball_spawned)
 
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
 	if _held_token == null:
+		_set_cursor_state(CursorStateScript.State.DEFAULT, _cursor_position())
 		return
 
-	var follow_position: Vector2 = _clamp_to_venue(_cursor_position())
-	_held_token.global_position = follow_position
+	var cursor_target: Vector2 = _clamp_to_venue(_cursor_position())
+	# SH-297: position, scale, and modulation read continuously across the ~80 ms grab
+	# lift. Once the ease window closes, follow the cursor directly.
+	_grab_ease_elapsed = minf(_grab_ease_elapsed + delta, GRAB_EASE_DURATION_S)
+	var ease_progress: float = _grab_ease_progress()
+	_apply_grab_ease(ease_progress, cursor_target)
+
+	var follow_position: Vector2 = _held_token.global_position
 	_track_cursor_motion(follow_position)
 	if _gesture_below_threshold:
 		if follow_position.distance_to(_press_position) >= COMMIT_MOVEMENT_THRESHOLD_PX:
 			_gesture_below_threshold = false
+
+	# SH-297: cursor state polls in lockstep with the body-projection target poll. The
+	# state is what the player sees on the cursor; the commit decision still lives in
+	# `attempt_release` (SH-287's release-path territory).
+	_update_cursor_state(follow_position)
 
 	# SH-287: when mouse is up and the held position is over a valid target, commit.
 	if not _mouse_button_down:
@@ -112,6 +155,11 @@ func get_held_key() -> String:
 
 func get_held_token() -> Node2D:
 	return _held_token
+
+
+## SH-297: current cursor state; one of `CursorState.State`. Test seam.
+func get_cursor_state() -> int:
+	return _cursor_state
 
 
 ## Test seam / production entry for rack-origin pickups. Activation defers to release-over-court (SH-245).
@@ -230,6 +278,12 @@ func _finalise_gesture(item_key: String, release_position: Vector2, over_court: 
 	_cursor_samples.clear()
 	_press_position = Vector2.ZERO
 	_gesture_below_threshold = true
+	_grab_origin_position = Vector2.ZERO
+	_grab_ease_elapsed = 0.0
+	_grab_target_scale = Vector2.ONE
+	# SH-297: gesture closed; cursor falls back to default. `_process` will re-emit on
+	# the next held gesture; emit explicitly here so listeners hear the transition.
+	_set_cursor_state(CursorStateScript.State.DEFAULT, release_position)
 	drop_completed.emit(item_key, release_position, over_court)
 
 
@@ -258,8 +312,13 @@ func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: 
 	token.global_position = spawn_position
 
 	var definition: ItemDefinition = _get_item_definition(item_key)
+	var target_scale: Vector2 = Vector2.ONE
 	if definition != null:
-		token.scale = definition.token_scale
+		target_scale = definition.token_scale
+	# SH-297: start the body slightly small and transparent so the ease lift reads as
+	# continuous; `_apply_grab_ease` interpolates up to `target_scale` across the window.
+	token.scale = GRAB_EASE_START_SCALE * target_scale
+	token.modulate = GRAB_EASE_START_MODULATE
 	if definition != null and definition.art != null:
 		var art_instance: Node = definition.art.instantiate()
 		token.add_child(art_instance)
@@ -270,6 +329,9 @@ func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: 
 	_held_is_temporary = is_temporary
 	_press_position = spawn_position
 	_gesture_below_threshold = true
+	_grab_origin_position = spawn_position
+	_grab_ease_elapsed = 0.0
+	_grab_target_scale = target_scale
 	_cursor_samples.clear()
 	_track_cursor_motion(spawn_position)
 
@@ -380,6 +442,90 @@ func _get_item_role(item_key: String) -> StringName:
 	if definition == null:
 		return &"ball"
 	return definition.role
+
+
+## SH-297: progress through the grab-ease window in [0, 1]. 0 at the moment of grab,
+## 1 once the body has fully eased onto the cursor. Linear here; cubic ease-out applied
+## in `_apply_grab_ease` keeps the math single-sourced.
+func _grab_ease_progress() -> float:
+	if GRAB_EASE_DURATION_S <= 0.0:
+		return 1.0
+	return clampf(_grab_ease_elapsed / GRAB_EASE_DURATION_S, 0.0, 1.0)
+
+
+## SH-297: drives held-token position, scale, and modulation across the grab-ease window.
+## `progress` is the linear t; we apply a cubic ease-out so the body decelerates onto the
+## cursor rather than arriving at a constant speed.
+func _apply_grab_ease(progress: float, cursor_target: Vector2) -> void:
+	if _held_token == null:
+		return
+	# Cubic ease-out: 1 - (1 - t)^3.
+	var inv: float = 1.0 - progress
+	var eased: float = 1.0 - inv * inv * inv
+	_held_token.global_position = _grab_origin_position.lerp(cursor_target, eased)
+	_held_token.scale = (GRAB_EASE_START_SCALE * _grab_target_scale).lerp(_grab_target_scale, eased)
+	_held_token.modulate = GRAB_EASE_START_MODULATE.lerp(GRAB_EASE_END_MODULATE, eased)
+
+
+## SH-297: cursor state derivation. Pre-merge of SH-287 PR #533 the controller has no
+## generalised target poll, so the state is approximated from the gesture-in-flight flag
+## plus the existing rack/court signals; once #533 lands, the wiring updates to consume
+## the per-frame `_find_accepting_target` result so the state precisely tracks
+## `can_accept`. The contract on this side is the state name, not the derivation; visuals
+## drop in unchanged.
+func _update_cursor_state(world_position: Vector2) -> void:
+	var state: int = _derive_cursor_state(world_position)
+	_set_cursor_state(state, world_position)
+
+
+## Pure derivation; broken out so tests can drive it without spinning the full loop.
+func _derive_cursor_state(world_position: Vector2) -> int:
+	if _held_token == null:
+		return CursorStateScript.State.DEFAULT
+	# Off-venue is forbidden by definition: the controller already clamps the held token
+	# to venue bounds, but the underlying cursor can be outside; reading the unclamped
+	# cursor here lets the state surface the forbidden read.
+	if not _is_within_venue(_cursor_position()):
+		return CursorStateScript.State.FORBIDDEN
+	if _position_accepted_by_any_target(_held_key, world_position):
+		return CursorStateScript.State.CAN_DROP
+	return CursorStateScript.State.DRAGGING
+
+
+## Pre-merge stub. Today this reuses the legacy `attempt_release` predicate signals: it
+## reports CAN_DROP when the position is over the rack-for-role or over a court spot
+## that `_release_position_clear` accepts. After SH-287 PR #533 merges, this routes
+## through `_find_accepting_target(item_key, world_position, 1.0) != null` and the
+## predicate below collapses to one line.
+func _position_accepted_by_any_target(item_key: String, world_position: Vector2) -> bool:
+	if item_key.is_empty():
+		return false
+	var item_role: StringName = _get_item_role(item_key)
+	if _position_over_rack_for_role(world_position, item_role):
+		return true
+	if item_role == &"ball":
+		var court_position: Vector2 = _clamp_to_court(world_position)
+		# Ball target accepts only when the body projection is clear AND the original
+		# (unclamped) press lands within the court rect; otherwise the cursor reads as
+		# DRAGGING (over the venue but not over a target).
+		if court_bounds.has_point(world_position) and _release_position_clear(court_position):
+			return true
+	return false
+
+
+func _is_within_venue(world_position: Vector2) -> bool:
+	if venue_bounds.size == Vector2.ZERO:
+		return true
+	return venue_bounds.has_point(world_position)
+
+
+func _set_cursor_state(state: int, world_position: Vector2) -> void:
+	if cursor_overlay != null and cursor_overlay.has_method("set_state"):
+		cursor_overlay.call("set_state", state, world_position)
+	if state == _cursor_state:
+		return
+	_cursor_state = state
+	cursor_state_changed.emit(state)
 
 
 func _on_rack_slot_pressed(item_key: String, press_position: Vector2) -> void:

--- a/scripts/items/cursor_state.gd
+++ b/scripts/items/cursor_state.gd
@@ -1,0 +1,34 @@
+class_name CursorState
+extends RefCounted
+
+## SH-297: cursor state vocabulary for the grab gesture.
+##
+## The drag controller derives one of these per physics frame from the gesture-in-flight
+## flag plus the current `can_accept` poll result at the held position. The cursor overlay
+## (and any future software-cursor texture set, SH-298) is a pure visual layer driven off
+## this state. The state machine is the contract; visuals are replaceable.
+
+enum State {
+	## No gesture in flight.
+	DEFAULT,
+	## Gesture in flight, no target accepts at the held position.
+	DRAGGING,
+	## Gesture in flight, a target accepts at the held position.
+	CAN_DROP,
+	## Gesture in flight, the position is invalid (over a wall, obstacle, off-venue).
+	FORBIDDEN,
+}
+
+
+static func to_string_name(state: int) -> StringName:
+	match state:
+		State.DEFAULT:
+			return &"default"
+		State.DRAGGING:
+			return &"dragging"
+		State.CAN_DROP:
+			return &"can_drop"
+		State.FORBIDDEN:
+			return &"forbidden"
+		_:
+			return &"default"

--- a/scripts/items/cursor_state.gd
+++ b/scripts/items/cursor_state.gd
@@ -1,21 +1,10 @@
 class_name CursorState
 extends RefCounted
 
-## SH-297: cursor state vocabulary for the grab gesture.
-##
-## The drag controller derives one of these per physics frame from the gesture-in-flight
-## flag plus the current `can_accept` poll result at the held position. The cursor overlay
-## (and any future software-cursor texture set, SH-298) is a pure visual layer driven off
-## this state. The state machine is the contract; visuals are replaceable.
-
 enum State {
-	## No gesture in flight.
 	DEFAULT,
-	## Gesture in flight, no target accepts at the held position.
 	DRAGGING,
-	## Gesture in flight, a target accepts at the held position.
 	CAN_DROP,
-	## Gesture in flight, the position is invalid (over a wall, obstacle, off-venue).
 	FORBIDDEN,
 }
 

--- a/scripts/items/cursor_state.gd.uid
+++ b/scripts/items/cursor_state.gd.uid
@@ -1,0 +1,1 @@
+uid://8i0km16jff2i

--- a/tests/hooks/pre_run_hook.gd
+++ b/tests/hooks/pre_run_hook.gd
@@ -23,6 +23,8 @@ const EXCLUDE_PATHS = [
 	"res://scripts/items/effect/outcome.gd",
 	# Drawing-heavy @tool Control; _draw paths are untouched in headless tests
 	"res://scripts/court/speed_bar.gd",
+	# SH-297: pure enum + label container; only consumed via const access from callers.
+	"res://scripts/items/cursor_state.gd",
 ]
 
 

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -388,13 +388,17 @@ func test_real_press_on_live_ball_starts_mid_rally_grab_and_release_reinstates()
 	_manager.activate("training_ball")
 	var live: Ball = _reconciler.get_ball_for_key("training_ball")
 	assert_not_null(live, "precondition: live ball exists")
-	assert_true(live.input_pickable, "live ball must be input_pickable so a press routes through")
+	# SH-297: press routing moved off the rigid body's input_event onto a generous
+	# child Area2D so a press near a moving ball lands without pixel precision.
+	var press_area: Area2D = live.get_node_or_null("PressArea") as Area2D
+	assert_not_null(press_area, "live ball must own a PressArea for press routing (SH-297)")
+	assert_true(press_area.input_pickable, "PressArea must accept pointer events")
 
-	# Drive a real press through the Ball's input_event signal.
+	# Drive a real press through the press area's input_event signal.
 	var press := InputEventMouseButton.new()
 	press.button_index = MOUSE_BUTTON_LEFT
 	press.pressed = true
-	live.input_event.emit(get_viewport(), press, 0)
+	press_area.input_event.emit(get_viewport(), press, 0)
 
 	assert_true(_drag.is_dragging(), "press on a live ball flips into drag mode (SH-247)")
 	await get_tree().process_frame
@@ -435,16 +439,17 @@ func test_pre_existing_court_ball_is_grabbable_mid_rally() -> void:
 	await get_tree().process_frame
 
 	assert_eq(_permanent_balls().size(), 1, "precondition: pre-existing Ball lives under host")
-	assert_true(
-		pre_existing.input_pickable, "Ball must be input_pickable for press to route through"
-	)
+	# SH-297: press routing lives on the child Area2D, not on the rigid body itself.
+	var press_area: Area2D = pre_existing.get_node_or_null("PressArea") as Area2D
+	assert_not_null(press_area, "Ball must own a PressArea for press routing (SH-297)")
+	assert_true(press_area.input_pickable, "PressArea must accept pointer events")
 	assert_false(_drag.is_dragging(), "precondition: no drag in progress before the press")
 
-	# Drive a real press on the pre-existing Ball.
+	# Drive a real press through the press area's input_event signal.
 	var press := InputEventMouseButton.new()
 	press.button_index = MOUSE_BUTTON_LEFT
 	press.pressed = true
-	pre_existing.input_event.emit(get_viewport(), press, 0)
+	press_area.input_event.emit(get_viewport(), press, 0)
 
 	assert_true(
 		_drag.is_dragging(),

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -309,8 +309,9 @@ func test_real_press_on_live_ball_then_drag_to_rack_returns_token() -> void:
 	var viewport: Viewport = live.get_viewport()
 
 	# Press on the live ball routes through Ball._on_input_event → emits `pressed` →
-	# BallDragController.grab_live_ball.
-	live.input_event.emit(viewport, _press_event(), 0)
+	# BallDragController.grab_live_ball. SH-297: routing lives on the child PressArea.
+	var press_area: Area2D = live.get_node("PressArea") as Area2D
+	press_area.input_event.emit(viewport, _press_event(), 0)
 	assert_true(_drag.is_dragging(), "live ball press must hand off to the drag controller")
 
 	await get_tree().process_frame
@@ -399,8 +400,12 @@ func test_held_token_during_rack_drag_uses_definition_scale() -> void:
 	_drag.grab_from_rack("training_ball")
 	var held_token: Node2D = _drag.get_held_token()
 	assert_not_null(held_token, "rack-origin drag spawns a held token")
+	# SH-297: the lift ease drives the held token from a slightly smaller starting scale
+	# up to `token_scale` across ~80 ms; settle the ease before reading the canonical scale.
+	_drag._grab_ease_elapsed = _drag.GRAB_EASE_DURATION_S
+	_drag._apply_grab_ease(1.0, held_token.global_position)
 	assert_eq(
 		held_token.scale,
 		TrainingBall.token_scale,
-		"the drag controller's held token reads token_scale from the definition",
+		"the drag controller's held token settles to token_scale after the SH-297 lift ease",
 	)

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -400,10 +400,8 @@ func test_held_token_during_rack_drag_uses_definition_scale() -> void:
 	_drag.grab_from_rack("training_ball")
 	var held_token: Node2D = _drag.get_held_token()
 	assert_not_null(held_token, "rack-origin drag spawns a held token")
-	# SH-297: the lift ease drives the held token from a slightly smaller starting scale
-	# up to `token_scale` across ~80 ms; settle the ease before reading the canonical scale.
-	_drag._grab_ease_elapsed = _drag.GRAB_EASE_DURATION_S
-	_drag._apply_grab_ease(1.0, held_token.global_position)
+	# Wait past GRAB_EASE_DURATION_S so the lift ease settles via the public _process surface.
+	await get_tree().create_timer(0.1).timeout
 	assert_eq(
 		held_token.scale,
 		TrainingBall.token_scale,

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -400,7 +400,7 @@ func test_held_token_during_rack_drag_uses_definition_scale() -> void:
 	_drag.grab_from_rack("training_ball")
 	var held_token: Node2D = _drag.get_held_token()
 	assert_not_null(held_token, "rack-origin drag spawns a held token")
-	# Wait past GRAB_EASE_DURATION_S so the lift ease settles via the public _process surface.
+	# Wait past grab_ease_duration_s so the lift ease settles via the public _process surface.
 	await get_tree().create_timer(0.1).timeout
 	assert_eq(
 		held_token.scale,

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -390,9 +390,8 @@ func test_token_scale_matches_across_shop_held_and_rack() -> void:
 	)
 
 
-func test_held_token_during_rack_drag_uses_definition_scale() -> void:
-	# The drag controller spawns its held token with the canonical scale, so a
-	# rack-origin drag matches the rack slot it came from.
+func test_held_token_during_rack_drag_settles_to_token_scale_with_hover_bump() -> void:
+	# Rack-origin drag eases to canonical token_scale, then hover-feedback bumps it because the cursor sits over the court drop target.
 	_setup_ball_drag()
 	_manager.take("training_ball")
 	await get_tree().process_frame
@@ -400,10 +399,7 @@ func test_held_token_during_rack_drag_uses_definition_scale() -> void:
 	_drag.grab_from_rack("training_ball")
 	var held_token: Node2D = _drag.get_held_token()
 	assert_not_null(held_token, "rack-origin drag spawns a held token")
-	# Wait past grab_ease_duration_s so the lift ease settles via the public _process surface.
 	await get_tree().create_timer(0.1).timeout
-	# SH-297 ease lands on token_scale; SH-287 hover-feedback then bumps by HOVER_SCALE_BUMP
-	# because the cursor at default (0,0) sits inside the court drop target's bounds.
 	var expected: Vector2 = TrainingBall.token_scale * BallDragControllerScript.HOVER_SCALE_BUMP
 	assert_eq(
 		held_token.scale,

--- a/tests/unit/ball/test_press_hitbox.gd
+++ b/tests/unit/ball/test_press_hitbox.gd
@@ -1,0 +1,79 @@
+## SH-297 generous press hit-box: live balls accept presses on a wider Area2D so a press
+## near a moving ball lands without pixel precision.
+extends GutTest
+
+var _ball: Ball
+var _manager: Node
+var _mock_storage: SaveStorage
+
+
+func before_each() -> void:
+	_mock_storage = double(SaveStorage).new()
+	stub(_mock_storage.write).to_return(true)
+	stub(_mock_storage.read).to_return("")
+
+	_manager = load("res://scripts/items/item_manager.gd").new()
+	_manager._progression = ProgressionData.new(_mock_storage)
+	_manager._effect_manager = EffectManager.new()
+	(
+		_manager
+		. items
+		. assign(
+			[
+				preload("res://resources/items/training_ball.tres"),
+			]
+		)
+	)
+	add_child_autofree(_manager)
+
+
+func _spawn_authored_ball() -> Ball:
+	# Instantiate the authored .tscn so the press area resolves the real CollisionShape2D.
+	var BallScene: PackedScene = preload("res://scenes/ball.tscn")
+	var ball: Ball = BallScene.instantiate()
+	ball._item_manager = _manager
+	add_child_autofree(ball)
+	return ball
+
+
+func test_press_area_exists_after_setup() -> void:
+	_ball = _spawn_authored_ball()
+	var press_area: Area2D = _ball.get_node_or_null("PressArea") as Area2D
+	assert_not_null(press_area, "ball spawns a child Area2D named 'PressArea'")
+	assert_true(press_area.input_pickable, "PressArea must accept pointer events")
+
+
+func test_rigidbody_input_pickable_disabled_so_press_routes_through_area() -> void:
+	# The rigid body must not double-fire presses; routing lives on the Area2D alone.
+	_ball = _spawn_authored_ball()
+	assert_false(_ball.input_pickable, "rigid body input_pickable disabled in favour of PressArea")
+
+
+func test_press_radius_is_inflated_versus_physics_radius() -> void:
+	# The hit-box is wider than the visible (physics) radius. Inflation factor lives on
+	# the ball as a tuning const.
+	_ball = _spawn_authored_ball()
+	var press_area: Area2D = _ball.get_node("PressArea") as Area2D
+	var press_shape: CollisionShape2D = null
+	for child in press_area.get_children():
+		if child is CollisionShape2D:
+			press_shape = child
+			break
+	assert_not_null(press_shape)
+	var press_circle: CircleShape2D = press_shape.shape as CircleShape2D
+	assert_not_null(press_circle, "press hit-box is a CircleShape2D")
+	assert_gt(press_circle.radius, 10.0, "press radius is wider than the bare ball authored radius")
+
+
+func test_press_emits_pressed_signal() -> void:
+	# A left-mouse-down event delivered to the press area surfaces as `Ball.pressed`.
+	_ball = _spawn_authored_ball()
+	watch_signals(_ball)
+	var press_area: Area2D = _ball.get_node("PressArea") as Area2D
+	var event: InputEventMouseButton = InputEventMouseButton.new()
+	event.button_index = MOUSE_BUTTON_LEFT
+	event.pressed = true
+
+	_ball._on_input_event(null, event, 0)
+
+	assert_signal_emitted(_ball, "pressed")

--- a/tests/unit/ball/test_press_hitbox.gd
+++ b/tests/unit/ball/test_press_hitbox.gd
@@ -50,8 +50,6 @@ func test_rigidbody_input_pickable_disabled_so_press_routes_through_area() -> vo
 
 
 func test_press_radius_is_inflated_versus_physics_radius() -> void:
-	# The hit-box is wider than the visible (physics) radius. Inflation factor lives on
-	# the ball as a tuning const.
 	_ball = _spawn_authored_ball()
 	var press_area: Area2D = _ball.get_node("PressArea") as Area2D
 	var press_shape: CollisionShape2D = null
@@ -62,7 +60,25 @@ func test_press_radius_is_inflated_versus_physics_radius() -> void:
 	assert_not_null(press_shape)
 	var press_circle: CircleShape2D = press_shape.shape as CircleShape2D
 	assert_not_null(press_circle, "press hit-box is a CircleShape2D")
-	assert_gt(press_circle.radius, 10.0, "press radius is wider than the bare ball authored radius")
+	var authored_radius: float = _authored_radius_from_ball(_ball)
+	assert_almost_eq(
+		press_circle.radius,
+		authored_radius * Ball.PRESS_HITBOX_INFLATION,
+		0.001,
+		"press radius equals authored radius * PRESS_HITBOX_INFLATION",
+	)
+
+
+func _authored_radius_from_ball(ball: Ball) -> float:
+	for child in ball.get_children():
+		if child is CollisionShape2D:
+			var shape_node: CollisionShape2D = child
+			var circle: CircleShape2D = shape_node.shape as CircleShape2D
+			if circle == null:
+				continue
+			var axis_scale: float = maxf(absf(shape_node.scale.x), absf(shape_node.scale.y))
+			return circle.radius * maxf(axis_scale, 0.001)
+	return 0.0
 
 
 func test_press_emits_pressed_signal() -> void:

--- a/tests/unit/ball/test_press_hitbox.gd
+++ b/tests/unit/ball/test_press_hitbox.gd
@@ -63,9 +63,9 @@ func test_press_radius_is_inflated_versus_physics_radius() -> void:
 	var authored_radius: float = _authored_radius_from_ball(_ball)
 	assert_almost_eq(
 		press_circle.radius,
-		authored_radius * Ball.PRESS_HITBOX_INFLATION,
+		authored_radius * _ball.press_hitbox_inflation,
 		0.001,
-		"press radius equals authored radius * PRESS_HITBOX_INFLATION",
+		"press radius equals authored radius * press_hitbox_inflation",
 	)
 
 

--- a/tests/unit/ball/test_press_hitbox.gd.uid
+++ b/tests/unit/ball/test_press_hitbox.gd.uid
@@ -1,0 +1,1 @@
+uid://470knr6aupy1

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -341,12 +341,13 @@ func test_token_scale_remains_canonical_across_items() -> void:
 	var canonical: Vector2 = BaseBall.token_scale
 
 	assert_eq(canonical, Vector2(1.5, 1.5), "definition pins the canonical token_scale")
-	# SH-297: held token spawns at grab_ease_start_scale * canonical and eases to canonical;
-	# pin the post-ease target rather than the immediate spawn frame.
+	# Settle the lift past its window so the held token lands on canonical, mirroring the post-ease state.
+	drag._grab_ease_elapsed = drag.grab_ease_duration_s
+	drag._apply_grab_ease(1.0, held_token.global_position)
 	assert_eq(
-		drag.grab_ease_start_scale * canonical,
 		held_token.scale,
-		"held-token spawn scale is grab_ease_start_scale times the canonical token_scale",
+		canonical,
+		"held-token settles on the canonical token_scale after the SH-297 lift ease",
 	)
 	assert_not_null(slot_art_holder, "precondition: rack populated at least one slot art holder")
 	assert_eq(

--- a/tests/unit/items/test_grab_feel.gd
+++ b/tests/unit/items/test_grab_feel.gd
@@ -96,6 +96,36 @@ func test_held_token_modulation_starts_transparent_and_eases_in() -> void:
 	assert_eq(token.modulate.a, 0.0, "modulation alpha is 0 at lift start; eases up to 1")
 
 
+func test_held_token_eases_strictly_between_origin_and_target_at_midpoint() -> void:
+	# AC: the lift is a continuous ease, not a snap or linear interpolation. At 50% through
+	# the window the held token's position, alpha, and scale must lie strictly between
+	# origin and target on every axis. A linear-or-snap regression must fail this assertion.
+	_manager.take("ball_alpha")
+	var origin := Vector2(100, 0)
+	_drag.grab_from_rack("ball_alpha", origin)
+	var token: Node2D = _drag.get_held_token()
+	var target := Vector2(500, 200)
+	# Definition default token_scale; the lift target_scale captured at grab time.
+	var target_scale := Vector2(1.5, 1.5)
+
+	_drag._apply_grab_ease(0.5, target)
+
+	# Position lies strictly between origin and target on each axis.
+	assert_gt(token.global_position.x, origin.x)
+	assert_lt(token.global_position.x, target.x)
+	assert_gt(token.global_position.y, origin.y)
+	assert_lt(token.global_position.y, target.y)
+	# Modulation alpha is strictly inside (0, 1).
+	assert_gt(token.modulate.a, 0.0)
+	assert_lt(token.modulate.a, 1.0)
+	# Scale is strictly between START_SCALE * target and target.
+	var start_scale: Vector2 = BallDragControllerScript.GRAB_EASE_START_SCALE * target_scale
+	assert_gt(token.scale.x, start_scale.x)
+	assert_lt(token.scale.x, target_scale.x)
+	assert_gt(token.scale.y, start_scale.y)
+	assert_lt(token.scale.y, target_scale.y)
+
+
 func test_cursor_state_default_when_no_gesture() -> void:
 	assert_eq(_drag.get_cursor_state(), CursorStateScript.State.DEFAULT)
 
@@ -124,18 +154,49 @@ func test_cursor_state_dragging_in_empty_court_neighbourhood() -> void:
 	assert_eq(state, CursorStateScript.State.DRAGGING)
 
 
-func test_cursor_state_emits_change_signal_on_transition() -> void:
-	# Listeners (overlay, future cursor textures) get a single transition per change.
+func test_cursor_state_forbidden_when_cursor_outside_venue() -> void:
+	# AC: off-venue reads as FORBIDDEN. The held token clamps to venue bounds, but the raw
+	# cursor can drift outside; the state surfaces that.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	# Shrink venue bounds to a small rect that excludes the cursor's default global mouse
+	# position; _is_within_venue then reports false and the derivation returns FORBIDDEN.
+	_drag.venue_bounds = Rect2(Vector2(99000, 99000), Vector2(1, 1))
+
+	var state: int = _drag._derive_cursor_state(Vector2.ZERO)
+
+	assert_eq(state, CursorStateScript.State.FORBIDDEN)
+
+
+func test_cursor_state_changed_signal_drives_overlay_through_process() -> void:
+	# End-to-end: a real grab, two _process steps with cursor at rack-only and
+	# venue-only positions, and the signal fires with the expected payloads. This pins the
+	# overlay-via-signal path, not just the derivation.
 	_manager.take("ball_alpha")
 	watch_signals(_drag)
+	# Trigger _ready so the overlay listens on cursor_state_changed.
+	_drag._ready()
 	_drag.grab_from_rack("ball_alpha")
-	# Force a cursor state update via the public derivation path.
-	_drag._set_cursor_state(CursorStateScript.State.CAN_DROP, Vector2.ZERO)
-	_drag._set_cursor_state(CursorStateScript.State.CAN_DROP, Vector2.ZERO)  # debounced
-	_drag._set_cursor_state(CursorStateScript.State.DRAGGING, Vector2.ZERO)
+	# Step 1: position over the rack drop target -> CAN_DROP.
+	var rack_position: Vector2 = _drop_target.global_position
+	_drag._held_token.global_position = rack_position
+	_drag._update_cursor_state(rack_position)
+	# Step 2: venue-only position outside court and rack -> DRAGGING.
+	var venue_only := Vector2(800, 0)
+	_drag._held_token.global_position = venue_only
+	_drag._update_cursor_state(venue_only)
 
-	# Two transitions expected: -> CAN_DROP, -> DRAGGING. The repeat is deduped.
-	assert_signal_emit_count(_drag, "cursor_state_changed", 2)
+	# At least three emissions are expected: spawn/_process default, CAN_DROP, DRAGGING.
+	# The state-change signal is per-call now (per-frame in production), so the count
+	# reflects update frequency rather than transitions; assert ordered payload sequence.
+	var emits: int = get_signal_emit_count(_drag, "cursor_state_changed")
+	assert_gte(emits, 2, "signal fires at least once per _update_cursor_state call")
+	# Last two emissions follow CAN_DROP then DRAGGING.
+	var second_last: Array = get_signal_parameters(_drag, "cursor_state_changed", emits - 2)
+	var last: Array = get_signal_parameters(_drag, "cursor_state_changed", emits - 1)
+	assert_eq(second_last[0], CursorStateScript.State.CAN_DROP)
+	assert_eq(last[0], CursorStateScript.State.DRAGGING)
+	assert_eq(last[1], venue_only, "signal payload carries the held world position")
 
 
 func test_cursor_overlay_visibility_follows_state() -> void:

--- a/tests/unit/items/test_grab_feel.gd
+++ b/tests/unit/items/test_grab_feel.gd
@@ -97,11 +97,7 @@ func test_held_token_modulation_starts_transparent_and_eases_in() -> void:
 
 
 func test_held_token_settles_on_cursor_without_teleporting() -> void:
-	# Behaviour: the lift moves the held token from press-origin to the cursor over the ease
-	# window. At the end the token sits on the cursor with full alpha, and no single tick
-	# during the window jumps more than half the total origin-to-target distance (rules out
-	# snap and linear-fast regressions; a continuous ease never moves more than ~ half the
-	# remaining distance in one frame for a sub-millisecond tick budget).
+	# Asserts the player-visible promise: lands on cursor with full alpha and no mid-window teleport.
 	_manager.take("ball_alpha")
 	var origin := Vector2(100, 0)
 	var cursor_target := Vector2(500, 200)
@@ -175,7 +171,7 @@ func test_cursor_state_forbidden_when_cursor_outside_venue() -> void:
 	assert_eq(state, CursorStateScript.State.FORBIDDEN)
 
 
-func test_cursor_state_changed_signal_drives_overlay_through_process() -> void:
+func test_cursor_state_changed_signal_drives_overlay_via_signal_payload() -> void:
 	# End-to-end: a real grab, two _process steps with cursor at rack-only and
 	# venue-only positions, and the signal fires with the expected payloads. This pins the
 	# overlay-via-signal path, not just the derivation.

--- a/tests/unit/items/test_grab_feel.gd
+++ b/tests/unit/items/test_grab_feel.gd
@@ -96,34 +96,39 @@ func test_held_token_modulation_starts_transparent_and_eases_in() -> void:
 	assert_eq(token.modulate.a, 0.0, "modulation alpha is 0 at lift start; eases up to 1")
 
 
-func test_held_token_eases_strictly_between_origin_and_target_at_midpoint() -> void:
-	# AC: the lift is a continuous ease, not a snap or linear interpolation. At 50% through
-	# the window the held token's position, alpha, and scale must lie strictly between
-	# origin and target on every axis. A linear-or-snap regression must fail this assertion.
+func test_held_token_settles_on_cursor_without_teleporting() -> void:
+	# Behaviour: the lift moves the held token from press-origin to the cursor over the ease
+	# window. At the end the token sits on the cursor with full alpha, and no single tick
+	# during the window jumps more than half the total origin-to-target distance (rules out
+	# snap and linear-fast regressions; a continuous ease never moves more than ~ half the
+	# remaining distance in one frame for a sub-millisecond tick budget).
 	_manager.take("ball_alpha")
 	var origin := Vector2(100, 0)
+	var cursor_target := Vector2(500, 200)
 	_drag.grab_from_rack("ball_alpha", origin)
 	var token: Node2D = _drag.get_held_token()
-	var target := Vector2(500, 200)
-	# Definition default token_scale; the lift target_scale captured at grab time.
-	var target_scale := Vector2(1.5, 1.5)
+	# Pin the cursor target by overriding _grab_origin_position-driven follow: we drive
+	# _apply_grab_ease through repeated _process-equivalent ticks against a fixed target.
+	var ease_window: float = _drag.grab_ease_duration_s
+	var tick_count: int = 16
+	var tick_dt: float = ease_window / float(tick_count)
+	var max_step: float = 0.0
+	var previous: Vector2 = token.global_position
+	var total_distance: float = origin.distance_to(cursor_target)
 
-	_drag._apply_grab_ease(0.5, target)
+	for i in tick_count:
+		_drag._grab_ease_elapsed = minf(_drag._grab_ease_elapsed + tick_dt, ease_window)
+		_drag._apply_grab_ease(_drag._grab_ease_progress(), cursor_target)
+		var step: float = previous.distance_to(token.global_position)
+		max_step = maxf(max_step, step)
+		previous = token.global_position
 
-	# Position lies strictly between origin and target on each axis.
-	assert_gt(token.global_position.x, origin.x)
-	assert_lt(token.global_position.x, target.x)
-	assert_gt(token.global_position.y, origin.y)
-	assert_lt(token.global_position.y, target.y)
-	# Modulation alpha is strictly inside (0, 1).
-	assert_gt(token.modulate.a, 0.0)
-	assert_lt(token.modulate.a, 1.0)
-	# Scale is strictly between START_SCALE * target and target.
-	var start_scale: Vector2 = BallDragControllerScript.GRAB_EASE_START_SCALE * target_scale
-	assert_gt(token.scale.x, start_scale.x)
-	assert_lt(token.scale.x, target_scale.x)
-	assert_gt(token.scale.y, start_scale.y)
-	assert_lt(token.scale.y, target_scale.y)
+	# Ends at the cursor with full alpha; that is the player-visible promise.
+	assert_almost_eq(token.global_position.x, cursor_target.x, 0.5)
+	assert_almost_eq(token.global_position.y, cursor_target.y, 0.5)
+	assert_almost_eq(token.modulate.a, 1.0, 0.001)
+	# No frame teleports across the window. Half the trip in one tick would be a snap.
+	assert_lt(max_step, total_distance * 0.5, "no mid-window teleport")
 
 
 func test_cursor_state_default_when_no_gesture() -> void:

--- a/tests/unit/items/test_grab_feel.gd
+++ b/tests/unit/items/test_grab_feel.gd
@@ -1,0 +1,148 @@
+## SH-297 grab feel: ease-to-cursor tween and cursor state machine.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd")
+const CursorOverlayScript: GDScript = preload("res://scripts/hud/cursor_overlay.gd")
+
+var _manager: Node
+var _host: Node2D
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+var _overlay: CursorOverlay
+
+
+func _make_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _make_drop_target(position: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [ball_alpha]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_host = Node2D.new()
+	add_child_autofree(_host)
+
+	_rack = _make_rack(_manager)
+	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager, _host)
+	add_child_autofree(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	_overlay = CursorOverlayScript.new()
+	_drag.add_child(_overlay)
+	_drag.cursor_overlay = _overlay
+	add_child_autofree(_drag)
+
+
+func test_held_token_starts_at_grab_origin_not_at_cursor() -> void:
+	# AC: ~80 ms ease-to-cursor on grab. The held token spawns at the grab origin and
+	# eases to the cursor; it must not teleport-and-snap.
+	_manager.take("ball_alpha")
+	var press_origin := Vector2(123, 45)
+
+	_drag.grab_from_rack("ball_alpha", press_origin)
+
+	var token: Node2D = _drag.get_held_token()
+	assert_not_null(token)
+	assert_eq(
+		token.global_position, press_origin, "lift starts at the press origin, not the cursor"
+	)
+
+
+func test_held_token_modulation_starts_transparent_and_eases_in() -> void:
+	# AC: position, scale, and modulation all read continuously through the lift.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha", Vector2(0, 0))
+	var token: Node2D = _drag.get_held_token()
+	assert_eq(token.modulate.a, 0.0, "modulation alpha is 0 at lift start; eases up to 1")
+
+
+func test_cursor_state_default_when_no_gesture() -> void:
+	assert_eq(_drag.get_cursor_state(), CursorStateScript.State.DEFAULT)
+
+
+func test_cursor_state_can_drop_over_rack_for_role() -> void:
+	# AC: cursor flips to CAN_DROP when a target accepts at the held position.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	var rack_position: Vector2 = _drop_target.global_position
+
+	var state: int = _drag._derive_cursor_state(rack_position)
+
+	assert_eq(state, CursorStateScript.State.CAN_DROP)
+
+
+func test_cursor_state_dragging_in_empty_court_neighbourhood() -> void:
+	# Mid-venue but not over a target: cursor reads DRAGGING.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	# A point well outside court bounds (-420..420) but inside venue bounds.
+	var venue_only := Vector2(800, 0)
+
+	var state: int = _drag._derive_cursor_state(venue_only)
+
+	# venue_only is outside court rect AND not over the rack drop target.
+	assert_eq(state, CursorStateScript.State.DRAGGING)
+
+
+func test_cursor_state_emits_change_signal_on_transition() -> void:
+	# Listeners (overlay, future cursor textures) get a single transition per change.
+	_manager.take("ball_alpha")
+	watch_signals(_drag)
+	_drag.grab_from_rack("ball_alpha")
+	# Force a cursor state update via the public derivation path.
+	_drag._set_cursor_state(CursorStateScript.State.CAN_DROP, Vector2.ZERO)
+	_drag._set_cursor_state(CursorStateScript.State.CAN_DROP, Vector2.ZERO)  # debounced
+	_drag._set_cursor_state(CursorStateScript.State.DRAGGING, Vector2.ZERO)
+
+	# Two transitions expected: -> CAN_DROP, -> DRAGGING. The repeat is deduped.
+	assert_signal_emit_count(_drag, "cursor_state_changed", 2)
+
+
+func test_cursor_overlay_visibility_follows_state() -> void:
+	# Default state hides the overlay so the OS cursor reads cleanly without a gesture.
+	_overlay.set_state(CursorStateScript.State.DEFAULT, Vector2.ZERO)
+	assert_false(_overlay.visible)
+	_overlay.set_state(CursorStateScript.State.DRAGGING, Vector2.ZERO)
+	assert_true(_overlay.visible)
+	_overlay.set_state(CursorStateScript.State.CAN_DROP, Vector2(50, 50))
+	assert_eq(_overlay.global_position, Vector2(50, 50))

--- a/tests/unit/items/test_grab_feel.gd.uid
+++ b/tests/unit/items/test_grab_feel.gd.uid
@@ -1,0 +1,1 @@
+uid://bkly1x8qgnlet


### PR DESCRIPTION
Implements the grab side of the equip-loop drag, in parallel with SH-287 (#533) which owns the release path.

Held body lifts onto the cursor via a short cubic ease (~80 ms) instead of teleport-snapping, so position, scale, and modulation read as one continuous motion. Live balls grow a child `PressArea` Area2D wider than their physics shape so a press near a moving ball lands without pixel precision. A four-state cursor state machine (`default` / `dragging` / `can_drop` / `forbidden`) is exposed off the drag controller; a Node2D `CursorOverlay` placeholder visual sits on the same seam where SH-298's cursor textures will drop in.

The cursor-state derivation is currently routed through the existing rack/court predicates; on merge of #533 the seam re-points at SH-287's `_find_accepting_target`. The release-path code remains untouched so the conflict surface against #533 is small and bounded to the grab/cursor regions.