### PR TITLE
SH-314 dragged-gravity held-body state

### DIFF
--- a/scenes/items/held_body.tscn
+++ b/scenes/items/held_body.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=2 format=3 uid="uid://b7sh314heldbody"]
+
+[ext_resource type="Script" uid="uid://dxwfoo1jc2set" path="res://scripts/items/held_body.gd" id="1_held"]
+
+[node name="HeldBody" type="RigidBody2D"]
+collision_layer = 0
+collision_mask = 0
+input_pickable = false
+gravity_scale = 0.0
+lock_rotation = true
+contact_monitor = false
+freeze = true
+freeze_mode = 1
+linear_damp = 1.0
+script = ExtResource("1_held")
+
+[node name="Collision" type="CollisionShape2D" parent="."]

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -1,7 +1,7 @@
 class_name BallDragController
 extends Node2D
 
-## Owns the held-token visual during a ball or equipment drag gesture and polls every registered DropTarget for a valid commit.
+## Owns the held-body during a drag gesture and polls every registered DropTarget for a valid commit.
 
 signal pickup_started(item_key: String)
 signal drop_completed(item_key: String, release_position: Vector2, over_court: bool)
@@ -11,18 +11,14 @@ const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd
 
 const CURSOR_SAMPLE_WINDOW: float = 0.08
 const PRESERVED_SPEED_NONE: float = -1.0
-## Minimum cursor travel before a rack-origin gesture counts as a real drag (SH-252 a).
+## Minimum cursor travel before a rack-origin gesture counts as a real drag.
 const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
 const HOVER_SCALE_BUMP: Vector2 = Vector2(1.08, 1.08)
 const HOVER_MODULATE: Color = Color(1.15, 1.15, 1.15, 1.0)
 const NEUTRAL_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
-## Duration of the grab ease-to-cursor lift; the held token tweens for this long after a press.
 @export var grab_ease_duration_s: float = 0.08
-## Scale multiplier on the held token at the start of the lift; eases up to 1.0 over the window.
 @export var grab_ease_start_scale: Vector2 = Vector2(0.85, 0.85)
-## Modulate at the start of the lift; the alpha eases up to grab_ease_end_modulate.
 @export var grab_ease_start_modulate: Color = Color(1.0, 1.0, 1.0, 0.0)
-## Modulate at the end of the lift.
 @export var grab_ease_end_modulate: Color = Color(1.0, 1.0, 1.0, 1.0)
 
 @export var rack: RackDisplay
@@ -40,23 +36,20 @@ var _item_manager: Node
 var _held_body: HeldBody = null
 var _held_key: String = ""
 var _held_is_temporary: bool = false
-## Was the item on-court before the gesture? Rack pickups defer activation, so a click-without-movement is a no-op.
 var _held_was_on_court: bool = false
-## &"rack" or &"live"; rack origins gate the SH-252 click-without-movement no-op.
+## &"rack" or &"live"; rack origins gate the click-without-movement no-op.
 var _held_origin: StringName = &"rack"
 var _cursor_samples: Array = []
-## Cursor position when the held token spawned; gates the SH-252 a click-without-movement no-op.
 var _press_position: Vector2 = Vector2.ZERO
 var _gesture_below_threshold: bool = true
-## SH-287: tracks mouse-button state so _process can poll for valid targets when mouse is up.
 var _mouse_button_down: bool = false
-## Mid-rally rally speed inherited by the released ball; negative means none preserved.
+## Negative means no preserved energy; positive carries rally speed across grab+release.
 var _held_preserved_speed: float = PRESERVED_SPEED_NONE
 var _grab_origin_position: Vector2 = Vector2.ZERO
 var _grab_ease_elapsed: float = 0.0
 var _grab_target_scale: Vector2 = Vector2.ONE
 var _cursor_state: int = CursorStateScript.State.DEFAULT
-## Monotonic seconds when expansion-ring polling started; negative means not yet timing.
+## Negative means expansion-ring polling has not started timing yet.
 var _expansion_started_at: float = -1.0
 
 var _drop_targets: Array[DropTarget] = []
@@ -122,7 +115,7 @@ func _process(delta: float) -> void:
 		if not attempt_release(follow_position):
 			_update_expansion_state(follow_position)
 	elif ease_progress >= 1.0:
-		# Hover feedback is suppressed while the SH-297 lift ease is still settling.
+		# Hover feedback is suppressed until the lift ease settles to avoid mid-tween bumps.
 		_update_hover_feedback(follow_position)
 
 
@@ -138,7 +131,7 @@ func _input(event: InputEvent) -> void:
 	if mouse_button.pressed or _held_body == null:
 		return
 
-	# Use the event's own position so a Camera2D in the venue doesn't break rack hit-testing.
+	# Use event position so a Camera2D in the venue doesn't break rack hit-testing.
 	if not attempt_release(_clamp_to_venue(_event_world_position(mouse_button))):
 		_expansion_started_at = _now_seconds()
 
@@ -151,7 +144,7 @@ func get_held_key() -> String:
 	return _held_key
 
 
-func get_held_token() -> Node2D:
+func get_held_body() -> HeldBody:
 	return _held_body
 
 
@@ -159,8 +152,7 @@ func get_cursor_state() -> int:
 	return _cursor_state
 
 
-## Public registration so subsystems with their own area resources (Shop) can join the
-## target poll without owning the held token.
+## Lets subsystems with their own area resources (Shop) join the target poll without owning the held body.
 func register_target(target: DropTarget) -> void:
 	if target == null:
 		return
@@ -179,7 +171,7 @@ func get_registered_targets() -> Array[DropTarget]:
 	return _drop_targets.duplicate()
 
 
-## Test seam / production entry for rack-origin pickups. Activation defers to release-over-court (SH-245).
+## Activation defers to release-over-court so a click-without-movement is a no-op.
 func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
 	if _held_body != null:
 		return false
@@ -191,7 +183,7 @@ func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
 	var spawn_position: Vector2 = (
 		press_position if press_position is Vector2 else _cursor_position()
 	)
-	_spawn_held_token(item_key, spawn_position, false)
+	_spawn_held_body(item_key, spawn_position, false)
 	_held_was_on_court = false
 	_held_origin = &"rack"
 	# A grab only happens on a press; assume mouse is down so polling waits for mouse-up.
@@ -200,7 +192,6 @@ func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
 	return true
 
 
-## Test seam / production entry for mid-rally live-ball grabs.
 func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 	if _held_body != null:
 		return false
@@ -212,15 +203,14 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 	var spawn_position: Vector2 = _cursor_position()
 	if existing != null:
 		spawn_position = existing.global_position
-		# SH-288: capture the rally's friendship energy before freeing the live ball so the
-		# released ball inherits it. Reset only on miss, never on grab-and-release.
+		# Capture rally speed before freeing the live ball so the released ball inherits it.
 		_held_preserved_speed = existing.speed
 		if reconciler != null:
 			reconciler.release_ball(item_key)
 		existing.freeze = true
 		existing.call_deferred("queue_free")
 
-	_spawn_held_token(item_key, spawn_position, is_temporary)
+	_spawn_held_body(item_key, spawn_position, is_temporary)
 	_held_was_on_court = not is_temporary
 	_held_origin = &"live"
 	_mouse_button_down = true
@@ -228,7 +218,7 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 	return true
 
 
-## Returns true if a court target accepted; false routes the new token to the rack.
+## Returns true if a court target accepted; false routes the new item to the rack.
 func spawn_purchased_at(
 	item_key: String, world_position: Vector2, gesture_velocity: Vector2
 ) -> bool:
@@ -242,7 +232,7 @@ func spawn_purchased_at(
 	return true
 
 
-## Returns false on no valid target so the held token stays with the cursor.
+## Returns false on no valid target so the held body stays with the cursor.
 func attempt_release(release_position: Vector2) -> bool:
 	if _held_body == null:
 		return false
@@ -251,7 +241,7 @@ func attempt_release(release_position: Vector2) -> bool:
 	var item_key: String = _held_key
 	var was_temporary: bool = _held_is_temporary
 
-	# Direct callers bypass _process, so re-check distance here to keep the no-op gate honest.
+	# Direct callers bypass _process; re-check distance to keep the no-op gate honest.
 	var below_threshold: bool = _gesture_below_threshold
 	if below_threshold:
 		below_threshold = (
@@ -306,7 +296,7 @@ func _release_loose(release_position: Vector2, was_temporary: bool) -> void:
 	body.global_position = release_position
 	body.modulate = grab_ease_end_modulate
 	body.go_loose(release_velocity)
-	# Drop our handle so the loose body survives gesture finalisation.
+	# Drop the handle so finalisation does not free the loose body.
 	_held_body = null
 
 
@@ -324,7 +314,6 @@ func _loose_body_host() -> Node:
 	return get_parent()
 
 
-## Re-applies mid-rally preserved speed to the freshly spawned ball after a court/venue accept.
 func _apply_preserved_speed_after_accept(item_key: String) -> void:
 	if _held_preserved_speed < 0.0:
 		return
@@ -338,7 +327,6 @@ func _apply_preserved_speed_after_accept(item_key: String) -> void:
 		ball.linear_velocity = ball.linear_velocity.normalized() * _held_preserved_speed
 
 
-## Polled in registration order; built-ins register court before venue.
 func _find_accepting_target(
 	item_key: String, world_position: Vector2, scale_factor: float
 ) -> DropTarget:
@@ -348,7 +336,6 @@ func _find_accepting_target(
 	return null
 
 
-## Hover-feedback bump applied to the held token while a target accepts the current pos.
 func _update_hover_feedback(world_position: Vector2) -> void:
 	if _held_body == null:
 		return
@@ -363,7 +350,6 @@ func _update_hover_feedback(world_position: Vector2) -> void:
 		_held_body.modulate = NEUTRAL_MODULATE
 
 
-## Cancels back to source after the widened poll has also failed for one full hold window.
 func _update_expansion_state(world_position: Vector2) -> void:
 	if _held_body == null:
 		return
@@ -379,7 +365,6 @@ func _update_expansion_state(world_position: Vector2) -> void:
 		_held_key, world_position, expansion_ring_scale
 	)
 	if widened != null:
-		# Re-run now so the commit lands this frame instead of waiting for the next attempt_release.
 		attempt_release(world_position)
 		return
 
@@ -387,7 +372,7 @@ func _update_expansion_state(world_position: Vector2) -> void:
 		_cancel_to_source()
 
 
-## Live-ball grabs that cancel must deactivate the on-court placement so the rack regrows it.
+## Live-ball cancels deactivate the on-court placement so the rack regrows the at-rest token.
 func _cancel_to_source() -> void:
 	var item_key: String = _held_key
 	var was_on_court: bool = _held_was_on_court
@@ -427,7 +412,7 @@ func _reset_gesture_state() -> void:
 	_expansion_started_at = -1.0
 
 
-func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: bool) -> void:
+func _spawn_held_body(item_key: String, spawn_position: Vector2, is_temporary: bool) -> void:
 	var definition: ItemDefinition = _get_item_definition(item_key)
 	var target_scale: Vector2 = Vector2.ONE
 	if definition != null:
@@ -452,7 +437,7 @@ func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: 
 	_track_cursor_motion(spawn_position)
 
 
-## Registers the controller's authored targets in priority order: court strict projection first, role-aware racks, venue catch-all.
+## Priority order: court strict projection first, role-aware racks, venue catch-all last.
 func _register_builtin_targets() -> void:
 	_drop_targets.clear()
 	_builtin_targets.clear()
@@ -495,7 +480,6 @@ func _make_venue_target() -> VenueDropTarget:
 	return venue_target
 
 
-## Records cursor positions across a short rolling window so release velocity can be derived from recent motion.
 func _track_cursor_motion(sample_position: Vector2) -> void:
 	var now_ms: float = float(Time.get_ticks_msec()) / 1000.0
 	_cursor_samples.append({"time": now_ms, "position": sample_position})
@@ -579,7 +563,7 @@ func _update_cursor_state(world_position: Vector2) -> void:
 func _derive_cursor_state(world_position: Vector2) -> int:
 	if _held_body == null:
 		return CursorStateScript.State.DEFAULT
-	# The held token is clamped to venue but the raw cursor can drift outside.
+	# The held body is clamped to venue but the raw cursor can drift outside.
 	if not _is_within_venue(_cursor_position()):
 		return CursorStateScript.State.FORBIDDEN
 	if _position_accepted_by_any_target(_held_key, world_position):
@@ -590,7 +574,6 @@ func _derive_cursor_state(world_position: Vector2) -> int:
 func _position_accepted_by_any_target(item_key: String, world_position: Vector2) -> bool:
 	if item_key.is_empty():
 		return false
-	# SH-287: delegate to the registered DropTarget poll so cursor state mirrors release acceptance exactly.
 	return _find_accepting_target(item_key, world_position, 1.0) != null
 
 
@@ -610,7 +593,6 @@ func _on_rack_slot_pressed(item_key: String, press_position: Vector2) -> void:
 
 
 func _on_reconciler_ball_spawned(item_key: String, ball: Ball) -> void:
-	# Each Ball is a fresh instance from ensure_ball_for_key, no double-connect risk.
 	ball.pressed.connect(_on_live_ball_pressed.bind(item_key))
 
 

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -37,7 +37,10 @@ const NEUTRAL_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
 @export var expansion_ring_scale: float = 1.5
 
 var _item_manager: Node
+## SH-314: held body is a `HeldBody` (RigidBody2D) so dragged-gravity is real physics; the typed
+## reference stays Node2D so existing callers and tests reading `.global_position`/`.scale` keep working.
 var _held_token: Node2D = null
+var _held_body: HeldBody = null
 var _held_key: String = ""
 var _held_is_temporary: bool = false
 ## Was the item on-court before the gesture? Rack pickups defer activation, so a click-without-movement is a no-op.
@@ -228,7 +231,9 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 	return true
 
 
-## Shop-purchase entry: returns true if a court/venue target accepted; false routes the new token to the rack.
+## Shop-purchase entry: returns true if a court target accepted; false routes the new token to the rack.
+## SH-314: VenueDropTarget no longer brings into play (loose state instead), so the shop entry only
+## counts the court-side accept here. Loose shop-purchase flow is a separate concern.
 func spawn_purchased_at(
 	item_key: String, world_position: Vector2, gesture_velocity: Vector2
 ) -> bool:
@@ -236,7 +241,7 @@ func spawn_purchased_at(
 	var target: DropTarget = _find_accepting_target(item_key, world_position, 1.0)
 	if target == null:
 		return false
-	if not (target is CourtDropTarget or target is VenueDropTarget):
+	if not (target is CourtDropTarget):
 		return false
 	target.accept(item_key, world_position, gesture_velocity)
 	return true
@@ -272,7 +277,7 @@ func attempt_release(release_position: Vector2) -> bool:
 	if target == null:
 		return false
 
-	if target is CourtDropTarget or target is VenueDropTarget:
+	if target is CourtDropTarget:
 		var velocity: Vector2 = _compute_release_velocity()
 		if was_temporary:
 			# Temporary balls bypass the reconciler so they don't survive the gesture.
@@ -280,14 +285,73 @@ func attempt_release(release_position: Vector2) -> bool:
 		else:
 			target.accept(item_key, clamped_position, velocity)
 			_apply_preserved_speed_after_accept(item_key)
+	elif target is VenueDropTarget:
+		# SH-314: loose-on-venue-floor. The held body unfreezes and falls under gravity.
+		_release_loose(item_key, clamped_position, was_temporary)
+		var over_court_loose: bool = false
+		_finalise_loose_gesture(item_key, clamped_position, over_court_loose)
+		return true
 	else:
 		target.accept(item_key, clamped_position, Vector2.ZERO)
 
-	var over_court: bool = target is CourtDropTarget or target is VenueDropTarget
+	var over_court: bool = target is CourtDropTarget
 	if was_temporary:
 		over_court = false
 	_finalise_gesture(item_key, clamped_position, over_court)
 	return true
+
+
+## SH-314: detach the held body from the controller and unfreeze it so gravity finishes the motion.
+func _release_loose(_item_key: String, release_position: Vector2, was_temporary: bool) -> void:
+	if _held_body == null:
+		return
+	if was_temporary:
+		# Temporary held bodies do not survive the gesture; the standard finaliser will free.
+		return
+	var release_velocity: Vector2 = _compute_release_velocity()
+	var body: HeldBody = _held_body
+	# Reparent to the reconciler's ball host (or to our parent as a fallback) so the body keeps
+	# living after the controller clears its references in _finalise_loose_gesture.
+	var host: Node = _loose_body_host()
+	if host != null and body.get_parent() != host:
+		body.get_parent().remove_child(body)
+		host.add_child(body)
+	body.global_position = release_position
+	body.scale = body.scale  # already at token_scale from the lift settle
+	body.modulate = grab_ease_end_modulate
+	body.go_loose(release_velocity)
+	# Drop our handle so _finalise_loose_gesture does not free the body we just released.
+	_held_token = null
+	_held_body = null
+	# Suppress the standard finaliser's queue_free; tracked via the dropped reference above.
+
+
+## Loose finaliser: keeps state-clear semantics but never frees the held body (release_loose owns it).
+func _finalise_loose_gesture(item_key: String, release_position: Vector2, over_court: bool) -> void:
+	# After _release_loose, _held_token/_held_body are already cleared. Run the rest of the
+	# state reset without touching the body so the loose body persists in the venue.
+	_held_token = null
+	_held_body = null
+	_held_key = ""
+	_held_is_temporary = false
+	_held_was_on_court = false
+	_held_origin = &"rack"
+	_held_preserved_speed = PRESERVED_SPEED_NONE
+	_cursor_samples.clear()
+	_press_position = Vector2.ZERO
+	_gesture_below_threshold = true
+	_grab_origin_position = Vector2.ZERO
+	_grab_ease_elapsed = 0.0
+	_grab_target_scale = Vector2.ONE
+	_expansion_started_at = -1.0
+	_set_cursor_state(CursorStateScript.State.DEFAULT, release_position)
+	drop_completed.emit(item_key, release_position, over_court)
+
+
+func _loose_body_host() -> Node:
+	if reconciler != null and reconciler._ball_host != null:
+		return reconciler._ball_host
+	return get_parent()
 
 
 ## Re-applies mid-rally preserved speed to the freshly spawned ball after a court/venue accept.
@@ -374,6 +438,7 @@ func _finalise_gesture(item_key: String, release_position: Vector2, over_court: 
 	if _held_token != null:
 		_held_token.queue_free()
 	_held_token = null
+	_held_body = null
 	_held_key = ""
 	_held_is_temporary = false
 	_held_was_on_court = false
@@ -391,22 +456,21 @@ func _finalise_gesture(item_key: String, release_position: Vector2, over_court: 
 
 
 func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: bool) -> void:
-	var token: Node2D = Node2D.new()
-	token.name = "HeldToken_%s" % item_key
-	token.global_position = spawn_position
-
 	var definition: ItemDefinition = _get_item_definition(item_key)
 	var target_scale: Vector2 = Vector2.ONE
 	if definition != null:
 		target_scale = definition.token_scale
-	token.scale = grab_ease_start_scale * target_scale
-	token.modulate = grab_ease_start_modulate
-	if definition != null and definition.art != null:
-		var art_instance: Node = definition.art.instantiate()
-		token.add_child(art_instance)
-	add_child(token)
 
-	_held_token = token
+	# SH-314: dragged-gravity body. Frozen-kinematic during lift+held so the controller drives
+	# position; release flips freeze off only for the loose-on-venue-floor branch.
+	var body: HeldBody = HeldBody.make_for(definition, item_key)
+	body.global_position = spawn_position
+	body.scale = grab_ease_start_scale * target_scale
+	body.modulate = grab_ease_start_modulate
+	add_child(body)
+
+	_held_token = body
+	_held_body = body
 	_held_key = item_key
 	_held_is_temporary = is_temporary
 	_press_position = spawn_position
@@ -457,6 +521,8 @@ func _make_venue_target() -> VenueDropTarget:
 		return null
 	var venue_target: VenueDropTarget = VenueDropTarget.new()
 	venue_target.configure(_item_manager, reconciler, venue_bounds, court_bounds)
+	# Body projection on the venue rect rejects loose drops that would land in walls/partners.
+	venue_target.set_world(get_world_2d())
 	return venue_target
 
 
@@ -532,6 +598,10 @@ func _apply_grab_ease(progress: float, cursor_target: Vector2) -> void:
 	_held_token.global_position = _grab_origin_position.lerp(cursor_target, eased)
 	_held_token.scale = (grab_ease_start_scale * _grab_target_scale).lerp(_grab_target_scale, eased)
 	_held_token.modulate = grab_ease_start_modulate.lerp(grab_ease_end_modulate, eased)
+	# SH-314: gravity engages once the lift settles; the body is still cursor-pinned (frozen) but
+	# any later release into the venue floor uses its loose_gravity_scale.
+	if _held_body != null and progress >= 1.0 and _held_body.phase == HeldBody.Phase.LIFTING:
+		_held_body.mark_held()
 
 
 func _update_cursor_state(world_position: Vector2) -> void:

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -323,6 +323,10 @@ func _apply_preserved_speed_after_accept(item_key: String) -> void:
 	if ball == null:
 		return
 	ball.speed = _held_preserved_speed
+	# Re-sync the effect processor's base so the next physics frame's speed-limit clamp
+	# does not snap us back to ball_speed_min.
+	if ball.effect_processor != null:
+		ball.effect_processor.sync_base_speed()
 	if ball.linear_velocity.length() > 0.0:
 		ball.linear_velocity = ball.linear_velocity.normalized() * _held_preserved_speed
 

--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -37,9 +37,6 @@ const NEUTRAL_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
 @export var expansion_ring_scale: float = 1.5
 
 var _item_manager: Node
-## SH-314: held body is a `HeldBody` (RigidBody2D) so dragged-gravity is real physics; the typed
-## reference stays Node2D so existing callers and tests reading `.global_position`/`.scale` keep working.
-var _held_token: Node2D = null
 var _held_body: HeldBody = null
 var _held_key: String = ""
 var _held_is_temporary: bool = false
@@ -104,7 +101,7 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
-	if _held_token == null:
+	if _held_body == null:
 		_set_cursor_state(CursorStateScript.State.DEFAULT, _cursor_position())
 		return
 
@@ -113,7 +110,7 @@ func _process(delta: float) -> void:
 	var ease_progress: float = _grab_ease_progress()
 	_apply_grab_ease(ease_progress, cursor_target)
 
-	var follow_position: Vector2 = _held_token.global_position
+	var follow_position: Vector2 = _held_body.global_position
 	_track_cursor_motion(follow_position)
 	if _gesture_below_threshold:
 		if follow_position.distance_to(_press_position) >= COMMIT_MOVEMENT_THRESHOLD_PX:
@@ -138,7 +135,7 @@ func _input(event: InputEvent) -> void:
 		return
 
 	_mouse_button_down = mouse_button.pressed
-	if mouse_button.pressed or _held_token == null:
+	if mouse_button.pressed or _held_body == null:
 		return
 
 	# Use the event's own position so a Camera2D in the venue doesn't break rack hit-testing.
@@ -147,7 +144,7 @@ func _input(event: InputEvent) -> void:
 
 
 func is_dragging() -> bool:
-	return _held_token != null
+	return _held_body != null
 
 
 func get_held_key() -> String:
@@ -155,7 +152,7 @@ func get_held_key() -> String:
 
 
 func get_held_token() -> Node2D:
-	return _held_token
+	return _held_body
 
 
 func get_cursor_state() -> int:
@@ -184,7 +181,7 @@ func get_registered_targets() -> Array[DropTarget]:
 
 ## Test seam / production entry for rack-origin pickups. Activation defers to release-over-court (SH-245).
 func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
-	if _held_token != null:
+	if _held_body != null:
 		return false
 	if _item_manager.get_level(item_key) <= 0:
 		return false
@@ -205,7 +202,7 @@ func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
 
 ## Test seam / production entry for mid-rally live-ball grabs.
 func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
-	if _held_token != null:
+	if _held_body != null:
 		return false
 
 	var existing: Ball = null
@@ -231,9 +228,7 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 	return true
 
 
-## Shop-purchase entry: returns true if a court target accepted; false routes the new token to the rack.
-## SH-314: VenueDropTarget no longer brings into play (loose state instead), so the shop entry only
-## counts the court-side accept here. Loose shop-purchase flow is a separate concern.
+## Returns true if a court target accepted; false routes the new token to the rack.
 func spawn_purchased_at(
 	item_key: String, world_position: Vector2, gesture_velocity: Vector2
 ) -> bool:
@@ -249,7 +244,7 @@ func spawn_purchased_at(
 
 ## Returns false on no valid target so the held token stays with the cursor.
 func attempt_release(release_position: Vector2) -> bool:
-	if _held_token == null:
+	if _held_body == null:
 		return false
 
 	var clamped_position: Vector2 = _clamp_to_venue(release_position)
@@ -263,7 +258,7 @@ func attempt_release(release_position: Vector2) -> bool:
 			clamped_position.distance_to(_press_position) < COMMIT_MOVEMENT_THRESHOLD_PX
 		)
 
-	# SH-252 a: a press-and-release without movement on a rack-origin gesture cancels back to source.
+	# Rack-origin press-and-release without movement cancels back to source instead of activating.
 	if below_threshold and _held_origin == &"rack" and not _held_was_on_court and not was_temporary:
 		_finalise_gesture(item_key, clamped_position, false)
 		return true
@@ -286,10 +281,8 @@ func attempt_release(release_position: Vector2) -> bool:
 			target.accept(item_key, clamped_position, velocity)
 			_apply_preserved_speed_after_accept(item_key)
 	elif target is VenueDropTarget:
-		# SH-314: loose-on-venue-floor. The held body unfreezes and falls under gravity.
-		_release_loose(item_key, clamped_position, was_temporary)
-		var over_court_loose: bool = false
-		_finalise_loose_gesture(item_key, clamped_position, over_court_loose)
+		_release_loose(clamped_position, was_temporary)
+		_finalise_loose_gesture(item_key, clamped_position, false)
 		return true
 	else:
 		target.accept(item_key, clamped_position, Vector2.ZERO)
@@ -301,56 +294,33 @@ func attempt_release(release_position: Vector2) -> bool:
 	return true
 
 
-## SH-314: detach the held body from the controller and unfreeze it so gravity finishes the motion.
-func _release_loose(_item_key: String, release_position: Vector2, was_temporary: bool) -> void:
-	if _held_body == null:
-		return
-	if was_temporary:
-		# Temporary held bodies do not survive the gesture; the standard finaliser will free.
+func _release_loose(release_position: Vector2, was_temporary: bool) -> void:
+	if _held_body == null or was_temporary:
 		return
 	var release_velocity: Vector2 = _compute_release_velocity()
 	var body: HeldBody = _held_body
-	# Reparent to the reconciler's ball host (or to our parent as a fallback) so the body keeps
-	# living after the controller clears its references in _finalise_loose_gesture.
 	var host: Node = _loose_body_host()
 	if host != null and body.get_parent() != host:
 		body.get_parent().remove_child(body)
 		host.add_child(body)
 	body.global_position = release_position
-	body.scale = body.scale  # already at token_scale from the lift settle
 	body.modulate = grab_ease_end_modulate
 	body.go_loose(release_velocity)
-	# Drop our handle so _finalise_loose_gesture does not free the body we just released.
-	_held_token = null
+	# Drop our handle so the loose body survives gesture finalisation.
 	_held_body = null
-	# Suppress the standard finaliser's queue_free; tracked via the dropped reference above.
 
 
-## Loose finaliser: keeps state-clear semantics but never frees the held body (release_loose owns it).
 func _finalise_loose_gesture(item_key: String, release_position: Vector2, over_court: bool) -> void:
-	# After _release_loose, _held_token/_held_body are already cleared. Run the rest of the
-	# state reset without touching the body so the loose body persists in the venue.
-	_held_token = null
-	_held_body = null
-	_held_key = ""
-	_held_is_temporary = false
-	_held_was_on_court = false
-	_held_origin = &"rack"
-	_held_preserved_speed = PRESERVED_SPEED_NONE
-	_cursor_samples.clear()
-	_press_position = Vector2.ZERO
-	_gesture_below_threshold = true
-	_grab_origin_position = Vector2.ZERO
-	_grab_ease_elapsed = 0.0
-	_grab_target_scale = Vector2.ONE
-	_expansion_started_at = -1.0
+	_reset_gesture_state()
 	_set_cursor_state(CursorStateScript.State.DEFAULT, release_position)
 	drop_completed.emit(item_key, release_position, over_court)
 
 
 func _loose_body_host() -> Node:
-	if reconciler != null and reconciler._ball_host != null:
-		return reconciler._ball_host
+	if reconciler != null:
+		var host: Node = reconciler.get_ball_host()
+		if host != null:
+			return host
 	return get_parent()
 
 
@@ -380,22 +350,22 @@ func _find_accepting_target(
 
 ## Hover-feedback bump applied to the held token while a target accepts the current pos.
 func _update_hover_feedback(world_position: Vector2) -> void:
-	if _held_token == null:
+	if _held_body == null:
 		return
 	var hovering: bool = _find_accepting_target(_held_key, world_position, 1.0) != null
 	var definition: ItemDefinition = _get_item_definition(_held_key)
 	var base_scale: Vector2 = definition.token_scale if definition != null else Vector2.ONE
 	if hovering:
-		_held_token.scale = base_scale * HOVER_SCALE_BUMP
-		_held_token.modulate = HOVER_MODULATE
+		_held_body.scale = base_scale * HOVER_SCALE_BUMP
+		_held_body.modulate = HOVER_MODULATE
 	else:
-		_held_token.scale = base_scale
-		_held_token.modulate = NEUTRAL_MODULATE
+		_held_body.scale = base_scale
+		_held_body.modulate = NEUTRAL_MODULATE
 
 
 ## Cancels back to source after the widened poll has also failed for one full hold window.
 func _update_expansion_state(world_position: Vector2) -> void:
-	if _held_token == null:
+	if _held_body == null:
 		return
 	if _expansion_started_at < 0.0:
 		_expansion_started_at = _now_seconds()
@@ -423,7 +393,7 @@ func _cancel_to_source() -> void:
 	var was_on_court: bool = _held_was_on_court
 	var origin: StringName = _held_origin
 	var release_position: Vector2 = (
-		_held_token.global_position if _held_token != null else _press_position
+		_held_body.global_position if _held_body != null else _press_position
 	)
 
 	if origin == &"live" and was_on_court:
@@ -433,11 +403,15 @@ func _cancel_to_source() -> void:
 	_finalise_gesture(item_key, release_position, false)
 
 
-## Clear held-token state after a successful commit (rack accept or court spawn).
 func _finalise_gesture(item_key: String, release_position: Vector2, over_court: bool) -> void:
-	if _held_token != null:
-		_held_token.queue_free()
-	_held_token = null
+	if _held_body != null:
+		_held_body.queue_free()
+	_reset_gesture_state()
+	_set_cursor_state(CursorStateScript.State.DEFAULT, release_position)
+	drop_completed.emit(item_key, release_position, over_court)
+
+
+func _reset_gesture_state() -> void:
 	_held_body = null
 	_held_key = ""
 	_held_is_temporary = false
@@ -451,8 +425,6 @@ func _finalise_gesture(item_key: String, release_position: Vector2, over_court: 
 	_grab_ease_elapsed = 0.0
 	_grab_target_scale = Vector2.ONE
 	_expansion_started_at = -1.0
-	_set_cursor_state(CursorStateScript.State.DEFAULT, release_position)
-	drop_completed.emit(item_key, release_position, over_court)
 
 
 func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: bool) -> void:
@@ -461,15 +433,12 @@ func _spawn_held_token(item_key: String, spawn_position: Vector2, is_temporary: 
 	if definition != null:
 		target_scale = definition.token_scale
 
-	# SH-314: dragged-gravity body. Frozen-kinematic during lift+held so the controller drives
-	# position; release flips freeze off only for the loose-on-venue-floor branch.
 	var body: HeldBody = HeldBody.make_for(definition, item_key)
 	body.global_position = spawn_position
 	body.scale = grab_ease_start_scale * target_scale
 	body.modulate = grab_ease_start_modulate
 	add_child(body)
 
-	_held_token = body
 	_held_body = body
 	_held_key = item_key
 	_held_is_temporary = is_temporary
@@ -590,17 +559,15 @@ func _grab_ease_progress() -> float:
 
 
 func _apply_grab_ease(progress: float, cursor_target: Vector2) -> void:
-	if _held_token == null:
+	if _held_body == null:
 		return
 	# Cubic ease-out: 1 - (1 - t)^3.
 	var inv: float = 1.0 - progress
 	var eased: float = 1.0 - inv * inv * inv
-	_held_token.global_position = _grab_origin_position.lerp(cursor_target, eased)
-	_held_token.scale = (grab_ease_start_scale * _grab_target_scale).lerp(_grab_target_scale, eased)
-	_held_token.modulate = grab_ease_start_modulate.lerp(grab_ease_end_modulate, eased)
-	# SH-314: gravity engages once the lift settles; the body is still cursor-pinned (frozen) but
-	# any later release into the venue floor uses its loose_gravity_scale.
-	if _held_body != null and progress >= 1.0 and _held_body.phase == HeldBody.Phase.LIFTING:
+	_held_body.global_position = _grab_origin_position.lerp(cursor_target, eased)
+	_held_body.scale = (grab_ease_start_scale * _grab_target_scale).lerp(_grab_target_scale, eased)
+	_held_body.modulate = grab_ease_start_modulate.lerp(grab_ease_end_modulate, eased)
+	if progress >= 1.0 and _held_body.phase == HeldBody.Phase.LIFTING:
 		_held_body.mark_held()
 
 
@@ -610,7 +577,7 @@ func _update_cursor_state(world_position: Vector2) -> void:
 
 
 func _derive_cursor_state(world_position: Vector2) -> int:
-	if _held_token == null:
+	if _held_body == null:
 		return CursorStateScript.State.DEFAULT
 	# The held token is clamped to venue but the raw cursor can drift outside.
 	if not _is_within_venue(_cursor_position()):

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -140,6 +140,10 @@ func _apply_preserved_speed(ball: Ball, preserved_speed: float) -> void:
 	if preserved_speed < 0.0:
 		return
 	ball.speed = preserved_speed
+	# Re-sync the effect processor's base so the next physics frame's speed-limit clamp
+	# does not snap us back to ball_speed_min.
+	if ball.effect_processor != null:
+		ball.effect_processor.sync_base_speed()
 	if ball.linear_velocity.length() > 0.0:
 		ball.linear_velocity = ball.linear_velocity.normalized() * preserved_speed
 

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -27,6 +27,10 @@ func configure(item_manager: Node, ball_host: Node) -> void:
 	_ball_host = ball_host
 
 
+func get_ball_host() -> Node:
+	return _ball_host
+
+
 func _ready() -> void:
 	if _item_manager == null:
 		_item_manager = ItemManager

--- a/scripts/items/drop_targets/court_drop_target.gd
+++ b/scripts/items/drop_targets/court_drop_target.gd
@@ -58,14 +58,9 @@ func _projection_clear(item_key: String, position: Vector2, scale_factor: float)
 	if space == null:
 		return true
 	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
-	var shape: Shape2D = null
-	if definition != null and definition.at_rest_shape != null:
-		shape = _scaled_shape(definition.at_rest_shape, scale_factor)
-	if shape == null:
-		# Legacy probe radius for items (e.g. test fixtures) missing an authored shape.
-		var circle: CircleShape2D = CircleShape2D.new()
-		circle.radius = 14.0 * scale_factor
-		shape = circle
+	if definition == null or definition.at_rest_shape == null:
+		return false
+	var shape: Shape2D = _scaled_shape(definition.at_rest_shape, scale_factor)
 	var params: PhysicsShapeQueryParameters2D = PhysicsShapeQueryParameters2D.new()
 	params.shape = shape
 	params.transform = Transform2D(0.0, position)

--- a/scripts/items/drop_targets/venue_drop_target.gd
+++ b/scripts/items/drop_targets/venue_drop_target.gd
@@ -1,9 +1,7 @@
 class_name VenueDropTarget
 extends DropTarget
 
-## SH-314 dragged-gravity: accepts releases inside the venue rect when the at-rest projection clears,
-## so the held body can fall as a loose RigidBody2D. The controller branches on `target is VenueDropTarget`
-## to keep the body alive after release; this target's `accept` is intentionally a no-op for that reason.
+## Accepts releases inside the venue rect; the controller branches on this type to keep the body alive after release.
 
 var _item_manager: Node
 var _reconciler: BallReconciler
@@ -24,7 +22,6 @@ func configure(
 	_court_bounds = court_bounds
 
 
-## Optional: enables body-projection on the venue rect so wall/partner overlap rejects the loose drop.
 func set_world(world: World2D) -> void:
 	_world = world
 
@@ -40,15 +37,11 @@ func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) 
 	)
 	if not inside:
 		return false
-	# Body projection: a loose drop must clear walls/partners just like a court drop.
-	# Skipped when no World2D was provided (test fixtures keep working without one).
 	if _world == null:
 		return true
 	return _projection_clear(item_key, position, scale_factor)
 
 
-## SH-314: the controller owns the loose handoff (reparents and unfreezes the held body).
-## This accept is kept for DropTarget contract symmetry but does no work.
 func accept(_item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
 	pass
 
@@ -86,4 +79,10 @@ func _scaled_shape(source: Shape2D, scale_factor: float) -> Shape2D:
 		var scaled_rect: RectangleShape2D = RectangleShape2D.new()
 		scaled_rect.size = src_rect.size * scale_factor
 		return scaled_rect
+	push_warning(
+		(
+			"VenueDropTarget._scaled_shape: unscaled %s falls through; expansion-ring projection will be wrong."
+			% source.get_class()
+		)
+	)
 	return source

--- a/scripts/items/drop_targets/venue_drop_target.gd
+++ b/scripts/items/drop_targets/venue_drop_target.gd
@@ -1,12 +1,15 @@
 class_name VenueDropTarget
 extends DropTarget
 
-## Lowest-priority fallback: ball-role releases inside the venue rect clamp to the court edge.
+## SH-314 dragged-gravity: accepts releases inside the venue rect when the at-rest projection clears,
+## so the held body can fall as a loose RigidBody2D. The controller branches on `target is VenueDropTarget`
+## to keep the body alive after release; this target's `accept` is intentionally a no-op for that reason.
 
 var _item_manager: Node
 var _reconciler: BallReconciler
 var _venue_bounds: Rect2
 var _court_bounds: Rect2
+var _world: World2D
 
 
 func configure(
@@ -21,26 +24,66 @@ func configure(
 	_court_bounds = court_bounds
 
 
-func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:
-	if not _is_ball_role(item_key):
-		return false
+## Optional: enables body-projection on the venue rect so wall/partner overlap rejects the loose drop.
+func set_world(world: World2D) -> void:
+	_world = world
+
+
+func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) -> bool:
 	if _venue_bounds.size == Vector2.ZERO:
 		return false
 	# Inclusive max-edge check; Rect2.has_point treats max as exclusive.
 	var lo: Vector2 = _venue_bounds.position
 	var hi: Vector2 = lo + _venue_bounds.size
-	return position.x >= lo.x and position.x <= hi.x and position.y >= lo.y and position.y <= hi.y
-
-
-func accept(item_key: String, position: Vector2, gesture_velocity: Vector2) -> void:
-	if _reconciler == null:
-		return
-	var clamped: Vector2 = DropTarget.clamp_to_rect(position, _court_bounds)
-	_reconciler.bring_into_play(item_key, clamped, gesture_velocity)
-
-
-func _is_ball_role(item_key: String) -> bool:
-	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
-	if definition == null:
+	var inside: bool = (
+		position.x >= lo.x and position.x <= hi.x and position.y >= lo.y and position.y <= hi.y
+	)
+	if not inside:
+		return false
+	# Body projection: a loose drop must clear walls/partners just like a court drop.
+	# Skipped when no World2D was provided (test fixtures keep working without one).
+	if _world == null:
 		return true
-	return definition.role == &"ball"
+	return _projection_clear(item_key, position, scale_factor)
+
+
+## SH-314: the controller owns the loose handoff (reparents and unfreezes the held body).
+## This accept is kept for DropTarget contract symmetry but does no work.
+func accept(_item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
+	pass
+
+
+func _projection_clear(item_key: String, position: Vector2, scale_factor: float) -> bool:
+	var space: PhysicsDirectSpaceState2D = _world.direct_space_state
+	if space == null:
+		return true
+	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
+	var shape: Shape2D = null
+	if definition != null and definition.at_rest_shape != null:
+		shape = _scaled_shape(definition.at_rest_shape, scale_factor)
+	if shape == null:
+		var fallback: CircleShape2D = CircleShape2D.new()
+		fallback.radius = 14.0 * scale_factor
+		shape = fallback
+	var params: PhysicsShapeQueryParameters2D = PhysicsShapeQueryParameters2D.new()
+	params.shape = shape
+	params.transform = Transform2D(0.0, position)
+	params.collide_with_bodies = true
+	params.collide_with_areas = false
+	return space.intersect_shape(params, 1).is_empty()
+
+
+func _scaled_shape(source: Shape2D, scale_factor: float) -> Shape2D:
+	if is_equal_approx(scale_factor, 1.0):
+		return source
+	if source is CircleShape2D:
+		var src_circle: CircleShape2D = source
+		var scaled_circle: CircleShape2D = CircleShape2D.new()
+		scaled_circle.radius = src_circle.radius * scale_factor
+		return scaled_circle
+	if source is RectangleShape2D:
+		var src_rect: RectangleShape2D = source
+		var scaled_rect: RectangleShape2D = RectangleShape2D.new()
+		scaled_rect.size = src_rect.size * scale_factor
+		return scaled_rect
+	return source

--- a/scripts/items/drop_targets/venue_drop_target.gd
+++ b/scripts/items/drop_targets/venue_drop_target.gd
@@ -51,13 +51,9 @@ func _projection_clear(item_key: String, position: Vector2, scale_factor: float)
 	if space == null:
 		return true
 	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
-	var shape: Shape2D = null
-	if definition != null and definition.at_rest_shape != null:
-		shape = _scaled_shape(definition.at_rest_shape, scale_factor)
-	if shape == null:
-		var fallback: CircleShape2D = CircleShape2D.new()
-		fallback.radius = 14.0 * scale_factor
-		shape = fallback
+	if definition == null or definition.at_rest_shape == null:
+		return true
+	var shape: Shape2D = _scaled_shape(definition.at_rest_shape, scale_factor)
 	var params: PhysicsShapeQueryParameters2D = PhysicsShapeQueryParameters2D.new()
 	params.shape = shape
 	params.transform = Transform2D(0.0, position)

--- a/scripts/items/held_body.gd
+++ b/scripts/items/held_body.gd
@@ -1,0 +1,77 @@
+class_name HeldBody
+extends RigidBody2D
+
+## Dragged-gravity body per `designs/01-prototype/21-ball-dynamics.md` (SH-314).
+## During the lift and held phases the body is kinematic-frozen so the controller drives position;
+## release transitions either despawn the body (rack/court) or unfreeze it for loose-on-venue-floor.
+
+enum Phase { LIFTING, HELD, LOOSE }
+
+@export_range(0.0, 4.0, 0.05) var loose_gravity_scale: float = 1.0
+
+var phase: int = Phase.LIFTING
+var item_key: String = ""
+
+
+## Builds a held body for `item_key` using the definition's authored art and at_rest_shape.
+static func make_for(definition: ItemDefinition, item_key_override: String) -> HeldBody:
+	var body: HeldBody = HeldBody.new()
+	body.name = "HeldBody_%s" % item_key_override
+	body.item_key = item_key_override
+	body.gravity_scale = 0.0
+	body.lock_rotation = true
+	body.linear_damp = 1.0
+	body.contact_monitor = false
+	body.freeze = true
+	body.freeze_mode = RigidBody2D.FREEZE_MODE_KINEMATIC
+	# Held bodies must not be press-targets; the controller owns the gesture lifecycle.
+	body.input_pickable = false
+	# Visible scale rides on the body for the SH-297 lift feel; collision must not scale with it,
+	# so collision layer/mask stay zeroed until go_loose flips the body into the world.
+	body.collision_layer = 0
+	body.collision_mask = 0
+
+	var collision: CollisionShape2D = CollisionShape2D.new()
+	collision.name = "Collision"
+	if definition != null and definition.at_rest_shape != null:
+		collision.shape = definition.at_rest_shape
+	else:
+		# Fallback so test fixtures without an authored shape still spawn a valid body.
+		var fallback: CircleShape2D = CircleShape2D.new()
+		fallback.radius = 12.0
+		collision.shape = fallback
+	body.add_child(collision)
+
+	if definition != null and definition.art != null:
+		var art_holder: Node2D = Node2D.new()
+		art_holder.name = "ArtHolder"
+		# ArtHolder stays unscaled while held; the body's `scale` carries the SH-297 lift feel.
+		# go_loose transfers the visible scale onto the ArtHolder so the body ends up unscaled
+		# (so the collision shape matches the authored at_rest_shape in world space).
+		art_holder.add_child(definition.art.instantiate())
+		body.add_child(art_holder)
+
+	return body
+
+
+## Engages gravity for the loose-on-venue-floor state; unfreezes so physics integrates.
+func go_loose(release_velocity: Vector2) -> void:
+	phase = Phase.LOOSE
+	# Migrate the visible scale off the body and onto the ArtHolder so the collision shape
+	# matches the authored at_rest_shape (body itself is now unscaled in world space).
+	var pre_loose_scale: Vector2 = scale
+	scale = Vector2.ONE
+	var art_holder: Node2D = get_node_or_null("ArtHolder") as Node2D
+	if art_holder != null:
+		art_holder.scale = pre_loose_scale
+	freeze = false
+	gravity_scale = loose_gravity_scale
+	# Standard physics layer/mask: the body now collides with the venue floor and walls.
+	collision_layer = 1
+	collision_mask = 1
+	linear_velocity = release_velocity
+
+
+## Marks the lift tween as settled; the body is still kinematic-frozen on the cursor.
+func mark_held() -> void:
+	phase = Phase.HELD

--- a/scripts/items/held_body.gd
+++ b/scripts/items/held_body.gd
@@ -3,6 +3,8 @@ extends RigidBody2D
 
 enum Phase { LIFTING, HELD, LOOSE }
 
+const HELD_BODY_SCENE: PackedScene = preload("res://scenes/items/held_body.tscn")
+
 @export_range(0.0, 4.0, 0.05) var loose_gravity_scale: float = 1.0
 
 var phase: Phase = Phase.LIFTING
@@ -10,31 +12,14 @@ var item_key: String = ""
 
 
 static func make_for(definition: ItemDefinition, item_key: String) -> HeldBody:
-	var body: HeldBody = HeldBody.new()
+	var body: HeldBody = HELD_BODY_SCENE.instantiate()
 	body.name = "HeldBody_%s" % item_key
 	body.item_key = item_key
-	body.gravity_scale = 0.0
-	body.lock_rotation = true
-	body.linear_damp = 1.0
-	body.contact_monitor = false
-	body.freeze = true
-	body.freeze_mode = RigidBody2D.FREEZE_MODE_KINEMATIC
-	body.input_pickable = false
-	# Collision stays disabled until go_loose so the body cannot push the cursor-driven motion around.
-	body.collision_layer = 0
-	body.collision_mask = 0
+	var collision: CollisionShape2D = body.get_node("Collision")
+	# Per-instance shape so expansion-ring inflation cannot leak across held bodies.
+	collision.shape = definition.at_rest_shape.duplicate()
 
-	var collision: CollisionShape2D = CollisionShape2D.new()
-	collision.name = "Collision"
-	if definition != null and definition.at_rest_shape != null:
-		collision.shape = definition.at_rest_shape
-	else:
-		var fallback: CircleShape2D = CircleShape2D.new()
-		fallback.radius = 12.0
-		collision.shape = fallback
-	body.add_child(collision)
-
-	if definition != null and definition.art != null:
+	if definition.art != null:
 		var art_holder: Node2D = Node2D.new()
 		art_holder.name = "ArtHolder"
 		art_holder.add_child(definition.art.instantiate())

--- a/scripts/items/held_body.gd
+++ b/scripts/items/held_body.gd
@@ -1,10 +1,6 @@
 class_name HeldBody
 extends RigidBody2D
 
-## Dragged-gravity body per `designs/01-prototype/21-ball-dynamics.md` (SH-314).
-## During the lift and held phases the body is kinematic-frozen so the controller drives position;
-## release transitions either despawn the body (rack/court) or unfreeze it for loose-on-venue-floor.
-
 enum Phase { LIFTING, HELD, LOOSE }
 
 @export_range(0.0, 4.0, 0.05) var loose_gravity_scale: float = 1.0
@@ -13,21 +9,18 @@ var phase: Phase = Phase.LIFTING
 var item_key: String = ""
 
 
-## Builds a held body for `item_key` using the definition's authored art and at_rest_shape.
-static func make_for(definition: ItemDefinition, item_key_override: String) -> HeldBody:
+static func make_for(definition: ItemDefinition, item_key: String) -> HeldBody:
 	var body: HeldBody = HeldBody.new()
-	body.name = "HeldBody_%s" % item_key_override
-	body.item_key = item_key_override
+	body.name = "HeldBody_%s" % item_key
+	body.item_key = item_key
 	body.gravity_scale = 0.0
 	body.lock_rotation = true
 	body.linear_damp = 1.0
 	body.contact_monitor = false
 	body.freeze = true
 	body.freeze_mode = RigidBody2D.FREEZE_MODE_KINEMATIC
-	# Held bodies must not be press-targets; the controller owns the gesture lifecycle.
 	body.input_pickable = false
-	# Visible scale rides on the body for the SH-297 lift feel; collision must not scale with it,
-	# so collision layer/mask stay zeroed until go_loose flips the body into the world.
+	# Collision stays disabled until go_loose so the body cannot push the cursor-driven motion around.
 	body.collision_layer = 0
 	body.collision_mask = 0
 
@@ -36,7 +29,6 @@ static func make_for(definition: ItemDefinition, item_key_override: String) -> H
 	if definition != null and definition.at_rest_shape != null:
 		collision.shape = definition.at_rest_shape
 	else:
-		# Fallback so test fixtures without an authored shape still spawn a valid body.
 		var fallback: CircleShape2D = CircleShape2D.new()
 		fallback.radius = 12.0
 		collision.shape = fallback
@@ -45,20 +37,16 @@ static func make_for(definition: ItemDefinition, item_key_override: String) -> H
 	if definition != null and definition.art != null:
 		var art_holder: Node2D = Node2D.new()
 		art_holder.name = "ArtHolder"
-		# ArtHolder stays unscaled while held; the body's `scale` carries the SH-297 lift feel.
-		# go_loose transfers the visible scale onto the ArtHolder so the body ends up unscaled
-		# (so the collision shape matches the authored at_rest_shape in world space).
 		art_holder.add_child(definition.art.instantiate())
 		body.add_child(art_holder)
 
 	return body
 
 
-## Engages gravity for the loose-on-venue-floor state; unfreezes so physics integrates.
+# Loose bodies live under the reconciler's ball-host subtree; that subtree is freed on scene reload, which is what cleans them up.
 func go_loose(release_velocity: Vector2) -> void:
 	phase = Phase.LOOSE
-	# Migrate the visible scale off the body and onto the ArtHolder so the collision shape
-	# matches the authored at_rest_shape (body itself is now unscaled in world space).
+	# Migrate visible scale onto the ArtHolder so the body's collision matches at_rest_shape in world space.
 	var pre_loose_scale: Vector2 = scale
 	scale = Vector2.ONE
 	var art_holder: Node2D = get_node_or_null("ArtHolder") as Node2D
@@ -66,12 +54,10 @@ func go_loose(release_velocity: Vector2) -> void:
 		art_holder.scale = pre_loose_scale
 	freeze = false
 	gravity_scale = loose_gravity_scale
-	# Standard physics layer/mask: the body now collides with the venue floor and walls.
 	collision_layer = 1
 	collision_mask = 1
 	linear_velocity = release_velocity
 
 
-## Marks the lift tween as settled; the body is still kinematic-frozen on the cursor.
 func mark_held() -> void:
 	phase = Phase.HELD

--- a/scripts/items/held_body.gd
+++ b/scripts/items/held_body.gd
@@ -9,7 +9,7 @@ enum Phase { LIFTING, HELD, LOOSE }
 
 @export_range(0.0, 4.0, 0.05) var loose_gravity_scale: float = 1.0
 
-var phase: int = Phase.LIFTING
+var phase: Phase = Phase.LIFTING
 var item_key: String = ""
 
 

--- a/scripts/items/held_body.gd.uid
+++ b/scripts/items/held_body.gd.uid
@@ -1,0 +1,1 @@
+uid://dxwfoo1jc2set

--- a/tests/helpers/item_test_helpers.gd
+++ b/tests/helpers/item_test_helpers.gd
@@ -22,4 +22,8 @@ static func make_ball_item(key: String) -> ItemDefinition:
 	item.max_level = 3
 	item.effects = []
 	item.art = stub_art()
+	# Production ball items always ship an at_rest_shape; fixtures match that contract.
+	var default_shape := CircleShape2D.new()
+	default_shape.radius = 7.2
+	item.at_rest_shape = default_shape
 	return item

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -173,33 +173,32 @@ func test_drag_permanent_ball_off_court_onto_rack_regrows_token() -> void:
 	)
 
 
-# --- Scenario 3: rack -> mid-venue release clamps to court edge ------------
+# --- Scenario 3: rack -> mid-venue release drops loose (SH-314) -------------
 
 
-func test_drag_ball_onto_mid_venue_position_spawns_at_court_edge() -> void:
+func test_drag_ball_onto_mid_venue_position_drops_loose() -> void:
+	# SH-314: per the regime canon, a release inside the venue but outside the court spawns a
+	# loose RigidBody2D under gravity rather than clamping the spawn to the court edge.
 	_manager.take("training_ball")
 	_drag.grab_from_rack("training_ball")
 	for ball in _all_balls_under_host():
 		ball.queue_free()
 	await get_tree().process_frame
 
-	# Inside VENUE_BOUNDS.x (-2000..2000) but outside COURT_BOUNDS.x (-600..600).
 	var in_venue_outside_court := Vector2(1500, 50)
 	var released: bool = _drag.attempt_release(in_venue_outside_court)
 
 	assert_true(released, "release inside venue always resolves")
-	assert_true(_manager.is_on_court("training_ball"), "placement should settle on court")
-	var live: Array = _permanent_balls()
-	assert_eq(live.size(), 1, "exactly one permanent Ball for the key")
-	var ball: Ball = _reconciler.get_ball_for_key("training_ball")
-	assert_not_null(ball)
-	var court_right_edge: float = COURT_BOUNDS.position.x + COURT_BOUNDS.size.x
-	assert_eq(
-		ball.global_position.x,
-		court_right_edge,
-		"x should clamp to the court's right edge",
-	)
-	assert_eq(ball.global_position.y, 50.0, "in-bounds y should pass through unchanged")
+	assert_false(_manager.is_on_court("training_ball"), "loose release does not flip placement")
+	assert_eq(_permanent_balls().size(), 0, "no rally Ball spawns from a loose release")
+	var loose_under_host: Array = []
+	for child in _host.get_children():
+		if child is HeldBody:
+			loose_under_host.append(child)
+	assert_eq(loose_under_host.size(), 1, "loose body is reparented under the ball host")
+	var body: HeldBody = loose_under_host[0]
+	assert_false(body.freeze, "loose body unfreezes so gravity integrates")
+	assert_gt(body.gravity_scale, 0.0)
 
 
 # --- Scenario 4: temporary balls live outside the reconciler's set ---------
@@ -257,7 +256,9 @@ func test_temporary_ball_does_not_touch_placement_or_reconciler() -> void:
 # --- Scenario 5: release from outside venue still lands on the court -------
 
 
-func test_release_from_far_outside_cursor_spawns_ball_at_court_corner() -> void:
+func test_release_from_far_outside_cursor_drops_loose_at_venue_edge() -> void:
+	# SH-314: cursor outside the venue clamps to the venue rect; the resulting in-venue
+	# but off-court position resolves as a loose drop, not a court-corner Ball.
 	_manager.take("training_ball")
 	_drag.grab_from_rack("training_ball")
 	for ball in _all_balls_under_host():
@@ -268,17 +269,18 @@ func test_release_from_far_outside_cursor_spawns_ball_at_court_corner() -> void:
 	var released: bool = _drag.attempt_release(far_outside)
 
 	assert_true(released, "release always resolves, even from a far-outside cursor")
-	assert_true(
-		_manager.is_on_court("training_ball"),
-		"placement settles on court despite the out-of-bounds cursor",
-	)
-	var ball: Ball = _reconciler.get_ball_for_key("training_ball")
-	assert_not_null(ball, "release still spawns a live ball")
-	var court_max: Vector2 = COURT_BOUNDS.position + COURT_BOUNDS.size
+	assert_false(_manager.is_on_court("training_ball"))
+	assert_eq(_permanent_balls().size(), 0, "loose drop does not spawn a rally Ball")
+	var venue_max: Vector2 = VENUE_BOUNDS.position + VENUE_BOUNDS.size
+	var loose_under_host: Array = []
+	for child in _host.get_children():
+		if child is HeldBody:
+			loose_under_host.append(child)
+	assert_eq(loose_under_host.size(), 1)
 	assert_eq(
-		ball.global_position,
-		court_max,
-		"ball lands at the court corner after the out-of-bounds release",
+		loose_under_host[0].global_position,
+		venue_max,
+		"loose body lands at the venue's far corner after the cursor clamp",
 	)
 
 

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -1,4 +1,4 @@
-## SH-218 end-to-end ball regime transitions; see designs/01-prototype/21-ball-dynamics.md#regime-unification.
+## End-to-end ball regime transitions; see designs/01-prototype/21-ball-dynamics.md#regime-unification.
 extends GutTest
 
 const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
@@ -119,7 +119,7 @@ func test_place_ball_drags_onto_court_and_reconciler_spawns_live_ball() -> void:
 	var released: bool = _drag.attempt_release(court_point)
 
 	assert_true(released, "release over court should resolve")
-	assert_false(_drag.is_dragging(), "held token destroyed on release")
+	assert_false(_drag.is_dragging(), "held body destroyed on release")
 	assert_true(_manager.is_on_court("training_ball"), "placement state settles on court")
 	var live: Array = _permanent_balls()
 	assert_eq(live.size(), 1, "exactly one Ball for the key after the drop")
@@ -177,8 +177,6 @@ func test_drag_permanent_ball_off_court_onto_rack_regrows_token() -> void:
 
 
 func test_drag_ball_onto_mid_venue_position_drops_loose() -> void:
-	# SH-314: per the regime canon, a release inside the venue but outside the court spawns a
-	# loose RigidBody2D under gravity rather than clamping the spawn to the court edge.
 	_manager.take("training_ball")
 	_drag.grab_from_rack("training_ball")
 	for ball in _all_balls_under_host():
@@ -237,7 +235,7 @@ func test_temporary_ball_does_not_touch_placement_or_reconciler() -> void:
 	)
 
 	_drag.grab_live_ball("training_ball", true)
-	assert_true(_drag.is_dragging(), "temporary drag starts the held-token gesture")
+	assert_true(_drag.is_dragging(), "temporary drag starts the held-body gesture")
 
 	var released: bool = _drag.attempt_release(Vector2(0, 0))
 
@@ -257,8 +255,6 @@ func test_temporary_ball_does_not_touch_placement_or_reconciler() -> void:
 
 
 func test_release_from_far_outside_cursor_drops_loose_at_venue_edge() -> void:
-	# SH-314: cursor outside the venue clamps to the venue rect; the resulting in-venue
-	# but off-court position resolves as a loose drop, not a court-corner Ball.
 	_manager.take("training_ball")
 	_drag.grab_from_rack("training_ball")
 	for ball in _all_balls_under_host():
@@ -338,15 +334,11 @@ func test_save_round_trip_preserves_live_ball_placement() -> void:
 
 
 func test_real_press_drag_release_on_rack_spawns_live_ball_with_item_art() -> void:
-	# Drives the actual InputEventMouseButton path on the rack token: press,
-	# move, release. Asserts the released live ball lands at the release position
-	# AND wears the item's authored art (SH-244).
 	_manager.take("training_ball")
 	await get_tree().process_frame
 	var displayed: Array[String] = _rack.get_displayed_keys()
 	assert_eq(displayed, ["training_ball"], "precondition: rack shows the token")
 
-	# Resolve the slot's click area and feed it a mouse-down event.
 	var slot: Node2D = _find_slot_for_key("training_ball")
 	assert_not_null(slot, "rack slot exists for the owned key")
 	var click_area: Area2D = slot.get_node("ClickArea")
@@ -355,18 +347,16 @@ func test_real_press_drag_release_on_rack_spawns_live_ball_with_item_art() -> vo
 	press.pressed = true
 	click_area.input_event.emit(get_viewport(), press, 0)
 
-	assert_true(_drag.is_dragging(), "press on the rack token starts the held-token gesture")
+	assert_true(_drag.is_dragging(), "press on the rack token starts the held-body gesture")
 	assert_false(
 		_manager.is_on_court("training_ball"),
-		"press alone must not introduce the ball (SH-245)",
+		"press alone must not introduce the ball",
 	)
 
-	# Simulate cursor motion across a window so release velocity is non-zero.
 	_drag._cursor_samples.clear()
 	_drag._cursor_samples.append({"time": 0.0, "position": Vector2.ZERO})
 	_drag._cursor_samples.append({"time": 0.04, "position": Vector2(200, 0)})
 
-	# Release over the court. Drive the actual mouse-button-up path through _input.
 	for ball in _all_balls_under_host():
 		ball.queue_free()
 	await get_tree().process_frame
@@ -379,7 +369,7 @@ func test_real_press_drag_release_on_rack_spawns_live_ball_with_item_art() -> vo
 	assert_true(_manager.is_on_court("training_ball"), "release over court activates the item")
 	var ball: Ball = _reconciler.get_ball_for_key("training_ball")
 	assert_not_null(ball, "reconciler should own the live ball after release")
-	assert_true(ball.has_item_art(), "live ball must render the item's authored art (SH-244)")
+	assert_true(ball.has_item_art(), "live ball must render the item's authored art")
 
 
 # --- Scenario 8 (SH-247): real press on a live Ball flips into mid-rally grab --
@@ -390,26 +380,22 @@ func test_real_press_on_live_ball_starts_mid_rally_grab_and_release_reinstates()
 	_manager.activate("training_ball")
 	var live: Ball = _reconciler.get_ball_for_key("training_ball")
 	assert_not_null(live, "precondition: live ball exists")
-	# SH-297: press routing moved off the rigid body's input_event onto a generous
-	# child Area2D so a press near a moving ball lands without pixel precision.
 	var press_area: Area2D = live.get_node_or_null("PressArea") as Area2D
-	assert_not_null(press_area, "live ball must own a PressArea for press routing (SH-297)")
+	assert_not_null(press_area, "live ball must own a PressArea for press routing")
 	assert_true(press_area.input_pickable, "PressArea must accept pointer events")
 
-	# Drive a real press through the press area's input_event signal.
 	var press := InputEventMouseButton.new()
 	press.button_index = MOUSE_BUTTON_LEFT
 	press.pressed = true
 	press_area.input_event.emit(get_viewport(), press, 0)
 
-	assert_true(_drag.is_dragging(), "press on a live ball flips into drag mode (SH-247)")
+	assert_true(_drag.is_dragging(), "press on a live ball flips into drag mode")
 	await get_tree().process_frame
 	assert_false(
 		is_instance_valid(live),
-		"the live ball is freed during the hold; held token takes over the cursor",
+		"the live ball is freed during the hold; held body takes over the cursor",
 	)
 
-	# Release over the court reinstates a live ball at the cursor.
 	var court_point := Vector2(50, -25)
 	var released: bool = _drag.attempt_release(court_point)
 	assert_true(released)
@@ -417,37 +403,26 @@ func test_real_press_on_live_ball_starts_mid_rally_grab_and_release_reinstates()
 	var reinstated: Ball = _reconciler.get_ball_for_key("training_ball")
 	assert_not_null(reinstated, "court release should reinstate a Ball via the reconciler")
 	assert_eq(reinstated.global_position, court_point)
-	assert_true(reinstated.has_item_art(), "reinstated ball preserves the item's art (SH-244)")
+	assert_true(reinstated.has_item_art(), "reinstated ball preserves the item's art")
 
 
-# --- Scenario 9 (SH-262): pre-existing scene Ball is grabbable mid-rally ----
-
-
-# The live court scene ships with a Ball node already in the tree (see scenes/court.tscn).
-# That ball never went through ensure_ball_for_key, so the reconciler never emitted
-# ball_spawned for it, so the drag controller never wired its `pressed` signal. Players
-# pressed mid-rally and nothing happened. Reproduce by parenting a fresh Ball under the
-# host BEFORE the reconciler ever spawns one, then drive a real press through it.
 func test_pre_existing_court_ball_is_grabbable_mid_rally() -> void:
-	# Mirror the scene-load shape: Ball is already a child of the host with its authored item_key
-	# (court.tscn sets training_ball), reconciler never invoked ensure_ball_for_key for this instance.
+	# Mirror the scene-load shape: a Ball authored under the host that the reconciler never spawned.
 	_manager.take("training_ball")
 	var pre_existing: Ball = BallScene.instantiate()
 	pre_existing.item_key = "training_ball"
 	_host.add_child(pre_existing)
 	pre_existing.global_position = Vector2(0, 0)
 	await get_tree().process_frame
-	# Allow any deferred adoption pass to run before we drive input.
+	# Wait an extra frame so any deferred adoption pass runs before input drives.
 	await get_tree().process_frame
 
 	assert_eq(_permanent_balls().size(), 1, "precondition: pre-existing Ball lives under host")
-	# SH-297: press routing lives on the child Area2D, not on the rigid body itself.
 	var press_area: Area2D = pre_existing.get_node_or_null("PressArea") as Area2D
-	assert_not_null(press_area, "Ball must own a PressArea for press routing (SH-297)")
+	assert_not_null(press_area, "Ball must own a PressArea for press routing")
 	assert_true(press_area.input_pickable, "PressArea must accept pointer events")
 	assert_false(_drag.is_dragging(), "precondition: no drag in progress before the press")
 
-	# Drive a real press through the press area's input_event signal.
 	var press := InputEventMouseButton.new()
 	press.button_index = MOUSE_BUTTON_LEFT
 	press.pressed = true
@@ -455,12 +430,12 @@ func test_pre_existing_court_ball_is_grabbable_mid_rally() -> void:
 
 	assert_true(
 		_drag.is_dragging(),
-		"pressing a pre-existing scene Ball must flip the drag controller into mid-rally grab (SH-262)",
+		"pressing a pre-existing scene Ball must flip the drag controller into mid-rally grab",
 	)
 	await get_tree().process_frame
 	assert_false(
 		is_instance_valid(pre_existing),
-		"the pre-existing ball is freed during the hold; held token takes over the cursor",
+		"the pre-existing ball is freed during the hold; held body takes over the cursor",
 	)
 
 

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -397,7 +397,7 @@ func test_held_token_during_rack_drag_settles_to_token_scale_with_hover_bump() -
 	await get_tree().process_frame
 
 	_drag.grab_from_rack("training_ball")
-	var held_token: Node2D = _drag.get_held_token()
+	var held_token: Node2D = _drag.get_held_body()
 	assert_not_null(held_token, "rack-origin drag spawns a held token")
 	await get_tree().create_timer(0.1).timeout
 	var expected: Vector2 = TrainingBall.token_scale * BallDragControllerScript.HOVER_SCALE_BUMP

--- a/tests/unit/items/test_ball_drag_controller.gd
+++ b/tests/unit/items/test_ball_drag_controller.gd
@@ -75,6 +75,14 @@ func _permanent_balls() -> Array:
 	return result
 
 
+func _loose_bodies_under_host() -> Array:
+	var result: Array = []
+	for child in _host.get_children():
+		if child is HeldBody:
+			result.append(child)
+	return result
+
+
 func test_grab_from_rack_spawns_held_token_without_activating_item() -> void:
 	_manager.take("ball_alpha")
 	assert_false(_manager.is_on_court("ball_alpha"), "precondition: item is on the rack")
@@ -171,7 +179,9 @@ func test_release_without_gesture_uses_default_launch_velocity() -> void:
 	assert_eq(ball.linear_velocity, expected, "fallback path should match ItemManager default")
 
 
-func test_release_far_outside_court_clamps_to_bounds() -> void:
+func test_release_far_outside_court_falls_loose_inside_venue() -> void:
+	# SH-314: release inside venue but outside court no longer clamps to court; the held body
+	# unfreezes and falls as a loose RigidBody2D under gravity per the regime canon.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -181,11 +191,18 @@ func test_release_far_outside_court_clamps_to_bounds() -> void:
 
 	var released: bool = _drag.attempt_release(off_world)
 
-	assert_true(released, "any release not over the rack resolves as a court release")
-	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
-	assert_not_null(ball)
-	# Court bounds max corner is (600, 400); far-off position should clamp to it.
-	assert_eq(ball.global_position, Vector2(600, 400), "spawn clamps to court bounds")
+	assert_true(released, "venue-clamped release resolves as a loose drop")
+	assert_null(
+		_reconciler.get_ball_for_key("ball_alpha"),
+		"loose release does not bring the item into play",
+	)
+	assert_false(_manager.is_on_court("ball_alpha"), "loose release does not flip placement state")
+	# A HeldBody (RigidBody2D) was reparented to the ball host and unfrozen.
+	var loose_bodies: Array = _loose_bodies_under_host()
+	assert_eq(loose_bodies.size(), 1, "exactly one loose body lands in the venue")
+	var body: HeldBody = loose_bodies[0]
+	assert_false(body.freeze, "loose body unfreezes so gravity integrates")
+	assert_gt(body.gravity_scale, 0.0, "loose body has gravity active")
 
 
 func test_release_over_rack_returns_a_court_ball_to_the_rack() -> void:
@@ -262,7 +279,9 @@ func test_temporary_ball_release_over_court_does_not_spawn_through_reconciler() 
 	)
 
 
-func test_release_inside_venue_outside_court_spawns_at_court_clamped_position() -> void:
+func test_release_inside_venue_outside_court_drops_loose() -> void:
+	# SH-314: a release inside the venue but outside the court spawns a loose body that falls
+	# under gravity, not a court-clamped Ball.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -274,10 +293,14 @@ func test_release_inside_venue_outside_court_spawns_at_court_clamped_position() 
 	var released: bool = _drag.attempt_release(in_venue_out_of_court)
 	assert_true(released, "release inside venue always resolves, never a no-op")
 
-	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
-	assert_not_null(ball, "release inside venue but outside court still spawns a ball")
-	assert_eq(ball.global_position.x, 600.0, "x clamps to the right edge of court_bounds")
-	assert_eq(ball.global_position.y, 50.0, "in-bounds axes pass through unchanged")
+	assert_null(
+		_reconciler.get_ball_for_key("ball_alpha"),
+		"loose release does not bring the item into play",
+	)
+	assert_false(_manager.is_on_court("ball_alpha"))
+	var loose_bodies: Array = _loose_bodies_under_host()
+	assert_eq(loose_bodies.size(), 1, "loose body lands at the release position")
+	assert_eq(loose_bodies[0].global_position, in_venue_out_of_court)
 
 
 func test_mouse_button_release_event_triggers_release() -> void:

--- a/tests/unit/items/test_ball_drag_controller.gd
+++ b/tests/unit/items/test_ball_drag_controller.gd
@@ -1,4 +1,3 @@
-## SH-218 drag controller owns the held token and reconciles rack <-> court transitions.
 extends GutTest
 
 const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
@@ -83,7 +82,7 @@ func _loose_bodies_under_host() -> Array:
 	return result
 
 
-func test_grab_from_rack_spawns_held_token_without_activating_item() -> void:
+func test_grab_from_rack_spawns_held_body_without_activating_item() -> void:
 	_manager.take("ball_alpha")
 	assert_false(_manager.is_on_court("ball_alpha"), "precondition: item is on the rack")
 
@@ -91,8 +90,6 @@ func test_grab_from_rack_spawns_held_token_without_activating_item() -> void:
 	assert_true(ok)
 	assert_true(_drag.is_dragging(), "drag controller should be mid-gesture after rack pickup")
 	assert_eq(_drag.get_held_key(), "ball_alpha")
-	# SH-245: a press alone must not introduce the ball; activation is deferred to
-	# release-over-court so a click-without-movement leaves the rack untouched.
 	assert_false(
 		_manager.is_on_court("ball_alpha"),
 		"rack pickup is press-hold-release; activation only fires at release over court",
@@ -100,8 +97,6 @@ func test_grab_from_rack_spawns_held_token_without_activating_item() -> void:
 
 
 func test_click_on_rack_without_movement_does_not_introduce_ball() -> void:
-	# SH-245 regression guard: press, then immediately release at the same rack position.
-	# The held token must clear and no ball should land on the court.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -113,7 +108,7 @@ func test_click_on_rack_without_movement_does_not_introduce_ball() -> void:
 	var released: bool = _drag.attempt_release(rack_position)
 
 	assert_true(released)
-	assert_false(_drag.is_dragging(), "held token cleared on release")
+	assert_false(_drag.is_dragging(), "held body cleared on release")
 	assert_false(
 		_manager.is_on_court("ball_alpha"),
 		"no movement, no court release: the item must not be activated",
@@ -180,8 +175,6 @@ func test_release_without_gesture_uses_default_launch_velocity() -> void:
 
 
 func test_release_far_outside_court_falls_loose_inside_venue() -> void:
-	# SH-314: release inside venue but outside court no longer clamps to court; the held body
-	# unfreezes and falls as a loose RigidBody2D under gravity per the regime canon.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -197,7 +190,6 @@ func test_release_far_outside_court_falls_loose_inside_venue() -> void:
 		"loose release does not bring the item into play",
 	)
 	assert_false(_manager.is_on_court("ball_alpha"), "loose release does not flip placement state")
-	# A HeldBody (RigidBody2D) was reparented to the ball host and unfrozen.
 	var loose_bodies: Array = _loose_bodies_under_host()
 	assert_eq(loose_bodies.size(), 1, "exactly one loose body lands in the venue")
 	var body: HeldBody = loose_bodies[0]
@@ -206,8 +198,6 @@ func test_release_far_outside_court_falls_loose_inside_venue() -> void:
 
 
 func test_release_over_rack_returns_a_court_ball_to_the_rack() -> void:
-	# Grabbing a live ball that was already on court and releasing over the rack
-	# must deactivate the item so the rack regrows the token.
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	assert_true(_manager.is_on_court("ball_alpha"), "precondition: item is on court")
@@ -219,7 +209,7 @@ func test_release_over_rack_returns_a_court_ball_to_the_rack() -> void:
 	var released: bool = _drag.attempt_release(over_rack)
 
 	assert_true(released)
-	assert_false(_drag.is_dragging(), "held token destroyed on rack release")
+	assert_false(_drag.is_dragging(), "held body destroyed on rack release")
 	assert_false(
 		_manager.is_on_court("ball_alpha"),
 		"release onto rack should deactivate a permanent ball item",
@@ -260,8 +250,8 @@ func test_mid_rally_grab_then_release_over_court_reinstates_a_ball() -> void:
 
 func test_temporary_ball_release_over_court_does_not_spawn_through_reconciler() -> void:
 	_drag.grab_live_ball("ball_alpha", true)
-	assert_true(_drag.is_dragging(), "precondition: held token exists for the temporary drag")
-	var token_before: Node2D = _drag.get_held_token()
+	assert_true(_drag.is_dragging(), "precondition: held body exists for the temporary drag")
+	var body_before: HeldBody = _drag.get_held_body()
 	var court_point := Vector2(0, 0)
 
 	var released: bool = _drag.attempt_release(court_point)
@@ -273,15 +263,13 @@ func test_temporary_ball_release_over_court_does_not_spawn_through_reconciler() 
 	)
 	assert_false(_drag.is_dragging(), "temporary release clears the drag state")
 	await get_tree().process_frame
-	assert_false(is_instance_valid(token_before), "held token should be freed on release")
+	assert_false(is_instance_valid(body_before), "held body should be freed on release")
 	assert_eq(
 		_permanent_balls().size(), 0, "temporary release should not leave a permanent Ball behind"
 	)
 
 
 func test_release_inside_venue_outside_court_drops_loose() -> void:
-	# SH-314: a release inside the venue but outside the court spawns a loose body that falls
-	# under gravity, not a court-clamped Ball.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -310,8 +298,7 @@ func test_mouse_button_release_event_triggers_release() -> void:
 		ball.queue_free()
 	await get_tree().process_frame
 
-	# Release event must carry a position past the movement threshold so the controller
-	# treats it as a real drag rather than a click-without-movement no-op (SH-252 a).
+	# Release position must clear the movement threshold so the controller treats it as a real drag.
 	var event := InputEventMouseButton.new()
 	event.button_index = MOUSE_BUTTON_LEFT
 	event.pressed = false
@@ -325,13 +312,12 @@ func test_mouse_button_release_event_triggers_release() -> void:
 	)
 
 
-func test_process_follow_clamps_held_token_to_venue_bounds() -> void:
+func test_process_follow_clamps_held_body_to_venue_bounds() -> void:
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
-	var token: Node2D = _drag.get_held_token()
-	assert_not_null(token, "precondition: held token exists")
+	var body: HeldBody = _drag.get_held_body()
+	assert_not_null(body, "precondition: held body exists")
 
-	# _clamp_to_venue is the pure function behind _process follow; drive it directly.
 	var clamped: Vector2 = _drag._clamp_to_venue(Vector2(99999, -99999))
 	assert_eq(clamped, Vector2(2000, -1200), "clamp pulls to the venue rect corner")
 
@@ -344,9 +330,6 @@ func test_clamp_to_venue_is_identity_when_bounds_unset() -> void:
 
 
 func test_grab_and_release_preserves_live_ball_speed_through_to_reinstated_ball() -> void:
-	# SH-288: friendship energy persists across mid-rally grab + release-over-court.
-	# Capture a non-default rally speed, drive grab + release through _input, and assert the
-	# reinstated ball inherits that speed on both `speed` and `linear_velocity` magnitude.
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
@@ -356,7 +339,6 @@ func test_grab_and_release_preserves_live_ball_speed_through_to_reinstated_ball(
 	var grabbed: bool = _drag.grab_live_ball("ball_alpha", false)
 	assert_true(grabbed)
 	await get_tree().process_frame
-	# Feed a small gesture so the release gets a non-zero launch direction.
 	_drag._cursor_samples.clear()
 	_drag._cursor_samples.append({"time": 0.0, "position": Vector2(0, 0)})
 	_drag._cursor_samples.append({"time": 0.04, "position": Vector2(40, 0)})

--- a/tests/unit/items/test_ball_drag_controller_sh287.gd
+++ b/tests/unit/items/test_ball_drag_controller_sh287.gd
@@ -85,7 +85,7 @@ func test_invalid_release_leaves_gesture_open_when_no_target_accepts() -> void:
 
 	_manager.take("ball_alpha")
 	# Bypass grab_from_rack so the no-target controller still reaches held state.
-	drag._spawn_held_token("ball_alpha", Vector2.ZERO, false)
+	drag._spawn_held_body("ball_alpha", Vector2.ZERO, false)
 	drag._mouse_button_down = false
 	drag._gesture_below_threshold = false
 
@@ -222,7 +222,7 @@ func test_shop_purchase_falls_through_when_no_target_accepts() -> void:
 func test_hover_feedback_bumps_held_token_scale_over_valid_target() -> void:
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
-	var token: Node2D = _drag.get_held_token()
+	var token: Node2D = _drag.get_held_body()
 	assert_not_null(token, "precondition: held token spawned")
 	var definition: ItemDefinition = _drag._get_item_definition("ball_alpha")
 	var base_scale: Vector2 = definition.token_scale
@@ -237,7 +237,7 @@ func test_hover_feedback_bumps_held_token_scale_over_valid_target() -> void:
 func test_hover_feedback_resets_to_base_scale_when_no_target_accepts() -> void:
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
-	var token: Node2D = _drag.get_held_token()
+	var token: Node2D = _drag.get_held_body()
 	var definition: ItemDefinition = _drag._get_item_definition("ball_alpha")
 	var base_scale: Vector2 = definition.token_scale
 	_drag._mouse_button_down = true

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -1,0 +1,196 @@
+## SH-314: dragged-gravity state-machine transitions; canon at designs/01-prototype/21-ball-dynamics.md.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _host: Node2D
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+
+
+func _make_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _make_drop_target(position: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [ball_alpha]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_host = Node2D.new()
+	add_child_autofree(_host)
+
+	_rack = _make_rack(_manager)
+	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager, _host)
+	add_child_autofree(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	add_child_autofree(_drag)
+
+
+func _permanent_balls() -> Array:
+	var result: Array = []
+	for child in _host.get_children():
+		if child is Ball:
+			result.append(child)
+	return result
+
+
+func _loose_bodies_under_host() -> Array:
+	var result: Array = []
+	for child in _host.get_children():
+		if child is HeldBody:
+			result.append(child)
+	return result
+
+
+func test_grab_spawns_a_rigid_body_held_in_kinematic_freeze() -> void:
+	# Token -> Dragged-gravity: held body is a RigidBody2D, frozen-kinematic so the controller
+	# drives position; gravity_scale is zero during the lift so it does not fall mid-tween.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	var body: HeldBody = _drag.get_held_token() as HeldBody
+	assert_not_null(body, "held body is a HeldBody (RigidBody2D), not a plain Node2D")
+	assert_true(body.freeze, "held body stays frozen-kinematic so the controller drives position")
+	assert_eq(
+		body.freeze_mode,
+		RigidBody2D.FREEZE_MODE_KINEMATIC,
+		"freeze_mode is kinematic so position writes do not fight the solver",
+	)
+	assert_eq(body.gravity_scale, 0.0, "gravity is zero during the lift; engages on settle")
+	assert_eq(body.phase, HeldBody.Phase.LIFTING)
+
+
+func test_lift_settle_marks_body_held_and_arms_loose_gravity() -> void:
+	# Gravity engages once the lift tween settles; the body's loose_gravity_scale stays armed
+	# for any later release-into-venue branch.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha", Vector2(0, 0))
+	var body: HeldBody = _drag.get_held_token() as HeldBody
+	_drag._grab_ease_elapsed = _drag.grab_ease_duration_s
+	_drag._apply_grab_ease(_drag._grab_ease_progress(), Vector2(50, 50))
+	assert_eq(body.phase, HeldBody.Phase.HELD, "lift settle promotes phase to HELD")
+	assert_gt(body.loose_gravity_scale, 0.0, "loose gravity is armed for a future floor release")
+
+
+func test_release_over_court_frees_held_body_and_spawns_active_movement_ball() -> void:
+	# Dragged-gravity -> Active-movement: the rigid held body is freed, the reconciler
+	# instantiates a Ball at the release point with gesture velocity. Active-movement has
+	# gravity off (Ball.gravity_scale == 0) per the rally configuration.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
+	var held: HeldBody = _drag.get_held_token() as HeldBody
+	assert_not_null(held)
+	_drag._cursor_samples.clear()
+	_drag._cursor_samples.append({"time": 0.0, "position": Vector2.ZERO})
+	_drag._cursor_samples.append({"time": 0.04, "position": Vector2(80, 0)})
+
+	var court_point := Vector2(50, 25)
+	assert_true(_drag.attempt_release(court_point))
+	await get_tree().process_frame
+
+	assert_false(is_instance_valid(held), "held body is freed after a court release")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "court release spawns the rally Ball")
+	assert_eq(ball.gravity_scale, 0.0, "active-movement has gravity off (frictionless rally)")
+
+
+func test_release_into_venue_floor_unfreezes_held_body_with_gravity_active() -> void:
+	# Dragged-gravity -> loose-on-venue-floor: the held body unfreezes, gravity engages, the
+	# body falls. The reconciler does not spawn a Ball; placement state stays off-court.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
+
+	var loose_position := Vector2(1500, 100)
+	assert_true(_drag.attempt_release(loose_position))
+	var loose_bodies: Array = _loose_bodies_under_host()
+	assert_eq(loose_bodies.size(), 1)
+	var body: HeldBody = loose_bodies[0]
+	assert_eq(body.phase, HeldBody.Phase.LOOSE)
+	assert_false(body.freeze)
+	assert_gt(body.gravity_scale, 0.0)
+	assert_null(_reconciler.get_ball_for_key("ball_alpha"), "loose drop bypasses the reconciler")
+	assert_false(_manager.is_on_court("ball_alpha"))
+
+
+func test_mid_rally_grab_spawns_held_body_at_live_ball_position() -> void:
+	# Active-movement -> Dragged-gravity: grabbing a live ball spawns a HeldBody at the live
+	# ball's last world position (the gesture's start), with gravity off until the lift settles.
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(live)
+	live.global_position = Vector2(75, 30)
+
+	assert_true(_drag.grab_live_ball("ball_alpha", false))
+	await get_tree().process_frame
+
+	var body: HeldBody = _drag.get_held_token() as HeldBody
+	assert_not_null(body, "mid-rally grab spawns a HeldBody, not a plain Node2D")
+	assert_eq(_drag._grab_origin_position, Vector2(75, 30))
+	assert_eq(body.phase, HeldBody.Phase.LIFTING)
+	assert_true(body.freeze, "frozen-kinematic during the cursor follow")
+
+
+func test_loose_body_keeps_visual_scale_via_art_holder_after_release() -> void:
+	# go_loose transfers the visible token_scale off the body onto the ArtHolder so the body
+	# itself is unscaled in world space (collision shape matches the authored at_rest_shape).
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
+	# Settle the lift so body.scale = token_scale.
+	_drag._grab_ease_elapsed = _drag.grab_ease_duration_s
+	_drag._apply_grab_ease(1.0, Vector2(1500, 100))
+
+	assert_true(_drag.attempt_release(Vector2(1500, 100)))
+	var bodies: Array = _loose_bodies_under_host()
+	assert_eq(bodies.size(), 1)
+	var body: HeldBody = bodies[0]
+	assert_eq(body.scale, Vector2.ONE, "loose body sheds its lift-time scale onto the ArtHolder")

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -6,12 +6,15 @@ const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconci
 const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
 const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
 
+const AUTHORED_RADIUS: float = 9.0
+
 var _manager: Node
 var _host: Node2D
 var _rack: RackDisplay
 var _drop_target: Area2D
 var _reconciler: BallReconciler
 var _drag: BallDragController
+var _authored_shape: CircleShape2D
 
 
 func _make_rack(manager: Node) -> RackDisplay:
@@ -46,6 +49,11 @@ func _make_drop_target(position: Vector2, size: Vector2) -> Area2D:
 func before_each() -> void:
 	_manager = ItemFactory.create_manager(self)
 	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	# An authored at_rest_shape is part of the dragged-gravity contract; pin it on the fixture so
+	# tests fail if HeldBody ever silently falls back to its default circle.
+	_authored_shape = CircleShape2D.new()
+	_authored_shape.radius = AUTHORED_RADIUS
+	ball_alpha.at_rest_shape = _authored_shape
 	var typed_items: Array[ItemDefinition] = [ball_alpha]
 	_manager.items.assign(typed_items)
 	_manager._progression.friendship_point_balance = 10000
@@ -96,19 +104,24 @@ func test_grab_spawns_a_rigid_body_held_in_kinematic_freeze() -> void:
 		RigidBody2D.FREEZE_MODE_KINEMATIC,
 		"freeze_mode is kinematic so position writes do not fight the solver",
 	)
-	assert_eq(body.gravity_scale, 0.0, "gravity is zero during the lift; engages on settle")
+	assert_eq(body.gravity_scale, 0.0, "gravity is zero during the lift; engages on go_loose")
 	assert_eq(body.phase, HeldBody.Phase.LIFTING)
+	var collision: CollisionShape2D = body.get_node("Collision") as CollisionShape2D
+	assert_eq(
+		collision.shape, _authored_shape, "held body uses the definition's authored at_rest_shape"
+	)
 
 
-func test_lift_settle_marks_body_held_and_arms_loose_gravity() -> void:
-	# Gravity engages once the lift tween settles; the body's loose_gravity_scale stays armed
-	# for any later release-into-venue branch.
+func test_lift_settle_promotes_phase_and_arms_loose_gravity() -> void:
+	# After the lift tween settles the body's phase flips to HELD; its gravity stays off (the body
+	# is still cursor-pinned) and loose_gravity_scale stays armed for any later venue release.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha", Vector2(0, 0))
 	var body: HeldBody = _drag.get_held_token() as HeldBody
 	_drag._grab_ease_elapsed = _drag.grab_ease_duration_s
 	_drag._apply_grab_ease(_drag._grab_ease_progress(), Vector2(50, 50))
 	assert_eq(body.phase, HeldBody.Phase.HELD, "lift settle promotes phase to HELD")
+	assert_eq(body.gravity_scale, 0.0, "gravity stays off while the body is cursor-pinned")
 	assert_gt(body.loose_gravity_scale, 0.0, "loose gravity is armed for a future floor release")
 
 
@@ -158,28 +171,45 @@ func test_release_into_venue_floor_unfreezes_held_body_with_gravity_active() -> 
 	assert_false(_manager.is_on_court("ball_alpha"))
 
 
-func test_mid_rally_grab_spawns_held_body_at_live_ball_position() -> void:
+func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_carryover() -> void:
 	# Active-movement -> Dragged-gravity: grabbing a live ball spawns a HeldBody at the live
-	# ball's last world position (the gesture's start), with gravity off until the lift settles.
+	# ball's last world position, with the rally speed preserved into the released ball's
+	# linear_velocity after the gesture commits to a court target.
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_not_null(live)
 	live.global_position = Vector2(75, 30)
+	live.speed = 240.0
 
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
-	await get_tree().process_frame
 
 	var body: HeldBody = _drag.get_held_token() as HeldBody
 	assert_not_null(body, "mid-rally grab spawns a HeldBody, not a plain Node2D")
-	assert_eq(_drag._grab_origin_position, Vector2(75, 30))
+	assert_eq(
+		body.global_position,
+		Vector2(75, 30),
+		"held body spawns at the live ball's world position",
+	)
 	assert_eq(body.phase, HeldBody.Phase.LIFTING)
 	assert_true(body.freeze, "frozen-kinematic during the cursor follow")
+	await get_tree().process_frame
+
+	# Drive a release over the court to confirm the rally speed propagates into the new Ball.
+	_drag._cursor_samples.clear()
+	_drag._cursor_samples.append({"time": 0.0, "position": Vector2(75, 30)})
+	_drag._cursor_samples.append({"time": 0.04, "position": Vector2(155, 30)})
+	assert_true(_drag.attempt_release(Vector2(50, 25)))
+	await get_tree().process_frame
+	var released: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(released, "court release spawns the rally Ball")
+	assert_almost_eq(released.linear_velocity.length(), 240.0, 0.5)
 
 
-func test_loose_body_keeps_visual_scale_via_art_holder_after_release() -> void:
+func test_loose_body_transfers_visual_scale_onto_art_holder_after_release() -> void:
 	# go_loose transfers the visible token_scale off the body onto the ArtHolder so the body
-	# itself is unscaled in world space (collision shape matches the authored at_rest_shape).
+	# itself is unscaled in world space and the collision shape matches at_rest_shape; the
+	# ArtHolder picks up the lift-time scale so the visual does not pop.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -188,9 +218,18 @@ func test_loose_body_keeps_visual_scale_via_art_holder_after_release() -> void:
 	# Settle the lift so body.scale = token_scale.
 	_drag._grab_ease_elapsed = _drag.grab_ease_duration_s
 	_drag._apply_grab_ease(1.0, Vector2(1500, 100))
+	var held: HeldBody = _drag.get_held_token() as HeldBody
+	var pre_loose_scale: Vector2 = held.scale
 
 	assert_true(_drag.attempt_release(Vector2(1500, 100)))
 	var bodies: Array = _loose_bodies_under_host()
 	assert_eq(bodies.size(), 1)
 	var body: HeldBody = bodies[0]
 	assert_eq(body.scale, Vector2.ONE, "loose body sheds its lift-time scale onto the ArtHolder")
+	var art_holder: Node2D = body.get_node("ArtHolder") as Node2D
+	assert_not_null(art_holder, "loose body keeps an ArtHolder for the visual")
+	assert_eq(
+		art_holder.scale,
+		pre_loose_scale,
+		"ArtHolder receives the body's pre-loose scale so the visual does not pop",
+	)

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -178,7 +178,9 @@ func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_ca
 	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_not_null(live)
 	live.global_position = Vector2(75, 30)
-	live.speed = 240.0
+	# Use a speed within [ball_speed_min, max_speed_min + max_range] so the speed-limit clamp
+	# in BallEffectProcessor leaves the carryover untouched on the next physics tick.
+	live.speed = 600.0
 
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
 
@@ -198,7 +200,7 @@ func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_ca
 	await get_tree().process_frame
 	var released: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_not_null(released, "court release spawns the rally Ball")
-	assert_almost_eq(released.linear_velocity.length(), 240.0, 0.5)
+	assert_almost_eq(released.linear_velocity.length(), 600.0, 0.5)
 
 
 func test_loose_body_transfers_visual_scale_onto_art_holder_after_release() -> void:

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -1,4 +1,4 @@
-## SH-314: dragged-gravity state-machine transitions; canon at designs/01-prototype/21-ball-dynamics.md.
+## Dragged-gravity state-machine transitions; canon at designs/01-prototype/21-ball-dynamics.md.
 extends GutTest
 
 const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
@@ -49,8 +49,7 @@ func _make_drop_target(position: Vector2, size: Vector2) -> Area2D:
 func before_each() -> void:
 	_manager = ItemFactory.create_manager(self)
 	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
-	# An authored at_rest_shape is part of the dragged-gravity contract; pin it on the fixture so
-	# tests fail if HeldBody ever silently falls back to its default circle.
+	# Pin an authored at_rest_shape so a future fallback-to-default-circle regression fails here.
 	_authored_shape = CircleShape2D.new()
 	_authored_shape.radius = AUTHORED_RADIUS
 	ball_alpha.at_rest_shape = _authored_shape
@@ -92,11 +91,9 @@ func _loose_bodies_under_host() -> Array:
 
 
 func test_grab_spawns_a_rigid_body_held_in_kinematic_freeze() -> void:
-	# Token -> Dragged-gravity: held body is a RigidBody2D, frozen-kinematic so the controller
-	# drives position; gravity_scale is zero during the lift so it does not fall mid-tween.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
-	var body: HeldBody = _drag.get_held_token() as HeldBody
+	var body: HeldBody = _drag.get_held_body()
 	assert_not_null(body, "held body is a HeldBody (RigidBody2D), not a plain Node2D")
 	assert_true(body.freeze, "held body stays frozen-kinematic so the controller drives position")
 	assert_eq(
@@ -113,11 +110,9 @@ func test_grab_spawns_a_rigid_body_held_in_kinematic_freeze() -> void:
 
 
 func test_lift_settle_promotes_phase_and_arms_loose_gravity() -> void:
-	# After the lift tween settles the body's phase flips to HELD; its gravity stays off (the body
-	# is still cursor-pinned) and loose_gravity_scale stays armed for any later venue release.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha", Vector2(0, 0))
-	var body: HeldBody = _drag.get_held_token() as HeldBody
+	var body: HeldBody = _drag.get_held_body()
 	_drag._grab_ease_elapsed = _drag.grab_ease_duration_s
 	_drag._apply_grab_ease(_drag._grab_ease_progress(), Vector2(50, 50))
 	assert_eq(body.phase, HeldBody.Phase.HELD, "lift settle promotes phase to HELD")
@@ -126,15 +121,12 @@ func test_lift_settle_promotes_phase_and_arms_loose_gravity() -> void:
 
 
 func test_release_over_court_frees_held_body_and_spawns_active_movement_ball() -> void:
-	# Dragged-gravity -> Active-movement: the rigid held body is freed, the reconciler
-	# instantiates a Ball at the release point with gesture velocity. Active-movement has
-	# gravity off (Ball.gravity_scale == 0) per the rally configuration.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
 		ball.queue_free()
 	await get_tree().process_frame
-	var held: HeldBody = _drag.get_held_token() as HeldBody
+	var held: HeldBody = _drag.get_held_body()
 	assert_not_null(held)
 	_drag._cursor_samples.clear()
 	_drag._cursor_samples.append({"time": 0.0, "position": Vector2.ZERO})
@@ -151,8 +143,6 @@ func test_release_over_court_frees_held_body_and_spawns_active_movement_ball() -
 
 
 func test_release_into_venue_floor_unfreezes_held_body_with_gravity_active() -> void:
-	# Dragged-gravity -> loose-on-venue-floor: the held body unfreezes, gravity engages, the
-	# body falls. The reconciler does not spawn a Ball; placement state stays off-court.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -172,9 +162,6 @@ func test_release_into_venue_floor_unfreezes_held_body_with_gravity_active() -> 
 
 
 func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_carryover() -> void:
-	# Active-movement -> Dragged-gravity: grabbing a live ball spawns a HeldBody at the live
-	# ball's last world position, with the rally speed preserved into the released ball's
-	# linear_velocity after the gesture commits to a court target.
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
@@ -184,7 +171,7 @@ func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_ca
 
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
 
-	var body: HeldBody = _drag.get_held_token() as HeldBody
+	var body: HeldBody = _drag.get_held_body()
 	assert_not_null(body, "mid-rally grab spawns a HeldBody, not a plain Node2D")
 	assert_eq(
 		body.global_position,
@@ -195,7 +182,6 @@ func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_ca
 	assert_true(body.freeze, "frozen-kinematic during the cursor follow")
 	await get_tree().process_frame
 
-	# Drive a release over the court to confirm the rally speed propagates into the new Ball.
 	_drag._cursor_samples.clear()
 	_drag._cursor_samples.append({"time": 0.0, "position": Vector2(75, 30)})
 	_drag._cursor_samples.append({"time": 0.04, "position": Vector2(155, 30)})
@@ -207,18 +193,15 @@ func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_ca
 
 
 func test_loose_body_transfers_visual_scale_onto_art_holder_after_release() -> void:
-	# go_loose transfers the visible token_scale off the body onto the ArtHolder so the body
-	# itself is unscaled in world space and the collision shape matches at_rest_shape; the
-	# ArtHolder picks up the lift-time scale so the visual does not pop.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
 		ball.queue_free()
 	await get_tree().process_frame
-	# Settle the lift so body.scale = token_scale.
+	# Settle the lift so body.scale equals token_scale before the release.
 	_drag._grab_ease_elapsed = _drag.grab_ease_duration_s
 	_drag._apply_grab_ease(1.0, Vector2(1500, 100))
-	var held: HeldBody = _drag.get_held_token() as HeldBody
+	var held: HeldBody = _drag.get_held_body()
 	var pre_loose_scale: Vector2 = held.scale
 
 	assert_true(_drag.attempt_release(Vector2(1500, 100)))

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -104,8 +104,15 @@ func test_grab_spawns_a_rigid_body_held_in_kinematic_freeze() -> void:
 	assert_eq(body.gravity_scale, 0.0, "gravity is zero during the lift; engages on go_loose")
 	assert_eq(body.phase, HeldBody.Phase.LIFTING)
 	var collision: CollisionShape2D = body.get_node("Collision") as CollisionShape2D
-	assert_eq(
-		collision.shape, _authored_shape, "held body uses the definition's authored at_rest_shape"
+	assert_true(
+		collision.shape is CircleShape2D, "held body uses the definition's authored shape type"
+	)
+	var circle: CircleShape2D = collision.shape
+	assert_almost_eq(
+		circle.radius,
+		AUTHORED_RADIUS,
+		0.001,
+		"held body collision radius matches the authored at_rest_shape, not a fallback default",
 	)
 
 
@@ -120,6 +127,12 @@ func test_lift_settle_promotes_phase_and_arms_loose_gravity() -> void:
 	assert_gt(body.loose_gravity_scale, 0.0, "loose gravity is armed for a future floor release")
 
 
+func _seed_release_velocity(start: Vector2, end: Vector2) -> void:
+	_drag._cursor_samples.clear()
+	_drag._cursor_samples.append({"time": 0.0, "position": start})
+	_drag._cursor_samples.append({"time": 0.04, "position": end})
+
+
 func test_release_over_court_frees_held_body_and_spawns_active_movement_ball() -> void:
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
@@ -128,9 +141,7 @@ func test_release_over_court_frees_held_body_and_spawns_active_movement_ball() -
 	await get_tree().process_frame
 	var held: HeldBody = _drag.get_held_body()
 	assert_not_null(held)
-	_drag._cursor_samples.clear()
-	_drag._cursor_samples.append({"time": 0.0, "position": Vector2.ZERO})
-	_drag._cursor_samples.append({"time": 0.04, "position": Vector2(80, 0)})
+	_seed_release_velocity(Vector2.ZERO, Vector2(80, 0))
 
 	var court_point := Vector2(50, 25)
 	assert_true(_drag.attempt_release(court_point))
@@ -182,9 +193,7 @@ func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_ca
 	assert_true(body.freeze, "frozen-kinematic during the cursor follow")
 	await get_tree().process_frame
 
-	_drag._cursor_samples.clear()
-	_drag._cursor_samples.append({"time": 0.0, "position": Vector2(75, 30)})
-	_drag._cursor_samples.append({"time": 0.04, "position": Vector2(155, 30)})
+	_seed_release_velocity(Vector2(75, 30), Vector2(155, 30))
 	assert_true(_drag.attempt_release(Vector2(50, 25)))
 	await get_tree().process_frame
 	var released: Ball = _reconciler.get_ball_for_key("ball_alpha")

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -326,8 +326,8 @@ func test_token_scale_remains_canonical_across_items() -> void:
 	var drag: BallDragController = BallDragControllerScript.new()
 	drag.configure(manager, rack, null, null)
 	add_child_autofree(drag)
-	drag._spawn_held_token("base_ball", Vector2.ZERO, false)
-	var held_token: Node2D = drag.get_held_token()
+	drag._spawn_held_body("base_ball", Vector2.ZERO, false)
+	var held_token: Node2D = drag.get_held_body()
 	assert_not_null(held_token, "precondition: held token spawned")
 
 	rack.refresh()

--- a/tests/unit/items/test_grab_feel.gd
+++ b/tests/unit/items/test_grab_feel.gd
@@ -182,13 +182,13 @@ func test_cursor_state_changed_signal_drives_overlay_via_signal_payload() -> voi
 	_drag.grab_from_rack("ball_alpha")
 	# Step 1: position over the rack drop target -> CAN_DROP.
 	var rack_position: Vector2 = _drop_target.global_position
-	_drag._held_token.global_position = rack_position
+	_drag._held_body.global_position = rack_position
 	_drag._update_cursor_state(rack_position)
 	# Step 2: position outside every registered DropTarget -> DRAGGING.
 	# (After SH-287, VenueDropTarget's ball-role venue rect catches positions inside it,
 	# so DRAGGING requires a held position outside the venue rect.)
 	var venue_only := Vector2(5000, 0)
-	_drag._held_token.global_position = venue_only
+	_drag._held_body.global_position = venue_only
 	_drag._update_cursor_state(venue_only)
 
 	# At least three emissions are expected: spawn/_process default, CAN_DROP, DRAGGING.

--- a/tests/unit/items/test_grab_feel.gd
+++ b/tests/unit/items/test_grab_feel.gd
@@ -1,4 +1,4 @@
-## SH-297 grab feel: ease-to-cursor tween and cursor state machine.
+## Grab feel: ease-to-cursor tween and cursor state machine.
 extends GutTest
 
 const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
@@ -73,57 +73,48 @@ func before_each() -> void:
 	add_child_autofree(_drag)
 
 
-func test_held_token_starts_at_grab_origin_not_at_cursor() -> void:
-	# AC: ~80 ms ease-to-cursor on grab. The held token spawns at the grab origin and
-	# eases to the cursor; it must not teleport-and-snap.
+func test_held_body_starts_at_grab_origin_not_at_cursor() -> void:
 	_manager.take("ball_alpha")
 	var press_origin := Vector2(123, 45)
 
 	_drag.grab_from_rack("ball_alpha", press_origin)
 
-	var token: Node2D = _drag.get_held_token()
-	assert_not_null(token)
-	assert_eq(
-		token.global_position, press_origin, "lift starts at the press origin, not the cursor"
-	)
+	var body: HeldBody = _drag.get_held_body()
+	assert_not_null(body)
+	assert_eq(body.global_position, press_origin, "lift starts at the press origin, not the cursor")
 
 
-func test_held_token_modulation_starts_transparent_and_eases_in() -> void:
-	# AC: position, scale, and modulation all read continuously through the lift.
+func test_held_body_modulation_starts_transparent_and_eases_in() -> void:
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha", Vector2(0, 0))
-	var token: Node2D = _drag.get_held_token()
-	assert_eq(token.modulate.a, 0.0, "modulation alpha is 0 at lift start; eases up to 1")
+	var body: HeldBody = _drag.get_held_body()
+	assert_eq(body.modulate.a, 0.0, "modulation alpha is 0 at lift start; eases up to 1")
 
 
-func test_held_token_settles_on_cursor_without_teleporting() -> void:
-	# Asserts the player-visible promise: lands on cursor with full alpha and no mid-window teleport.
+func test_held_body_settles_on_cursor_without_teleporting() -> void:
 	_manager.take("ball_alpha")
 	var origin := Vector2(100, 0)
 	var cursor_target := Vector2(500, 200)
 	_drag.grab_from_rack("ball_alpha", origin)
-	var token: Node2D = _drag.get_held_token()
-	# Pin the cursor target by overriding _grab_origin_position-driven follow: we drive
-	# _apply_grab_ease through repeated _process-equivalent ticks against a fixed target.
+	var body: HeldBody = _drag.get_held_body()
 	var ease_window: float = _drag.grab_ease_duration_s
 	var tick_count: int = 16
 	var tick_dt: float = ease_window / float(tick_count)
 	var max_step: float = 0.0
-	var previous: Vector2 = token.global_position
+	var previous: Vector2 = body.global_position
 	var total_distance: float = origin.distance_to(cursor_target)
 
 	for i in tick_count:
 		_drag._grab_ease_elapsed = minf(_drag._grab_ease_elapsed + tick_dt, ease_window)
 		_drag._apply_grab_ease(_drag._grab_ease_progress(), cursor_target)
-		var step: float = previous.distance_to(token.global_position)
+		var step: float = previous.distance_to(body.global_position)
 		max_step = maxf(max_step, step)
-		previous = token.global_position
+		previous = body.global_position
 
-	# Ends at the cursor with full alpha; that is the player-visible promise.
-	assert_almost_eq(token.global_position.x, cursor_target.x, 0.5)
-	assert_almost_eq(token.global_position.y, cursor_target.y, 0.5)
-	assert_almost_eq(token.modulate.a, 1.0, 0.001)
-	# No frame teleports across the window. Half the trip in one tick would be a snap.
+	assert_almost_eq(body.global_position.x, cursor_target.x, 0.5)
+	assert_almost_eq(body.global_position.y, cursor_target.y, 0.5)
+	assert_almost_eq(body.modulate.a, 1.0, 0.001)
+	# Half the trip in one tick would be a snap; cap step well below that.
 	assert_lt(max_step, total_distance * 0.5, "no mid-window teleport")
 
 
@@ -132,7 +123,6 @@ func test_cursor_state_default_when_no_gesture() -> void:
 
 
 func test_cursor_state_can_drop_over_rack_for_role() -> void:
-	# AC: cursor flips to CAN_DROP when a target accepts at the held position.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	var rack_position: Vector2 = _drop_target.global_position
@@ -143,11 +133,7 @@ func test_cursor_state_can_drop_over_rack_for_role() -> void:
 
 
 func test_cursor_state_dragging_outside_any_target() -> void:
-	# Cursor inside venue but no DropTarget accepts the held position: reads DRAGGING.
-	# After SH-287's VenueDropTarget joined the poll as a ball-role catch-all, DRAGGING is
-	# reachable only when the held position is outside every registered target. Pick a
-	# point outside the registered venue rect so VenueDropTarget rejects it; the cursor's
-	# own (0,0) probe stays inside venue so derivation doesn't return FORBIDDEN.
+	# Pick a point outside venue rect so VenueDropTarget rejects it but the cursor's (0,0) probe stays in.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	var outside_targets := Vector2(5000, 0)
@@ -158,12 +144,9 @@ func test_cursor_state_dragging_outside_any_target() -> void:
 
 
 func test_cursor_state_forbidden_when_cursor_outside_venue() -> void:
-	# AC: off-venue reads as FORBIDDEN. The held token clamps to venue bounds, but the raw
-	# cursor can drift outside; the state surfaces that.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
-	# Shrink venue bounds to a small rect that excludes the cursor's default global mouse
-	# position; _is_within_venue then reports false and the derivation returns FORBIDDEN.
+	# Shrink venue bounds away from the default mouse position so derivation returns FORBIDDEN.
 	_drag.venue_bounds = Rect2(Vector2(99000, 99000), Vector2(1, 1))
 
 	var state: int = _drag._derive_cursor_state(Vector2.ZERO)
@@ -172,31 +155,19 @@ func test_cursor_state_forbidden_when_cursor_outside_venue() -> void:
 
 
 func test_cursor_state_changed_signal_drives_overlay_via_signal_payload() -> void:
-	# End-to-end: a real grab, two _process steps with cursor at rack-only and
-	# venue-only positions, and the signal fires with the expected payloads. This pins the
-	# overlay-via-signal path, not just the derivation.
 	_manager.take("ball_alpha")
 	watch_signals(_drag)
-	# Trigger _ready so the overlay listens on cursor_state_changed.
 	_drag._ready()
 	_drag.grab_from_rack("ball_alpha")
-	# Step 1: position over the rack drop target -> CAN_DROP.
 	var rack_position: Vector2 = _drop_target.global_position
 	_drag._held_body.global_position = rack_position
 	_drag._update_cursor_state(rack_position)
-	# Step 2: position outside every registered DropTarget -> DRAGGING.
-	# (After SH-287, VenueDropTarget's ball-role venue rect catches positions inside it,
-	# so DRAGGING requires a held position outside the venue rect.)
 	var venue_only := Vector2(5000, 0)
 	_drag._held_body.global_position = venue_only
 	_drag._update_cursor_state(venue_only)
 
-	# At least three emissions are expected: spawn/_process default, CAN_DROP, DRAGGING.
-	# The state-change signal is per-call now (per-frame in production), so the count
-	# reflects update frequency rather than transitions; assert ordered payload sequence.
 	var emits: int = get_signal_emit_count(_drag, "cursor_state_changed")
 	assert_gte(emits, 2, "signal fires at least once per _update_cursor_state call")
-	# Last two emissions follow CAN_DROP then DRAGGING.
 	var second_last: Array = get_signal_parameters(_drag, "cursor_state_changed", emits - 2)
 	var last: Array = get_signal_parameters(_drag, "cursor_state_changed", emits - 1)
 	assert_eq(second_last[0], CursorStateScript.State.CAN_DROP)
@@ -205,7 +176,6 @@ func test_cursor_state_changed_signal_drives_overlay_via_signal_payload() -> voi
 
 
 func test_cursor_overlay_visibility_follows_state() -> void:
-	# Default state hides the overlay so the OS cursor reads cleanly without a gesture.
 	_overlay.set_state(CursorStateScript.State.DEFAULT, Vector2.ZERO)
 	assert_false(_overlay.visible)
 	_overlay.set_state(CursorStateScript.State.DRAGGING, Vector2.ZERO)


### PR DESCRIPTION
Held body becomes a RigidBody2D (HeldBody) with kinematic-frozen position during the SH-297 lift and held phases; release routes into one of the three states named in the regime canon. Court releases free the body and let the reconciler spawn the rally Ball; rack and shop releases free the body so the slot regrows its token; releases inside the venue rect but outside the court unfreeze the body with gravity active so it falls under its weight, with no court placement and no Ball spawn.

VenueDropTarget gates the loose drop with at-rest body projection, so wall and partner overlap rejects; the SH-287 expansion-ring fallback still cancels back to source after the 250 ms hold when no expanded position passes.

Closes SH-314.