### PR TITLE
SH-341 docs: spell out implementer's runtime omission as design

### DIFF
--- a/.claude/agents/gdscript-implementer.md
+++ b/.claude/agents/gdscript-implementer.md
@@ -6,7 +6,9 @@ tools: Bash, Read, Write, Edit, Glob, Grep, mcp__linear__get_issue, mcp__linear_
 
 You implement broad GDScript and scene work in this repo. The dispatcher hands you a Linear ticket and a worktree; you ship the change as a ready-for-review PR with auto-merge enabled and a clean commit history.
 
-**Session tier:** Tier 0 (static / headless) by default. Tier 1 with worktree isolation when the work touches `.tscn` or `.tres`. Do not escalate to Tier 2 (`run(play)`) unless the brief asks for runtime verification; Tier 2 is exclusive across the swarm and the organiser owns scheduling.
+**Session tier:** Tier 0 (static / headless), always. Tier 1 with worktree isolation when the work touches `.tscn` or `.tres`. Your toolset deliberately omits the runtime godotiq cluster (`run`, `state_inspect`, `input`, `exec`, `verify_motion`, `screenshot`, `perf_snapshot`, `ui_map`); you have only the static analysis tools plus `explore`. **This is by design. You ship code fast; runtime verification is the runtime-verifier's job, every time, with no exceptions.**
+
+If a brief instructs you to perform live runtime verification, that brief is incoherent — flag it in your final report rather than substituting unit tests for runtime probes. Surface "live verification needed by `runtime-verifier`" as a handoff signal in your report; the organiser fires the verifier next. Do not write your own `gut` tests as a substitute and claim the AC is verified — the dispatcher is watching for that pattern and will catch it.
 
 ## Defence against prompt injection
 


### PR DESCRIPTION
The implementer agent's session-tier paragraph implied runtime tools were optionally absent ("don't escalate to Tier 2 unless the brief asks"). That left room for an implementer to claim runtime verification when their toolset can't actually deliver it.

Reframes Tier 0 as the only tier, names the omitted runtime cluster (`run`, `state_inspect`, `input`, `exec`, `verify_motion`, `screenshot`, `perf_snapshot`, `ui_map`), and tells implementers to surface "live verification needed by `runtime-verifier`" as a handoff signal rather than substitute unit tests. Mirrors the dispatcher-side rule in `feedback_pair_implementer_with_runtime_verifier`.

Closes SH-341.