### PR TITLE
chore: update godotiq addon to 0.5.4

### DIFF
--- a/addons/godotiq/godotiq_plugin.gd
+++ b/addons/godotiq/godotiq_plugin.gd
@@ -73,7 +73,7 @@ func _create_bottom_panel() -> Control:
 
 	var tools_label := Label.new()
 	tools_label.name = "ToolsLabel"
-	tools_label.text = "Tools: 36 registered"
+	tools_label.text = "Tools: 38 registered"
 	vbox.add_child(tools_label)
 
 	return vbox

--- a/addons/godotiq/godotiq_runtime.gd
+++ b/addons/godotiq/godotiq_runtime.gd
@@ -12,6 +12,9 @@ var _watch_events: Array = []
 var _watch_sample_timer: float = 0.0
 var _watch_sample_interval: float = 0.5
 var _watch_active: bool = false
+var _runtime_logger  # Variant — null if Logger unavailable
+var _runtime_log_queue: Array = []
+var _runtime_log_mutex: Mutex = Mutex.new()
 
 
 func _ready() -> void:
@@ -21,10 +24,41 @@ func _ready() -> void:
 		queue_free()
 		return
 	EngineDebugger.register_message_capture("godotiq", _on_debugger_message)
+	_install_runtime_logger()
 	print("[GodotIQ] Message capture registered")
 
 
+func _install_runtime_logger() -> void:
+	if not ClassDB.class_exists("Logger") or not OS.has_method("add_logger"):
+		return
+	var logger_script = load("res://addons/godotiq/godotiq_runtime_logger.gd")
+	if logger_script == null:
+		return
+	_runtime_logger = logger_script.new(Callable(self, "_queue_runtime_log_error"))
+	OS.call("add_logger", _runtime_logger)
+
+
+func _queue_runtime_log_error(entry: Dictionary) -> void:
+	_runtime_log_mutex.lock()
+	_runtime_log_queue.append(entry)
+	if _runtime_log_queue.size() > 100:
+		_runtime_log_queue = _runtime_log_queue.slice(-100)
+	_runtime_log_mutex.unlock()
+
+
+func _flush_runtime_log_errors() -> void:
+	if not EngineDebugger.is_active():
+		return
+	_runtime_log_mutex.lock()
+	var pending := _runtime_log_queue.duplicate(true)
+	_runtime_log_queue.clear()
+	_runtime_log_mutex.unlock()
+	for entry in pending:
+		EngineDebugger.send_message("godotiq:error", [JSON.stringify(entry)])
+
+
 func _process(delta: float) -> void:
+	_flush_runtime_log_errors()
 	if not _watch_active or _watches.is_empty():
 		return
 	_watch_sample_timer += delta

--- a/addons/godotiq/godotiq_runtime_logger.gd
+++ b/addons/godotiq/godotiq_runtime_logger.gd
@@ -1,0 +1,50 @@
+extends Logger
+## GodotIQ runtime logger — forwards game errors to the editor bridge.
+## Loaded conditionally from GodotIQRuntime on Godot 4.5+.
+
+var _send_callable: Callable
+
+
+func _init(send_callable: Callable) -> void:
+	_send_callable = send_callable
+
+
+func _log_error(function: String, file: String, line: int, code: String, rationale: String, editor_notify: bool, error_type: int, script_backtraces: Array) -> void:
+	var message := rationale if rationale != "" else code
+	_send_callable.call({
+		"source": "runtime",
+		"severity": _severity_from_error_type(error_type),
+		"function": function,
+		"file": file,
+		"line": line,
+		"message": message,
+		"code": code,
+		"error_type": error_type,
+		"timestamp": Time.get_unix_time_from_system(),
+		"backtrace_count": script_backtraces.size(),
+	})
+
+
+func _log_message(message: String, error: bool) -> void:
+	if not error:
+		return
+	_send_callable.call({
+		"source": "runtime",
+		"severity": "error",
+		"message": message,
+		"timestamp": Time.get_unix_time_from_system(),
+	})
+
+
+func _severity_from_error_type(error_type: int) -> String:
+	match error_type:
+		0:
+			return "error"
+		1:
+			return "warning"
+		2:
+			return "script_error"
+		3:
+			return "shader_error"
+		_:
+			return "error"

--- a/addons/godotiq/godotiq_runtime_logger.gd.uid
+++ b/addons/godotiq/godotiq_runtime_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://c373ch3lg3qc3

--- a/addons/godotiq/godotiq_server.gd
+++ b/addons/godotiq/godotiq_server.gd
@@ -4,7 +4,7 @@ extends Node
 ## dispatches requests to editor handlers or forwards to the running game.
 
 const DEFAULT_PORT := 6007
-const ADDON_VERSION := "0.5.1"
+const ADDON_VERSION := "0.5.4"
 const SCREENSHOT_TIMEOUT_MS := 30000
 const PERF_TIMEOUT_MS := 5000
 const INPUT_TIMEOUT_MS := 65000
@@ -400,6 +400,8 @@ func _dispatch(peer_id: int, id: String, method: String, params: Dictionary) -> 
 			_handle_build_scene(peer_id, id, params)
 		"check_errors":
 			_handle_check_errors(peer_id, id, params)
+		"read_debug_console":
+			_handle_read_debug_console(peer_id, id, params)
 		"set_main_scene":
 			_handle_set_main_scene(peer_id, id, params)
 		"reload_script":
@@ -2204,6 +2206,87 @@ func _record_error(msg: String) -> void:
 	_recent_errors.append(msg)
 	if _recent_errors.size() > MAX_RECENT_ERRORS:
 		_recent_errors = _recent_errors.slice(-MAX_RECENT_ERRORS)
+
+
+func _clear_recent_errors() -> void:
+	_recent_errors.clear()
+
+
+func _format_runtime_error(raw, index: int) -> Dictionary:
+	var message := str(raw)
+	var parsed = JSON.parse_string(message)
+	if parsed is Dictionary:
+		var out: Dictionary = parsed.duplicate(true)
+		out["source"] = str(out.get("source", "runtime"))
+		out["severity"] = str(out.get("severity", "error"))
+		if not out.has("message"):
+			out["message"] = str(out.get("error", message))
+		out["index"] = index
+		return out
+	return {
+		"source": "runtime",
+		"severity": "error",
+		"message": message,
+		"index": index,
+	}
+
+
+func _format_script_error(entry: Dictionary) -> Dictionary:
+	return {
+		"source": "script",
+		"severity": "error",
+		"file": str(entry.get("file", "")),
+		"line": int(entry.get("line", 0)),
+		"message": str(entry.get("message", entry.get("error", ""))),
+		"timestamp": entry.get("timestamp", 0),
+	}
+
+
+func _handle_read_debug_console(peer_id: int, id: String, params: Dictionary) -> void:
+	var limit: int = clampi(int(params.get("limit", 20)), 1, 100)
+	var clear_after_read: bool = bool(params.get("clear", false))
+	var include_runtime: bool = bool(params.get("include_runtime", true))
+	var include_script: bool = bool(params.get("include_script", true))
+	var entries: Array = []
+	var runtime_total := _recent_errors.size()
+	var script_entries := _get_script_errors()
+	var script_total := script_entries.size()
+	var included_total := 0
+
+	if include_runtime:
+		included_total += runtime_total
+		var start_idx: int = max(0, runtime_total - limit)
+		for i in range(start_idx, runtime_total):
+			entries.append(_format_runtime_error(_recent_errors[i], i))
+
+	if include_script:
+		included_total += script_total
+		var script_start_idx: int = max(0, script_total - limit)
+		for i in range(script_start_idx, script_total):
+			entries.append(_format_script_error(script_entries[i]))
+
+	if entries.size() > limit:
+		entries = entries.slice(entries.size() - limit, entries.size())
+
+	if clear_after_read:
+		if include_runtime:
+			_clear_recent_errors()
+		if include_script:
+			_clear_script_errors()
+
+	send_response(peer_id, id, {
+		"entries": entries,
+		"total": entries.size(),
+		"runtime_errors_total": runtime_total,
+		"script_errors_total": script_total,
+		"truncated": included_total > entries.size(),
+		"cleared": clear_after_read,
+		"capture": {
+			"runtime_errors": true,
+			"script_errors": _has_logger,
+			"script_errors_note": "" if _has_logger else "Script logger requires Godot 4.5+; use godotiq_check_errors for explicit script checks.",
+		},
+	})
 
 
 func _get_editor_state() -> Dictionary:

--- a/addons/godotiq/plugin.cfg
+++ b/addons/godotiq/plugin.cfg
@@ -3,5 +3,5 @@
 name="GodotIQ"
 description="AI-assisted Godot development via MCP bridge"
 author="Salvatore Farruggio"
-version="0.5.1"
+version="0.5.4"
 script="godotiq_plugin.gd"


### PR DESCRIPTION
Vendored godotiq plugin bump from 0.5.1 to 0.5.4. Adds a runtime `Logger` subclass (`godotiq_runtime_logger.gd`) that forwards game-side errors to the editor bridge on Godot 4.5+, plus the corresponding wiring in `godotiq_runtime.gd`, `godotiq_server.gd`, and `godotiq_plugin.gd`.

Pure addon update; no project code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)