### PR TITLE
SH-309 docs: wall-less court control spec

### DIFF
--- a/designs/01-prototype/08-court-bounds.md
+++ b/designs/01-prototype/08-court-bounds.md
@@ -1,155 +1,39 @@
 # Court Bounds and Miss
 
-The court is not a closed box. It sits inside the venue, bounded on three sides and open on one; missed balls leave the court and rest on the venue floor until the player puts them back.
+Court geometry, the apex return, and the miss event live in [`08-court-control.md`](08-court-control.md). This doc covers cues, the spirit-of-the-volley framing, the rest-balls flow, and the future helper.
 
-**Dependencies:** Venue (`08-venue.md`), Balls (`08-balls.md`), Kit (`08-kit.md`), Items (`08-items.md`), Roles (`08-roles.md`), Fixtures (`08-fixtures.md`).
-
----
-
-## Bounds
-
-| Edge | Bound | Behaviour |
-|---|---|---|
-| Top | The screen edge | The camera never scrolls up; the top of the frame is a hard ceiling the ball bounces off. |
-| Bottom | The ground | Physical floor; ball bounces off (pong-style). Hitting the floor does not end the rally. |
-| Back | Behind the main character's paddle lane | The miss line. Ball crossing past the paddle is a miss. |
-| Sides | Open | The ball can leave the court sideways; leaving this way is also a miss. |
-
-No side walls. The court visibly opens onto the rest of the venue.
-
-### Miss-detection regions
-
-Two bands along the court sides detect sideways exits. Both run the full height of the play area.
-
-- **In-play region:** bounded by the top (ceiling), the ground (bounce floor), and the miss line to the paddle's court-facing side. A ball inside this region is live.
-- **Miss-line band:** a thin vertical trigger just in front of the paddle's tracking lane. A ball crossing it heading behind the paddle fires a back-miss. The paddle itself sits behind the line; the space further behind the paddle is open venue, not a wall.
-- **Side miss bands:** one on each side, just outside the court's lateral extent. Crossing either fires a side-miss.
-
-Detection uses `Area2D` triggers rather than tight collider math: the ball's centre entering a band is the event. This keeps the signal independent of ball radius or rotation quirks.
+**Dependencies:** Venue (`08-venue.md`), Balls (`08-balls.md`), Items (`08-items.md`), Roles (`08-roles.md`).
 
 ---
 
-## Miss
+## Cues
 
-A miss ends the current rally. It fires when either:
+Bounces and misses read distinctly. Bounces off the ground are a short tick and a small squash on the ground itself, no camera impact. A miss is the existing miss beat plus a flash on the player paddle's edge; the rally counter resets with its current audio. The ball is visibly still alive and rolling onto the venue floor; the cue acknowledges the rally ended without pretending the ball is gone. All cues are audio plus world-space, never screen-space banners.
 
-- The ball crosses the main character's miss line (back-miss, existing miss condition).
-- The ball leaves the court sideways without first landing back in play (side-miss).
+## Spirit of the volley
 
-On miss, the rally counter resets to zero (existing behaviour). The ball does not despawn; it keeps its velocity, rolls out of the court, loses energy on the venue floor, and comes to rest.
+A rally is how the spirit of the volley shows up. It is not owned by the player and it does not live in the ball; it answers commitment to the exchange and holds the ball up for as long as that commitment keeps paying out. Every return is tribute. The counter is how present the spirit is in this rally, not how many points were scored.
 
-### Cue layering
+A miss sends the spirit away. It does not leave in anger; it leaves because there is nothing left to answer. The ball loses what kept it weightless and does what balls do.
 
-Bounces and misses read distinctly:
+A player can call the spirit alone. Partners amplify it but do not create it. High-count rallies visibly run hotter; the ball carries the spirit's charge in how it reads. A miss drains it; the ball on the venue floor is just a ball. Items that extend or revive rallies are gestures of devotion to the spirit.
 
-- **Bounce off a bound** (top ceiling, ground): a short tick and a small squash on the bound itself. No camera impact.
-- **Back-miss:** the existing miss beat plays; the main character's wall flashes. Rally counter resets with its current audio.
-- **Side-miss:** a softer, lower-pitched variant of the miss beat. The ball is visibly still alive and rolling; the cue acknowledges the rally ended without pretending the ball is gone.
+## Resting balls
 
-All three are audio + world-space only. No screen-space banners (per venue diegetic rule).
+A ball rolled out of the court sits visibly on the venue floor wherever it stopped. The player can't serve from a rested ball; serves come from the rack. Rested balls stay put across rallies, saves, and scene reloads.
 
-### Physics at the court boundary
+Balls can rest anywhere on the venue floor; the shop, workshop, and kit zones absorb them and let them roll to a stop like any other patch. Rack footprints are drop targets, not rest surfaces; a ball that enters one snaps into the rack instead.
 
-While the rally is alive, balls live in a physics volume that treats them as weightless. Their `gravity_scale` is `0` and linear damping is off; every bounce is pong-crisp, and energy comes from the paddle, not from falling. The court's `Area2D` is what applies this treatment.
-
-A miss trigger (miss line or side band) flips the ball out of this state. `gravity_scale` rises to `1`. Linear damping kicks in. The ball retains whatever velocity it had at the moment of the cross, so a fast ball sails further before it lands; a slow one drops almost immediately. From there it rolls across the venue floor, decelerates against friction, and comes to rest.
-
-The transition is a single signal on `Area2D.body_exited`: clear the in-court flag, unlock gravity, engage damping. No interpolation, no blend window. The ball was in play and now it is not.
-
-### In-world framing: the spirit of the volley
-
-A rally is how the spirit of the volley shows up. It is not owned by the player and it does not live in the ball. It answers commitment to the exchange, and it holds the ball up for as long as that commitment keeps paying out. Every return is tribute. The counter is how present the spirit is in this rally, not how many points you have scored.
-
-A miss sends the spirit away. It does not leave in anger; it leaves because there is nothing left to answer. The ball loses what kept it weightless and does what balls do. It falls, rolls, and waits to be summoned again.
-
-A player can call the spirit alone. Partners, when they arrive, do not create it; they amplify it and make it easier to sustain. High-count rallies visibly run hotter: the ball carries the spirit's charge in how it reads, with a subtle light on it and a weight to its sound. A miss drains it; the ball on the venue floor is just a ball.
-
-Later items that extend or revive rallies are gestures of devotion to the spirit. Some plead with it to stay longer. Some call it back after it leaves. Naming them that way gives the system a vocabulary the player can feel rather than read from a stat block.
-
----
-
-## Resting balls in the venue
-
-A ball that has rolled out of the court sits visibly on the venue floor wherever it stopped. The player can't serve from a rested ball; serves come from the ball rack.
-
-To bring the ball back into play, the player drags it from the venue floor onto the `BallRack`. The ball becomes inactive and is available to drag back onto the court for the next rally, or the auto-serve picks it up when the rack's turn comes round (see `08-balls.md`).
-
-Rested balls stay put across rallies, saves, and scene reloads. Persistence lives alongside the ball's own state: position on the venue floor, last velocity (zero at rest), and the `resting` flag.
-
-### Where balls can legally rest
-
-Balls can come to rest anywhere on the venue floor. They always render in the mid or foreground relative to the shop/workshop backgrounds, so they stay visible regardless of where they land. No invisible barriers around the shop, workshop, or kit areas; those zones absorb the ball and let it roll to a stop like any other floor patch.
-
-One exception: the ball rack and gear rack themselves are drop targets, not rest surfaces. A ball that enters the rack's footprint snaps into the rack (racked, not resting). This matches the existing drag-to-rack gesture.
-
-### Auto-serve interaction with a resting ball
-
-If the player owns exactly one permanent ball and it is resting on the venue floor at the moment the rally needs a serve:
-
-- The ball rack is empty (the ball is not racked), and the court is empty (the ball is not in play).
-- The main character walks to the rack, finds it empty, and idles.
-- The player must drag the resting ball onto the rack to re-enter the loop.
-
-This is intentional friction. The main character does not fetch rested balls in the prototype; that job belongs to the future helper (below). Making the player re-rack reinforces that a miss has a cost beyond the rally counter reset, and it teaches the rack gesture before the helper takes it away.
-
-If the player owns multiple permanent balls, the auto-serve picks whichever is racked. Rested balls sit out of rotation until re-racked.
-
----
+If the player owns exactly one permanent ball and it is resting, the rack is empty and the main character idles. The player drags the resting ball back to the rack to re-enter the loop. This is intentional friction: a miss has a cost beyond the counter reset, and it teaches the rack gesture before the helper takes it away.
 
 ## Drag-out distinguished from miss
 
-The player can drag a live ball off the court back onto the ball rack mid-rally (see `08-balls.md`). That is not a miss: the ball enters the inactive state cleanly and the rally continues with whatever balls remain.
-
-If the player drops the ball outside the court bounds without landing on the rack, it counts as a miss. The ball rolls to rest on the venue floor; the rally ends if it was the last live ball.
-
----
+A live ball pulled mid-rally back onto the rack is not a miss; the ball enters the inactive state cleanly and the rally continues with whatever balls remain. A live ball dropped outside the court without landing on the rack counts as a miss.
 
 ## Temporary balls
 
-Temporary balls (frenzy, etc.) clear on their authored expiry regardless of where they land. A missed temporary ball despawns on miss like any other; it does not roll out to rest. A temporary ball that leaves sideways triggers a side-miss the same way a permanent one does, then despawns instead of resting.
+Temporary balls (frenzy and similar) clear on their authored expiry regardless of where they land. A missed temporary ball despawns on miss; it does not roll out to rest. This keeps the on-floor population bounded to owned balls only.
 
-This keeps the on-floor population bounded to owned balls only.
+## Helper upgrade (future)
 
----
-
-## Visual clutter
-
-The player will never own enough balls for visual clutter to become a problem at prototype scale. No cap, decay, or cleanup pass is in scope. If later content expands the owned-ball count dramatically, the helper item (below) absorbs the clutter naturally.
-
----
-
-## Helper upgrade (future, not in prototype scope)
-
-A `court` role item: a dog that automatically fetches rested balls and returns them to the rack. Authoring follows the existing court-item shape:
-
-- `role = &"court"` so it snaps to a `Roles/Court` marker on drag-in.
-- Acts as a fixture (see `08-fixtures.md`) if the dog's prop needs to sit in the venue; if a simple behavioural item is enough, it skips the fixture scene and just attaches a controller script.
-- Behaviour: scans for balls with the `resting` flag, the dog walks or bounds to each one, and carries them back to the rack one at a time on an authored cadence.
-
-The dog reuses the bot's `court` role plumbing; it does not need a new role. Whether it uses the bot's fixture shape or a lighter behavioural item is an implementation choice for its own ticket.
-
----
-
-## Resolved questions
-
-From the spike:
-
-1. **Ball-ground interaction.** Pong-style bounce. Hitting the floor does not end the rally.
-2. **Rally-ending condition.** Back-miss (miss line) or side-miss (lateral exit). Both reset the counter.
-3. **Clutter.** Not a real problem at prototype scale. No cap or decay.
-4. **Where rested balls can sit.** Anywhere on the venue floor. No invisible barriers. Rack footprints snap-to-rack instead of resting.
-5. **Auto-serve with one ball resting.** Main character idles; player must re-rack. The helper fixes this later.
-6. **Temporary balls.** Despawn on miss as before, regardless of where they land.
-7. **Cues.** Three distinct audio/world beats: bounce, back-miss, side-miss. All diegetic.
-8. **Helper authoring.** `court` role item. Fixture or behavioural controller is its own ticket's call.
-
----
-
-## Out of scope
-
-Called out so they don't leak into implementation:
-
-- Helper upgrade item, its prop scene, and its fetch cadence tuning.
-- Miss-ending-the-rally vs miss-ending-this-ball distinction for multiball (handled in `08-balls.md`).
-- Visual polish on the rest-roll deceleration curve; tuned during implementation.
-
+A court-role item, a dog that fetches rested balls and returns them to the rack. Reuses the existing court-role plumbing; whether it ships as a fixture or a lighter behavioural item is an implementation choice for its own ticket.

--- a/designs/01-prototype/08-court-control.md
+++ b/designs/01-prototype/08-court-control.md
@@ -1,0 +1,27 @@
+# Wall-less Court Control
+
+Today the rally tops out with a pong-bounce off a screen-edge ceiling, and balls straying sideways bounce off invisible walls and stay in play. This spec replaces both.
+
+At the top, the ball rises past the friendship-bound, arcs back down under gravity, and the rally continues; the player feels the ball being held in by the friendship rather than rebounding off a ceiling. At the sides, the ball rolls out onto the venue floor and lies among the items the player has placed, to be walked back to the rack.
+
+The top collider goes; gravity engages while the ball is above a per-venue friendship-bound height, so the ball arcs back into play. The side walls go; a ball crossing either lateral edge fires a side-miss before its body unfreezes and rolls. Paddle line and ground unchanged. Drives SH-309.
+
+## Apex return
+
+The friendship-bound is a per-venue height authored on `Court` as `@export var friendship_bound_height: float`. Today's `Top Wall` StaticBody2D under `Bounds` is removed.
+
+The active-ball state already runs at `gravity_scale = 0` for frictionless rally physics. The Court watches the ball's `y` position. While the ball is above the bound, the Court sets the ball's `gravity_scale` to its normal value; the ball arcs naturally and falls back. Once it re-enters the bound, `gravity_scale` returns to `0` and rally physics resume.
+
+The ball does not change state machine during the arc. It stays in active-movement; paddle hits and friendship-bound are valid throughout. The arc is a sub-state of in-play, not a state transition. The rally counter does not pause. A ball is only out of play when it is held (dragged-gravity), at rest on the venue floor (after a miss), or stashed in the rack.
+
+The bound is one number per Court instance. No horizontal restoring force, no centre-pull, no directional shaping; gravity alone returns the ball, and the ball's own momentum carries it where it goes. A hard reflect at the bound would read as an invisible ceiling; a soft arc reads as something holding the ball in.
+
+## Side miss
+
+The court's `Right Wall` and (currently un-authored) left side both become side-miss zones. The existing `Right Wall` StaticBody2D is removed; an `Area2D` band replaces it, mirrored on the left.
+
+A ball whose centre crosses either band fires the existing `ball_missed` path in `BallTracker`. The body's `gravity_scale` rises to its normal value (same flip the back-miss line already does today), velocity at the crossing is preserved, and the body rolls out onto `VenueFloor`. The ball comes to rest where friction stops it. The player drags it back to the `BallRack` to re-serve, per the existing flow in `08-court-bounds.md`.
+
+The partner-side miss zone, currently parented under `Right Wall`, re-parents to the new right `Area2D` band. The `BallTracker` registration remains.
+
+The back-miss line behind the player paddle and the bottom ground are unchanged.

--- a/designs/01-prototype/08-court-control.md
+++ b/designs/01-prototype/08-court-control.md
@@ -1,27 +1,29 @@
 # Wall-less Court Control
 
-Today the rally tops out with a pong-bounce off a screen-edge ceiling, and balls straying sideways bounce off invisible walls and stay in play. This spec replaces both.
+Today the rally tops out with a pong-bounce off a screen-edge ceiling, and balls straying past a paddle bounce off invisible walls and stay in play on the partner side (or end the rally on the player side, asymmetric). This spec replaces both with a single rule.
 
-At the top, the ball rises past the friendship-bound, arcs back down under gravity, and the rally continues; the player feels the ball being held in by the friendship rather than rebounding off a ceiling. At the sides, the ball rolls out onto the venue floor and lies among the items the player has placed, to be walked back to the rack.
+At the top, the ball rises past the friendship-bound, arcs back down under gravity, and the rally continues; the player feels the ball being held in by the friendship rather than rebounding off a ceiling. At either lateral edge, the ball rolls out onto the venue floor and lies among the items the player has placed, to be walked back to the rack.
 
-The top collider goes; gravity engages while the ball is above a per-venue friendship-bound height, so the ball arcs back into play. The side walls go; a ball crossing either lateral edge fires a side-miss before its body unfreezes and rolls. Paddle line and ground unchanged. Drives SH-309.
+The top collider goes; gravity engages on every live ball whose y is above a per-Court friendship-bound height, so each ball arcs back into play. The lateral walls go; a ball crossing either lateral edge fires a miss and rolls. The bottom (ground) is unchanged. Drives SH-309. Supersedes the apex-return section of `21-ball-dynamics.md` and the bounds/miss sections of `08-court-bounds.md`.
 
 ## Apex return
 
-The friendship-bound is a per-venue height authored on `Court` as `@export var friendship_bound_height: float`. Today's `Top Wall` StaticBody2D under `Bounds` is removed.
+The bound is a per-Court height. Each live ball whose y is above the bound has gravity on; each at or below has gravity off. The ball arcs naturally above the bound and rally physics resume on re-entry. Multi-ball is supported by construction; the rule applies per ball.
 
-The active-ball state already runs at `gravity_scale = 0` for frictionless rally physics. The Court watches the ball's `y` position. While the ball is above the bound, the Court sets the ball's `gravity_scale` to its normal value; the ball arcs naturally and falls back. Once it re-enters the bound, `gravity_scale` returns to `0` and rally physics resume.
+The mechanism is gravity-toggling, not a vertical-velocity flip. A flip would read as an invisible ceiling (sawtooth ricochet); the toggle reads as a held arc. The ball stays a live ball throughout the arc; paddle hits register and the volley counter increments above the bound the same as below.
 
-The ball does not change state machine during the arc. It stays in active-movement; paddle hits and friendship-bound are valid throughout. The arc is a sub-state of in-play, not a state transition. The rally counter does not pause. A ball is only out of play when it is held (dragged-gravity), at rest on the venue floor (after a miss), or stashed in the rack.
+This section supersedes the apex-return section of `21-ball-dynamics.md`, which described a velocity flip. The 21 section is retired or rewritten as part of the apex-return implementation.
 
-The bound is one number per Court instance. No horizontal restoring force, no centre-pull, no directional shaping; gravity alone returns the ball, and the ball's own momentum carries it where it goes. A hard reflect at the bound would read as an invisible ceiling; a soft arc reads as something holding the ball in.
+## Miss
 
-## Side miss
+A miss is the rally-ending event. A ball whose centre crosses either lateral edge of the court fires a miss: gravity engages, the rally counter resets, the ball comes to rest on the venue floor where friction or damping stops it, and the player drags it back to the rack to re-serve.
 
-The court's `Right Wall` and (currently un-authored) left side both become side-miss zones. The existing `Right Wall` StaticBody2D is removed; an `Area2D` band replaces it, mirrored on the left.
+Player-side and partner-side are the same event with the same outcome; both edges are lateral, both end the rally for the same reason (the ball got past a paddle's line). The partner already has its own miss zone in code; the player-side gets the same treatment when its wall is removed.
 
-A ball whose centre crosses either band fires the existing `ball_missed` path in `BallTracker`. The body's `gravity_scale` rises to its normal value (same flip the back-miss line already does today), velocity at the crossing is preserved, and the body rolls out onto `VenueFloor`. The ball comes to rest where friction stops it. The player drags it back to the `BallRack` to re-serve, per the existing flow in `08-court-bounds.md`.
+A live ball pulled to the rack mid-rally is not a miss; the drag controller already replaces the live ball with a held body before any band crossing can fire.
 
-The partner-side miss zone, currently parented under `Right Wall`, re-parents to the new right `Area2D` band. The `BallTracker` registration remains.
+## Open questions
 
-The back-miss line behind the player paddle and the bottom ground are unchanged.
+- **Energy loss on the rest-roll.** Should the rolled ball lose energy from the venue floor (grippy surface, ball decelerates by friction), from the ball itself (ball feels heavy, decelerates by damping), or both? The choice changes the feel of "rolls onto the floor".
+- **Bound-height data shape.** Does the friendship-bound height live on a `VenueConfig` Resource from day one (clusters with other per-venue tunables, future-proofs multi-venue), or as a loose `@export` on `Court` for now and promoted later?
+- **Drag-handoff frame window.** When a player grabs a live ball near a lateral edge while it is travelling outward, the drag controller swaps the live ball for a held body; the swap is deferred a frame, and during that frame the live ball can cross the band. Should the spec mandate that miss does not fire while a grab is in flight, or leave it as an implementer judgement?

--- a/designs/01-prototype/21-ball-dynamics.md
+++ b/designs/01-prototype/21-ball-dynamics.md
@@ -1,360 +1,77 @@
 # Ball Dynamics
 
-Design review of the ball physics model: what stays, what changes, and why. Answers the seven questions raised in SH-83 so that ball feel and the planned item effects (`Dead Weight`, `The Call`, `The Stray`, `Cadence`) can be implemented against a single coherent model.
+The ball-feel decisions. Implementation detail is deliberately thin; the ideas are the canon.
 
-**Points:** Spike
 **Dependencies:** [Balls on the Court](08-balls.md), [Partner AI](17-partner-ai.md), [Make Fun Pass](16-make-fun.md), [Effect System](07-effect-system.md).
 
 ---
 
-## Context: where the ball is today
+## Return angle
 
-The live implementation lives in `scripts/entities/ball.gd` and `scripts/entities/ball_effect_processor.gd`.
+The paddle's hit offset drives the return angle. Centre hits go flat, edge hits go steep, up to roughly a sixty-degree ceiling at full influence. The placeholder "bias toward horizontal" behaviour is removed because it fights the player's intent.
 
-- `Ball` extends `RigidBody2D` with `lock_rotation = true`, `linear_damp = 0.0`, and the court's `PhysicsMaterial` handling wall and paddle reflections.
-- Each physics frame the ball re-normalises its velocity and scales to a target `speed`. This clamps the magnitude the engine would otherwise drift through its integrator.
-- `BallEffectProcessor.process_frame` reads live stats from `ItemManager` (`ball_speed_min`, `ball_speed_max_range`, `ball_speed_increment`, `ball_speed_offset`, `ball_magnetism`) and applies magnetism (a small steering force toward the nearest paddle).
-- On paddle contact, `_on_body_entered` calls `paddle.on_ball_hit()` then `effect_processor.process_hit()`. The hit path already calls `_apply_return_angle_influence`, but that function biases the post-bounce velocity toward horizontal based on a single scalar stat. It does not read the paddle's position or the hit offset.
-- `speed` starts at `ball_speed_min` (450) and advances by `ball_speed_increment` (17) per paddle hit up to `ball_speed_min + ball_speed_max_range` (790). `set_speed_for_streak` lets the rally restore on pickup.
-- Partner AI (`scripts/core/paddle_ai_math.gd::predict_intercept`) models the ball as a straight line with perfect wall reflections, capped at 20 reflection iterations.
+## Speed curve
 
-The ticket's stated numbers (400-700, +15) are slightly out of date: live stats are 450-790, +17. Feel conclusions below use the live numbers.
+Speed climbs linearly per paddle hit, from a per-tier floor to a per-tier ceiling. A diminishing curve makes the top end feel like a wall the rally can never cross; that undercuts the moment a long rally caps. Tuning lives in the base-stats config and the speed-tier table, never as a curve type baked into code.
 
----
+## Spin and curve
 
-## Q1. Return angle control
+Out of scope as a baseline ball behaviour. Curve ships only through items as local fields (gravity wells, deflectors), not as a global ball trait. A constant curve makes every miss feel like the game's fault; a local field reads as a chosen risk.
 
-**Recommendation:** paddle-offset drives the return angle. Repurpose the `return_angle_influence` stat as the strength knob for that mapping. Remove the current "bias toward horizontal" behaviour; it is a placeholder that fights the player's intent.
+## Physics model
 
-Concretely, on `process_hit`:
+`RigidBody2D` with a per-frame speed clamp. A kinematic rewrite would cost more than it saves: walls, paddles, and future static fixtures all reflect for free under the existing material. Tunnelling at the current top speed is well within the physics tick; if items push the cap higher, switch the body to shape-cast continuous collision rather than rewrite.
 
-```
-hit_offset = clamp((ball.y - paddle.y) / (paddle_height / 2), -1, 1)
-max_deflection_radians = deg_to_rad(60)   # ceiling, not default
-target_angle = hit_offset * max_deflection_radians * return_angle_influence
-new_dir.x = sign(current_dir.x) * cos(target_angle)
-new_dir.y = sin(target_angle)
-ball.linear_velocity = new_dir * ball.speed
-```
+## Item compatibility
 
-Design properties:
+The planned ball-affecting items (gravity well, deflection, multi-ball, speed oscillation) all slot into the processor-plus-stats model without touching `Ball` itself. Each is a one-line addition on top of the baseline.
 
-- `return_angle_influence = 0` preserves the pure-reflection feel (current base stat default).
-- `return_angle_influence = 1` gives full Breakout/Arkanoid-style control: edge hits reach 60 deg, centre hits go flat.
-- The stat stays additive like every other `ItemManager` stat, so items can nudge it (e.g. a "Fine Tuning" passive lifts player return angle; a debuff trims it).
-- Hit offset is derived from the current paddle collision-shape height (`_collision_shape.size.y`), so `paddle_size` changes (shrink effects, levelling) automatically rescale the mapping.
+## AI prediction
 
-This subsumes the existing `_apply_return_angle_influence` implementation. The horizontal-bias version it replaced was never shipped as an item and was not observable in normal play, so removing it has no save-compat cost: just delete the old branch.
+Linear with reflections, exact for the baseline rally. Local curve fields are designed to break it: a partner that misses more under a gravity well is correct partner feel, not a bug. Multi-ball picks the nearest projected intercept.
 
-**Acceptance hooks:** paddle position influences return angle; `return_angle_influence` drives it.
+## Bounce variance
+
+No random noise on bounces. Variance is systemic, from paddle offset and the speed climb; random noise reads as the game being inconsistent rather than the player being good.
 
 ---
 
-## Q2. Speed curve feel
+## Regime: three shapes
 
-**Recommendation:** keep the curve linear in code; move the feel decision entirely into `BaseStatsConfig` by treating `ball_speed_min`, `ball_speed_max_range`, and `ball_speed_increment` as the tuning surface. No non-linear curve in the engine.
+A ball appears in three places: a rack token at rest, a held token under the cursor, a live rally body. Three node types, one per shape. Held is never physics; live always is.
 
-Rationale:
+Transitions swap shape rather than mutate one body. A rack click spawns a held token. A mid-rally grab destroys the live ball and spawns a held token in its place. Release over the court spawns a live ball. Release over the rack destroys the held token and the rack regrows its slot.
 
-- The current span is 450 to 790 at +17 per hit. That is 20 hits from floor to ceiling. On an average rally this is roughly 10-15 seconds of play, which is where the "rally pressure" beat should land. Rallies that run longer than that are already at the exciting end.
-- A diminishing curve (e.g. `speed += increment * (1 - t)`) makes the top end feel like a wall the rally can never cross. That undercuts the "we pushed through" moment that caps a long rally.
-- Items already manipulate speed additively through `ball_speed_offset`, and per-hit increment is a stat, so a future "slow burn" partner can ship a non-linear feel by owning those knobs without the core needing a curve type.
-- Keeping the model linear keeps the AI prediction stable (Q6) and the streak-restore path (`set_speed_for_streak`) a one-line calculation.
+Single-ball-on-court was an accidental constraint, not a rule. The reconciler tracks every live ball; consumers subscribe per-ball. Each ball carries its own speed; the streak counter is shared rally state.
 
-If future playtesting shows the ceiling arrives too fast, the levers are: raise `ball_speed_max_range`, lower `ball_speed_increment`, or add a per-streak-bracket offset via an item. None require a code change to the ball.
+## Three states (across all draggable items)
 
-This recommendation dovetails with the tier model in [20-ball-speed-tiers.md](20-ball-speed-tiers.md): `ball_speed_max_range` stays the tuning surface, and SH-88's `SpeedTierTable` reads it per-tier as a `max_range` field rather than a single flat stat. Tier 0 carries the flat value this doc assumes (340 px/s), so the linear-curve tuning story here still holds; Tiers 1-3 each declare their own `max_range` alongside their floor and ceiling, widening the surface without breaking it.
+Every item lives in one of three states:
 
-**Acceptance hooks:** speed curve reviewed, recommendation is keep linear and tune via base stats.
+- **Token.** No physics body; sits in its container's slot, sized by the item definition.
+- **Dragged-gravity.** A physics body, frozen while the cursor pins it, gravity engaged once released without a target. Stray balls that have left the court also live in this state.
+- **Active-movement.** A physics body with gravity off and frictionless momentum. Only ball-role items enter this state, and only when the court owns them.
 
----
+Transitions between states ease, never snap. Position, scale, and modulation read as continuous through the state change. The exception is the release-onto-court transition, where the body's velocity itself is the continuity; no tween needed.
 
-## Q3. Spin or curve
+## Speed is friendship
 
-**Recommendation:** out of scope for the prototype. Ship the mechanic only as an item-driven effect, not as a baseline ball behaviour.
+Rally speed carries through grab-and-release: a mid-rally grab is a redirect, not a reset. The magnitude survives the held-token detour; the gesture chooses only the direction. Speed only resets on miss.
 
-Reasons:
+## Drop validation
 
-- Constant curve on every ball makes the court read as unpredictable noise rather than a skill surface. The player cannot distinguish "this ball curved because I hit it poorly" from "this ball curved because the ball does that." We lose the teaching signal of the return-angle control above.
-- Curve on top of predictive AI (Q6) forces the AI to either track live (Tier 1, regresses partner feel) or simulate curve in its projection (expensive and brittle).
-- Items that want to curve balls (Dead Weight's gravity well is the designed path) already have a clean hook: per-frame acceleration applied in `BallEffectProcessor.process_frame`, driven by an item-owned node. That keeps curve scoped to moments the player opted into.
+Release polls every drop target on the held position each physics frame; the first target that accepts wins. For containers that respawn a non-physics token (shop, rack), validation is a bounds check. For the court, validation is a body projection: query the rally space with the body's at-rest collision shape and reject any overlap. The body never spawns inside another body.
 
-When an item does introduce curve, it should:
+## No restore on invalid release
 
-- Apply its acceleration through `process_frame`, then renormalise via the existing `linear_velocity = linear_velocity.normalized() * speed` clamp so the ball's top speed remains the stat-driven ceiling.
-- Expose a short-lived "curve field" region (gravity well radius, deflector cone) rather than a global scalar. Local effects are readable; global curve is not.
+The held token does not teleport home on a bad release. Teleport-restore is non-diegetic. The gesture stays open until a target accepts; mouse-up is a hint, not a gate. The source container is always a valid target, so the player always has a way to put the thing back.
 
-**Acceptance hooks:** spin/curve decision is out of scope for baseline ball; in scope only as item-driven local fields.
+## Press without movement
+
+A press lifts the preview but does not drop. The drop gate opens only past a movement threshold. Press-and-release on any container is a no-op; the player has to commit to the gesture.
 
 ---
-
-## Q4. Physics model suitability
-
-**Recommendation:** keep `RigidBody2D`. The friction the ticket describes is real but small, and the alternatives cost more than they save.
-
-What `RigidBody2D` gives us today:
-
-- Free collision resolution against paddles, walls, and any future `StaticBody2D` fixtures (posts, deflectors, bumpers).
-- One shared `PhysicsMaterial` controls bounciness across every surface; items that add surfaces get correct reflection for free.
-- `contact_monitor = true` + `_on_body_entered` gives us a signal-driven hit path that items already consume.
-
-What it costs:
-
-- Per-frame renormalisation to pin the speed.
-- Two fields on the `Ball` (`speed`, `linear_velocity`) that have to stay in sync.
-- An effect processor node holding the state machine that a kinematic version would hold in the ball itself.
-
-A kinematic rewrite (`CharacterBody2D` + manual reflection) would remove the renormalisation but require us to re-implement wall reflection, paddle reflection with the Q1 offset formula, tunnelling guards for the top speed, and collision-shape queries for every static fixture items add later. That is a lot of surface for a marginal speed-clamp win, and we already have the clamp working.
-
-**Tunnelling check.** At 790 px/s and 60 Hz the ball travels ~13 px per physics tick. Paddle thickness and wall thickness are both well above that. If future items push the speed cap higher, switch `continuous_cd` on the ball to `CCD_MODE_CAST_SHAPE` rather than moving to kinematic.
-
-**Acceptance hooks:** physics model reviewed, recommendation is keep `RigidBody2D` with the existing speed clamp.
-
----
-
-## Q5. Item interaction audit
-
-Each planned ball-affecting item checked against the recommended model.
-
-### Dead Weight (gravity well, SH-56)
-
-Clean fit. The well spawns as a scene with a position and a radius stat. `BallEffectProcessor.process_frame` grows a second pass (after magnetism, before speed-limit sync) that applies a per-frame acceleration toward any active well within range:
-
-```
-for well in active_wells:
-    to_well = well.global_position - ball.global_position
-    distance = to_well.length()
-    if distance < well.radius:
-        falloff = 1 - (distance / well.radius)
-        ball.linear_velocity += to_well.normalized() * well.strength * falloff * delta
-```
-
-The existing renormalise step at the end of `_physics_process` preserves the speed ceiling. No new field on `Ball`; wells register with `BallEffectProcessor` the same way paddles do today.
-
-### The Call (deflection, SH-55)
-
-Clean fit. Deflection is a one-shot redirect on demand. Add `Ball.deflect(target_direction: Vector2)` that sets `linear_velocity = target_direction.normalized() * speed`. The Call's outcome invokes it. No physics rewrite.
-
-### The Stray (multi-ball, SH-54)
-
-Clean fit. `SpawnBallOutcome` (already designed in `08-balls.md`) instantiates additional `Ball` scenes. Each one owns its own `BallEffectProcessor`, so effects scale per-ball. The only shared state is `ItemManager` stats, which every ball reads fresh each frame. No coupling across balls.
-
-One note for the ticket that implements it: AI prediction needs to know which ball to chase. The partner AI should track the nearest ball by projected intercept time, not by spawn order, so that temporary balls do not get ignored (see Q6).
-
-### Cadence (speed oscillation)
-
-Clean fit. Add a small sine-driven additive term inside `_sync_speed_limits` alongside `ball_speed_offset`:
-
-```
-oscillation = ItemManager.get_stat(&"ball_speed_oscillation_amp") * \
-              sin(TAU * ItemManager.get_stat(&"ball_speed_oscillation_hz") * time)
-```
-
-`time` is a per-ball accumulator so multiple balls do not beat against each other. Because this rides on the same `_base_speed + offset` stack, it composes with every other speed-modifying stat without special cases.
-
-**Summary:** all four planned items slot into the current processor-plus-stats model. None requires touching `Ball` itself except for The Call's one-line method.
-
-**Acceptance hooks:** item interaction audit covers each planned ball effect against the proposed model.
-
----
-
-## Q6. AI prediction compatibility
-
-**Recommendation:** keep linear-with-reflections prediction for the baseline ball. Do not try to simulate curve or gravity in the predictor. Instead, when an item introduces a local curve field, treat the prediction error as designed partner behaviour and surface it as such.
-
-Why that is acceptable:
-
-- The rally without items is straight-line with wall reflections. The current predictor is exact for this case.
-- The only baseline change this spike recommends is paddle-offset return angle (Q1). That affects the ball's direction at the instant of a paddle hit, which is already an event the predictor treats as "recompute from here." No upstream prediction goes wrong.
-- Local curve fields (wells, deflectors) break prediction on purpose. A partner running Dead Weight should miss more; the item's read is "this slows my partner down," which is correct partner feel and matches how the player experiences it. "Partner breaks on gravity" is the feature.
-- A partner can opt out of the confusion via a stat, e.g. `ai_intercept_uses_wells` is a boolean the predictor checks; an upgraded partner gets a smarter projection. That is a shippable progression hook rather than a tech debt.
-
-Multi-ball needs a small predictor change: today the partner AI targets one ball. When more than one is live, it should pick the ball with the smallest positive time-to-intercept for the partner's lane. That is a scoring function, not a physics rewrite.
-
-**Acceptance hooks:** AI prediction impact assessed.
-
----
-
-## Q7. Bounce angle variance
-
-**Recommendation:** drop SH-49's random-offset-on-bounce. Systemic variance from paddle offset (Q1) and hit-streak speed (Q2) is enough to keep the rally from looking scripted, and random noise on wall bounces would fight the player's ability to read the ball.
-
-What "enough variance" means here:
-
-- Paddle offset makes every return the player's decision. Edge hits are steep; centre hits are flat. The player controls the mix.
-- Speed increment means every rally's nth hit lands at a different speed, so even an identical trajectory plays out differently as the streak lengthens.
-- Item fields (wells, deflection) are the source of surprise when the build asks for surprise.
-
-Random bounce variance on walls cannot be attributed back to any player decision, so it reads as the game being inconsistent rather than the player being good. The existing SH-49 ticket should be closed out with this design as the rationale (or kept open as a "considered and declined" record, per the project's ticket-writing guide).
-
-**Acceptance hooks:** bounce-angle variance decision is systemic (paddle offset + speed curve + item fields); no random noise on bounces.
-
----
-
-## What this changes in code
-
-A follow-up implementation ticket should cover exactly these edits:
-
-1. Rewrite `BallEffectProcessor._apply_return_angle_influence` to use the Q1 paddle-offset formula. It needs the paddle that was hit, which `process_hit` does not currently receive. Pass the paddle through from `Ball._on_body_entered` so the processor has it.
-2. Add `Ball.deflect(target_direction)` for SH-55.
-3. Add a gravity-well registration surface to `BallEffectProcessor` (`register_well`, `unregister_well`) and a second pass in `process_frame` for SH-56.
-4. Partner AI: switch ball selection from "the ball" to "nearest projected intercept" for SH-54.
-5. Tests: unit-test the paddle-offset formula against known hit positions; extend `PaddleAIMath` tests only if the selection function becomes non-trivial.
-
-All four items above can ship independently and against current main. Nothing about this spike blocks landing SH-54, SH-55, or SH-56 separately.
-
----
-
-## Related tickets
-
-- [SH-49](https://github.com/shuck-dev/volley/issues/49) (ball bounce angle variance): close or decline per Q7.
-- [SH-54](https://github.com/shuck-dev/volley/issues/54) (The Stray, multi-ball): compatible, needs the nearest-ball predictor change (Q6).
-- [SH-55](https://github.com/shuck-dev/volley/issues/55) (The Call, deflection): compatible, needs `Ball.deflect`.
-- [SH-56](https://github.com/shuck-dev/volley/issues/56) (Dead Weight, gravity well): compatible, needs well registration on the effect processor.
-
----
-
-## Regime unification
-
-A ball shows up in three conceptual places: as a token on the rack between rounds, as something the player is dragging, and as the live rally body that everything else reacts to. The live body exists today in `scripts/entities/ball.gd`. Drag exists today only for shop items, in `scripts/shop/shop_item.gd`. Rack tokens, `SpawnBallOutcome`, `BallReconciler`, auto-serve, and Tinkerer are all design references without code behind them yet. `ItemManager` already emits `court_changed` (around line 255), and nothing listens.
-
-The question this spike answers: do these three presentations need three separate node types, or one?
-
-### Decision
-
-Held is not physics; live rally is. The cursor roams the whole screen during a hold, unconstrained by where a ball could legally sit, and physics only re-enters the picture at the moment of release.
-
-Three shapes, each with a clear job:
-
-- **Rack token.** `Node2D` plus art, owned by `RackDisplay`, regrown on refresh.
-- **Held token.** `Node2D` plus art, owned by the drag controller, parented to a screen-space layer so it follows the cursor with no collision and no solver cost.
-- **Live rally ball.** `Ball` (`RigidBody2D`), the behaviour already shipped.
-
-Transitions swap shape rather than mutate a single body:
-
-- Rack click: the drag controller spawns a held token and the rack marks that slot spent.
-- Mid-rally grab: the live `Ball` is removed from play (suspended, hidden, or `queue_free`d depending on what reads cleanest) and a held token takes over cursor-follow in its place.
-- Release over court: a `Ball` instance is instantiated (or reinstated, for a mid-rally grab) at the cursor with an initial velocity derived from the release gesture.
-- Release over rack: the held token is destroyed and the rack refresh regrows the rack token in its slot.
-
-Keeping physics out of the held state means the cursor never has to respect a collision envelope and the held visual is cheap to move, fade, or restyle without touching solver code.
-
-### Boundaries and ownership
-
-Three owners, one per shape:
-
-- **`RackDisplay`** owns rack tokens. Tokens are `Node2D` + art, regrown on each rack refresh.
-- **Drag controller** owns the held token. It spawns the token on grab, slides it under the cursor each frame, and destroys it on release.
-- **Reconciler / `Court`** owns live `Ball` instances. The reconciler hands out and tears down `Ball` nodes to match `on_court[&ball]`, and the court hosts them during rally.
-
-Release rules:
-
-- Held-token follow clamps to venue bounds each frame, so the cursor can never take the token outside the venue. Release always fires from within the venue; the clamp does the work at the edges.
-- Released over `BallRack.DropTarget`: the held token is destroyed and the item deactivates; the rack refresh handles the visual return.
-- Released over the court (inside `court_bounds`): the drag controller destroys the held token and asks the court (via the reconciler for permanent balls, directly for a mid-rally reinstatement) for a `Ball` at the cursor with the release-gesture velocity.
-- Released inside the venue but outside both rack and court: the ball enters play at the position clamped to `court_bounds` (the nearest valid play point). Defensively, any release position is clamped to venue bounds before the zone check.
-
-Nothing crosses boundaries by mutating a shared body. Each owner only creates and frees its own shape.
-
-### Multi-ball wiring
-
-The reconciler tracks N concurrent balls; consumers subscribe per-ball, not to a single "current ball." `BallReconciler` emits `ball_added(ball)` and `ball_removed(ball)` whenever the tracked set changes (spawn, ensure, adoption, release, deactivate). The previous `current_ball` / `current_ball_changed` single-var concept is removed; the reconciler keeps no opinion about which ball is "the" one.
-
-- **Court** subscribes to every tracked ball's `missed` and `at_max_speed_changed` for HUD and item-event purposes, but speed lives on each ball. Each `Ball` advances its own `speed` from its own paddle-collision path (`_on_body_entered`) and resets its own `speed` from its own `missed` signal. The streak counter is shared rally state on Court (it halves or zeroes on any miss and drives the volley HUD), but speed magnitudes are no longer fanned out across balls. A miss on one ball does not slow another; a hit on one ball does not accelerate another. With multi-ball items like The Stray this reads as each ball carrying its own rally pressure, layered onto a single streak readout.
-- **SpeedBar** subscribes to every tracked ball's `speed_changed` and renders the **highest** current speed across the set. The bar reads as rally pressure: the most energetic ball drives the visual, the calmer ones live underneath it.
-- **Partner targeting** still picks one ball at a time today (back-compat handle on Court). The smarter "nearest projected intercept" selection is a separate ticket; see Q6.
-
-This is design intent, not a bug to prevent: the prototype has always wanted The Stray (SH-54) and similar multi-ball items to layer cleanly on top of the rally. Single-ball-on-court was an accidental constraint that fell out of consumer wiring, not a rule the system was trying to keep.
-
-### Transition seams
-
-`court_changed` is the join point. A new `BallReconciler` listens to it and reconciles the live ball set to match `on_court[&ball]`. When a permanent ball becomes on-court, the reconciler hands out a `Ball` instance. When one leaves, the reconciler `queue_free`s the excess. Everything else about ball lifetime flows through this node, so nothing outside it needs to know about counts.
-
-`SpawnBallOutcome` instantiates `scenes/ball.tscn`, tags the instance as temporary, and `queue_free`s on the outcome's expiry trigger. Temporary balls live outside the reconciler's placement-driven set and do not touch `on_court`. No coupling across balls beyond the spawn itself.
-
-Auto-serve and Tinkerer are out of scope for this spike. Auto-serve belongs near Court's ball-spawn path; Tinkerer is a `BallEffectProcessor` extension rather than a regime question.
-
-### Save-shape
-
-Persist what the world actually contains: rack placement counts, and each live `Ball`'s position and `linear_velocity`. The held state is ephemeral UI and is never persisted; a save taken mid-hold snaps back to "ball on rack" for a held-from-rack grab or "ball in play" for a held-from-rally grab.
-
-On load, the court resumes as though the rally had continued in the background during the save window: live balls are reconstructed at their persisted position and velocity, and normal physics advances them from there. If resuming from the exact persisted state turns out to be too expensive (pathological stacks, solver warm-up cost), the escape hatch is to snap live balls to a sensible serve-ready position rather than stall the load. Hack it if it comes to that.
-
-### Temporary ball scenario
-
-Temporary balls cover the `SpawnBallOutcome` pathway and any other one-shot ball that does not belong to permanent-item placement. A temporary ball is instantiated from `scenes/ball.tscn` directly, tagged `is_temporary = true`, and parented under the court host. It stays outside the reconciler's tracked set, never touches `on_court`, and does not register an item-level effect. Dragging a temporary ball still goes through the drag controller's held-token gesture so the release path clears cleanly, but the release never spawns a permanent ball through the reconciler and never flips placement state.
-
-Integration coverage lives in `tests/integration/test_ball_regime_transitions.gd` under `test_temporary_ball_does_not_touch_placement_or_reconciler`.
-
-### Watchouts for the implementation
-
-- Add a `_dragging` guard on `Ball._on_body_entered` so a paddle contact at the edge of a grab does not register as a hit during the handoff.
-- Reparenting or freeing a `CollisionObject2D` inside a physics callback errors out. Any mid-rally grab that removes the live `Ball` from play uses `call_deferred` so the mutation lands between ticks.
-- Velocity on release comes from the gesture, not from whatever the old live ball was doing; a mid-rally grab intentionally resets motion.
-
-### Containers and the swap pattern
-
-Every item lives in a container. Every container owns its items the same way: one body per item, parented under the container, sized by `ItemDefinition.token_scale`. The body is the same body across containers; what changes per container is which physics state the body is in.
-
-Three states:
-
-- **Token.** No physics body. A `Node2D` parented under its container's slot, sized by `ItemDefinition.token_scale`. This is the at-rest form items take inside the shop, the racks, and the workshop. Tokens don't fall, don't collide, don't have weight; they sit where the container puts them. The slot is layout.
-- **Dragged-gravity.** A `RigidBody2D` used in two distinct sub-states. While the player is dragging (cursor pinned), the body is `freeze=true` and follows the cursor through the controller's lift-and-track logic; gravity is off and the player is moving the body, not holding it up. Once released without an accepting container, the body unfreezes, gravity engages, and it falls until it lands or rolls. Stray balls that exit the court are also in this fallen-and-rolling sub-state. The shared name reflects that both sub-states use the same node type and the same authored `at_rest_shape`; they differ only in whether the cursor or physics owns the body's motion.
-- **Active-movement.** A `RigidBody2D` with gravity off, frictionless momentum. The body keeps the velocity it was given until a paddle, wall, or item effect changes it. This is the rally physics: paddle collisions, wall bounces, the speed curve, magnetism, the friendship-bound apex return. **Only ball-role items ever enter this state, and only when the court owns them.**
-
-Transitions between states happen at container boundaries. Every transition is eased, never a snap, so the body's position, scale, and modulation read as continuous through the state change.
-
-- **Token → Dragged-gravity.** On grab, the source container's token is vacated and a `RigidBody2D` body spawns at the token's last world position. The body eases onto the cursor over a short tween (~80 ms) rather than teleporting; the player sees the body "lift" off the slot. Gravity engages once the tween settles. Because the body eases to the cursor rather than snapping under it, the press hit box can be generous (wider than the visible body) and the body still arrives at the cursor cleanly. This matters most for balls in flight: the player presses near a moving ball and the body eases over to the pointer rather than the press requiring a pixel-precise hit on a body the rally is already moving.
-- **Dragged-gravity → Token.** On release into a rack-style container, the held body is freed and the destination container regrows its slot at `token_scale`. No landing tween: the lift-ease is what reads as the continuous motion of the gesture, and a second ease on landing reads as the body second-guessing itself. The slot regrowth fires from `item_placement_changed`, which is what couples the body's disappearance to the slot's reappearance in the same frame.
-- **Dragged-gravity → Active-movement.** On release of a ball onto the court, gravity flips off and the rally takes the body's release-gesture velocity as its starting motion. No tween needed; the velocity itself is the continuity.
-
-Ball speed is friendship. It carries through grab-and-release: the magnitude the rally had built up before the grab is the magnitude the released ball resumes at, with the gesture choosing only the direction. It resets only on miss. A mid-rally grab is a redirect, not a reset; the streak's accumulated friendship survives the held-token detour.
-- **Active-movement → Dragged-gravity.** When a ball rolls off the court (stray), gravity flips back on as the body crosses the court boundary; the velocity at the boundary carries through, the deceleration on the venue floor is the continuity. The same transition fires when the player grabs a live ball mid-rally; the body's current world position is the gesture's start position, and the held tween eases the body onto the cursor as in the token-grab case.
-
-The lift ease keeps the diegetic feel on grab: the body is one physical thing being picked up out of its slot, not teleporting under the cursor. Landing is the asymmetric case: a body released onto the court inherits its release-gesture velocity directly (the velocity is the continuity), and a body released onto a rack-style container is replaced by the slot's token without a landing tween (the slot regrowth is the continuity).
-
-Container summary:
-
-- **Court.** Owns ball-role items in active-movement. The body is a `Ball` (`RigidBody2D` with the rally configured on it). Does not accept non-ball items.
-- **Shop.** Owns items as tokens under the shop's slot. Diegetic feel for shop pickup comes through visual, audio, and haptic response on grab rather than solver work.
-- **Racks.** Own items as tokens in a slot grid. Slot grid is layout.
-- **Workshop (future).** Same as racks: tokens at rest, until the workshop's own activity (synthesis, levelling) animates them.
-
-The drag flow is symmetric across items. Equipment items behave the same as ball items in the gesture: same press lifts a held body in dragged-gravity, same `at_rest_shape` projection on the candidate position before the drop, same canonical `token_scale` from the definition. What differs is which container ends up owning the item and what state that container holds it in. Balls are the only items that ever enter active-movement; everything else cycles between token (at rest in a container) and dragged-gravity (during the gesture).
-
-### Drop validation by body projection
-
-Release does not rely on rectangular hit-tests of the cursor position. The drag controller polls every registered drop target each physics frame on the held token's current position. The first target whose `can_accept(item, position)` returns true takes the drop and the gesture ends.
-
-For containers that respawn a non-physics token (shop, rack, workshop), `can_accept` is a bounds check plus per-target slot rules.
-
-For containers that respawn a physics body (the court), `can_accept` is a **body projection**: a `PhysicsDirectSpaceState2D.intersect_shape` query with the at-rest body's authored collision shape at the candidate position. If the query returns any overlap with walls, partners, other balls, or any future obstacle inside the court, the drop is rejected at that position. This is prevention, not depenetration; the body never spawns inside another body, so the solver never has to recover from one. Wall-edge release, ball-on-partner, ball-on-equipment-rack-edge, and stack-of-already-placed-balls all collapse into the same rule.
-
-`ItemDefinition.at_rest_shape` carries the projection shape per item. For balls this is the `CircleShape2D` at the ball's authored radius. Items whose at-rest representation is not a physics body declare `at_rest_shape = null` and the projection step is skipped (the bounds check alone decides).
-
-### No restore on invalid release
-
-The drag controller does not teleport the held token back to the source on an invalid release. Teleport-restore is non-diegetic; the held thing is a physical thing in the world.
-
-Instead, the gesture stays open until a valid target is reachable. After mouse-up, the held token continues to follow the cursor and the controller continues to poll `can_accept` every physics frame. The first frame any target accepts at the held position, the drop fires and the gesture ends. Mouse-button state is a hint after the initial press, not a gate.
-
-Hover feedback on the held token (slight lift, modulation, or scale bump) when `can_accept` returns true tells the player which positions will drop. Plain held state when no target accepts.
-
-The escape valve from this rule is that the source container is itself a target. Rack accepts a drop back into its slot (or any free slot). The shop's cancel rule is diegetic: a ball-role item released over the shop drops as a falling body and the body's settled position decides commit vs cancel. If it settles inside the shop area, the gesture cancels with no purchase; if it rolls or bounces out of the shop area, the purchase commits and the body becomes a loose ball the player can re-grab. The court accepts a drop back at the original spawn position when projecting from a live-ball grab. The player always has a way to put the thing back without the controller doing the move for them.
-
-### Press without movement does not drop
-
-A press on any container's at-rest representation lifts the held preview, but the drop gate stays closed until the gesture moves past the drag movement threshold. A press-and-immediate-release on a rack slot returns the item to the rack with no activation; on a shop slot it cancels back to the slot with no purchase (the press never built up enough motion to drop a body in the shop area); on a live ball it puts the ball back through the same target-accept loop without flipping placement state.
 
 ## Friendship-bound apex return
 
-The narrative canon in [`../narrative/00-two-styles.md`](../narrative/00-two-styles.md) treats the top of the court as sky, not surface: nothing physical bounces the ball back. The ball travels up to apex and returns under gravity and the friendship-bound. Whichever bond is in play in that venue is the medium the rally lives inside, and the bond's reach is what the ball cannot escape.
-
-Mechanically the ball changes direction at apex. Diegetically nothing physical bounces it. The current prototype implementation (top edge as hard ceiling, see `08-court-bounds.md`) is the placeholder; the friendship-bound apex return is the target shape, scoped past the prototype.
-
-Implementation notes:
-
-- The active-movement state already covers it. The body is a `RigidBody2D` with `gravity_scale = 0` and frictionless momentum (see "Containers and the swap pattern" above); the apex return is a vertical-velocity flip at the bound's height rather than a wall collision.
-- The bound's height per venue is data, not a global constant. Each venue's bond has its own reach.
-- The bottom edge of the court stays physical: the ground, the mat, the surface where the racquet meets the ball. Left and right remain open as miss zones.
-- The visible beat at apex (bloom, arc, chime, partner reaction) is art-bible scope; see [`../art/bible.md`](../art/bible.md) § 17.
+See [`08-court-control.md`](08-court-control.md) § Apex return.


### PR DESCRIPTION
Tech-design spike for SH-309. Adds `designs/01-prototype/08-court-control.md`, a focused spec for the wall-less court that implementation will work against.

The TLDR splits into three beats: today the rally tops out with a pong-bounce off a screen-edge ceiling and balls straying sideways bounce off invisible walls and stay in play; the player-felt change at each affected edge (held arc on top, ball-on-the-floor on the sides); and the implementation per surface (top collider gone with gravity above a per-venue friendship-bound height; side walls replaced with Area2D miss bands feeding the existing miss path).

Implementation is split out: SH-366 owns the apex return, SH-367 owns the side miss zones. Both are blocked by this spec.

The two old docs (`08-court-bounds.md` and `21-ball-dynamics.md`) carry material the new doc does not cover (ball state machine, container swap, cue layering, spirit-of-the-volley framing, resting-balls flow). They stay in place for now; we'll extract the kept material into focused successor docs as part of the implementation tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)