### PR TITLE
SH-366 feat: apex return via gravity-toggle

### DIFF
--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -58,22 +58,6 @@ item_key = "base_ball"
 
 [node name="Bounds" type="Node2D" parent="." unique_id=2106668171]
 
-[node name="Top Wall" type="StaticBody2D" parent="Bounds" unique_id=1297110620]
-position = Vector2(441.6, -351.6)
-rotation = 1.5707964
-physics_material_override = ExtResource("1_0wfyh")
-metadata/_edit_group_ = true
-
-[node name="ColorRect" type="ColorRect" parent="Bounds/Top Wall" unique_id=1483069279]
-offset_right = 21.6
-offset_bottom = 883.2
-mouse_filter = 2
-metadata/_edit_use_anchors_ = true
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Bounds/Top Wall" unique_id=2125011239]
-position = Vector2(10.8, 441.6)
-shape = SubResource("RectangleShape2D_horz")
-
 [node name="Bottom Wall" type="StaticBody2D" parent="Bounds" unique_id=743283118]
 position = Vector2(-441.6, 351.6)
 rotation = -1.5707964

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -18,9 +18,9 @@ const MissZoneScene: PackedScene = preload("res://scenes/miss_zone.tscn")
 @export var partner_spawn: Marker2D
 @export var timeout_controller: TimeoutController
 ## Friendship-bound Y; balls above (smaller y) arc under gravity back into the rally.
-@export var apex_bound_y: float = -351.6
+@export var apex_bound_y: float = ApexDefaults.BOUND_Y
 ## Gravity scale applied to balls above the friendship-bound.
-@export_range(0.0, 8.0, 0.05) var apex_gravity_scale: float = 1.0
+@export_range(0.0, 8.0, 0.05) var apex_gravity_scale: float = ApexDefaults.GRAVITY_SCALE
 
 ## Back-compat handle for tests; canonical live-ball set lives on `ball_tracker`.
 var ball: Ball
@@ -62,7 +62,7 @@ func _ready() -> void:
 		ball_tracker.ball_system = ball_system
 		add_child(ball_tracker)
 	ball_tracker.configure(player_paddle)
-	ball_tracker.set_apex(apex_bound_y, apex_gravity_scale)
+	ball_tracker.configure_apex(apex_bound_y, apex_gravity_scale)
 	ball_tracker.current_ball_changed.connect(_on_current_ball_changed)
 	ball_tracker.ball_missed.connect(_on_ball_missed)
 	autoplay_controller.bind_tracker(ball_tracker)

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -17,6 +17,10 @@ const MissZoneScene: PackedScene = preload("res://scenes/miss_zone.tscn")
 @export var right_wall: StaticBody2D
 @export var partner_spawn: Marker2D
 @export var timeout_controller: TimeoutController
+## Friendship-bound Y; balls above (smaller y) arc under gravity back into the rally.
+@export var apex_bound_y: float = -351.6
+## Gravity scale applied to balls above the friendship-bound.
+@export_range(0.0, 8.0, 0.05) var apex_gravity_scale: float = 1.0
 
 ## Back-compat handle for tests; canonical live-ball set lives on `ball_tracker`.
 var ball: Ball
@@ -58,6 +62,7 @@ func _ready() -> void:
 		ball_tracker.ball_system = ball_system
 		add_child(ball_tracker)
 	ball_tracker.configure(player_paddle)
+	ball_tracker.set_apex(apex_bound_y, apex_gravity_scale)
 	ball_tracker.current_ball_changed.connect(_on_current_ball_changed)
 	ball_tracker.ball_missed.connect(_on_ball_missed)
 	autoplay_controller.bind_tracker(ball_tracker)

--- a/scripts/court/apex_defaults.gd
+++ b/scripts/court/apex_defaults.gd
@@ -1,0 +1,7 @@
+class_name ApexDefaults
+extends Object
+
+## Single source of truth for apex/friendship-bound defaults; Court is the runtime authority but
+## Ball and BallTracker need safety-net values for tests and unconfigured spawns.
+const BOUND_Y: float = -351.6
+const GRAVITY_SCALE: float = 1.0

--- a/scripts/court/apex_defaults.gd.uid
+++ b/scripts/court/apex_defaults.gd.uid
@@ -1,0 +1,1 @@
+uid://c4jvudg7h0fe1

--- a/scripts/court/ball_tracker.gd
+++ b/scripts/court/ball_tracker.gd
@@ -17,19 +17,17 @@ var _current_ball: Ball
 var _partner_paddle: Node2D
 var _player_paddle: Node2D
 var _miss_zones: Array[MissZone] = []
-var _apex_bound_y: float = -351.6
-var _apex_gravity_scale: float = 1.0
-var _apex_configured: bool = false
+var _apex_bound_y: float = ApexDefaults.BOUND_Y
+var _apex_gravity_scale: float = ApexDefaults.GRAVITY_SCALE
 
 
 func configure(player_paddle: Node2D) -> void:
 	_player_paddle = player_paddle
 
 
-func set_apex(bound_y: float, gravity_scale: float) -> void:
+func configure_apex(bound_y: float, gravity_scale_value: float) -> void:
 	_apex_bound_y = bound_y
-	_apex_gravity_scale = gravity_scale
-	_apex_configured = true
+	_apex_gravity_scale = gravity_scale_value
 	for tracked in _balls:
 		if is_instance_valid(tracked):
 			_apply_apex(tracked)
@@ -156,7 +154,5 @@ func _on_ball_at_max_speed_changed(is_at_max: bool) -> void:
 
 
 func _apply_apex(target: Ball) -> void:
-	if not _apex_configured:
-		return
 	target.apex_bound_y = _apex_bound_y
 	target.apex_gravity_scale = _apex_gravity_scale

--- a/scripts/court/ball_tracker.gd
+++ b/scripts/court/ball_tracker.gd
@@ -17,10 +17,22 @@ var _current_ball: Ball
 var _partner_paddle: Node2D
 var _player_paddle: Node2D
 var _miss_zones: Array[MissZone] = []
+var _apex_bound_y: float = -351.6
+var _apex_gravity_scale: float = 1.0
+var _apex_configured: bool = false
 
 
 func configure(player_paddle: Node2D) -> void:
 	_player_paddle = player_paddle
+
+
+func set_apex(bound_y: float, gravity_scale: float) -> void:
+	_apex_bound_y = bound_y
+	_apex_gravity_scale = gravity_scale
+	_apex_configured = true
+	for tracked in _balls:
+		if is_instance_valid(tracked):
+			_apply_apex(tracked)
 
 
 func _ready() -> void:
@@ -41,6 +53,7 @@ func attach(new_ball: Ball) -> void:
 	if new_ball == null or _balls.has(new_ball):
 		return
 	_balls.append(new_ball)
+	_apply_apex(new_ball)
 	if _current_ball == null:
 		_set_current(new_ball)
 	if not new_ball.missed.is_connected(_on_ball_missed):
@@ -140,3 +153,10 @@ func _on_ball_missed() -> void:
 
 func _on_ball_at_max_speed_changed(is_at_max: bool) -> void:
 	ball_at_max_speed_changed.emit(is_at_max)
+
+
+func _apply_apex(target: Ball) -> void:
+	if not _apex_configured:
+		return
+	target.apex_bound_y = _apex_bound_y
+	target.apex_gravity_scale = _apex_gravity_scale

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -14,6 +14,10 @@ const SPEED_EMIT_THRESHOLD := 10.0
 @export_range(1.0, 4.0, 0.1) var press_hitbox_inflation: float = 2.4
 ## Authored Area2D that routes pointer presses; wired from the scene so the press hit-box stays scene-based.
 @export var press_area: Area2D
+## Y-coordinate of the friendship-bound; gravity engages while the ball is above (smaller y) this height. Court overrides per attach.
+@export var apex_bound_y: float = -351.6
+## Gravity scale applied while above the friendship-bound; off-bound the ball travels straight (gravity_scale = 0).
+@export_range(0.0, 8.0, 0.05) var apex_gravity_scale: float = 1.0
 
 var speed: float = 0.0
 var min_speed: float
@@ -40,6 +44,7 @@ func _ready() -> void:
 
 
 func _physics_process(delta: float) -> void:
+	_update_apex_gravity()
 	if linear_velocity == Vector2.ZERO:
 		return
 	effect_processor.process_frame(delta)
@@ -47,6 +52,15 @@ func _physics_process(delta: float) -> void:
 	if _should_emit_speed_changed():
 		_emit_speed_changed()
 	linear_velocity = linear_velocity.normalized() * speed
+
+
+# Gravity-toggle apex return: above the bound the ball arcs under gravity; the per-frame speed-lock
+# then re-normalises magnitude, so gravity bends direction without changing kinetic energy.
+func _update_apex_gravity() -> void:
+	if freeze:
+		gravity_scale = 0.0
+		return
+	gravity_scale = apex_gravity_scale if position.y < apex_bound_y else 0.0
 
 
 func _should_emit_speed_changed() -> bool:

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -15,9 +15,9 @@ const SPEED_EMIT_THRESHOLD := 10.0
 ## Authored Area2D that routes pointer presses; wired from the scene so the press hit-box stays scene-based.
 @export var press_area: Area2D
 ## Y-coordinate of the friendship-bound; gravity engages while the ball is above (smaller y) this height. Court overrides per attach.
-@export var apex_bound_y: float = -351.6
+@export var apex_bound_y: float = ApexDefaults.BOUND_Y
 ## Gravity scale applied while above the friendship-bound; off-bound the ball travels straight (gravity_scale = 0).
-@export_range(0.0, 8.0, 0.05) var apex_gravity_scale: float = 1.0
+@export_range(0.0, 8.0, 0.05) var apex_gravity_scale: float = ApexDefaults.GRAVITY_SCALE
 
 var speed: float = 0.0
 var min_speed: float
@@ -44,7 +44,7 @@ func _ready() -> void:
 
 
 func _physics_process(delta: float) -> void:
-	_update_apex_gravity()
+	_update_apex_gravity(delta)
 	if linear_velocity == Vector2.ZERO:
 		return
 	effect_processor.process_frame(delta)
@@ -54,13 +54,17 @@ func _physics_process(delta: float) -> void:
 	linear_velocity = linear_velocity.normalized() * speed
 
 
-# Gravity-toggle apex return: above the bound the ball arcs under gravity; the per-frame speed-lock
-# then re-normalises magnitude, so gravity bends direction without changing kinetic energy.
-func _update_apex_gravity() -> void:
+# Speed-lock turns gravity into curvature, not energy gain.
+func _update_apex_gravity(delta: float = 0.0) -> void:
 	if freeze:
 		gravity_scale = 0.0
 		return
-	gravity_scale = apex_gravity_scale if position.y < apex_bound_y else 0.0
+	# Predicted next-step y closes the one-tick overshoot: a fast-rising ball that skips the above-bound
+	# sample still triggers gravity. `<=` makes the bound closed so a ball stalled at exactly the line falls.
+	var current_y: float = global_position.y
+	var predicted_y: float = current_y + linear_velocity.y * delta
+	var above_bound: bool = current_y <= apex_bound_y or predicted_y <= apex_bound_y
+	gravity_scale = apex_gravity_scale if above_bound else 0.0
 
 
 func _should_emit_speed_changed() -> bool:

--- a/tests/unit/ball/test_ball_apex_return.gd
+++ b/tests/unit/ball/test_ball_apex_return.gd
@@ -1,0 +1,64 @@
+extends GutTest
+
+# Apex return: gravity engages above the friendship-bound, disengages below.
+# The per-frame speed-lock turns gravity into directional curvature, not energy gain.
+
+var _ball: Ball
+var _manager: Node
+var _mock_storage: SaveStorage
+
+
+func before_each() -> void:
+	_mock_storage = double(SaveStorage).new()
+	stub(_mock_storage.write).to_return(true)
+	stub(_mock_storage.read).to_return("")
+
+	_manager = load("res://scripts/items/item_manager.gd").new()
+	_manager._progression = ProgressionData.new(_mock_storage)
+	_manager._effect_manager = EffectManager.new()
+	(
+		_manager
+		. items
+		. assign(
+			[
+				preload("res://resources/items/training_ball.tres"),
+				preload("res://resources/items/court_lines.tres"),
+			]
+		)
+	)
+	add_child_autofree(_manager)
+
+	_ball = load("res://scripts/entities/ball.gd").new()
+	_ball._item_manager = _manager
+	_ball.apex_bound_y = -100.0
+	_ball.apex_gravity_scale = 1.5
+	add_child_autofree(_ball)
+	_ball.linear_velocity = Vector2(_manager.get_stat(&"ball_speed_min"), 0.0)
+
+
+func test_gravity_off_below_bound() -> void:
+	_ball.position = Vector2(0.0, 0.0)
+	_ball._physics_process(0.016)
+	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)
+
+
+func test_gravity_on_above_bound() -> void:
+	_ball.position = Vector2(0.0, -200.0)
+	_ball._physics_process(0.016)
+	assert_almost_eq(_ball.gravity_scale, _ball.apex_gravity_scale, 0.001)
+
+
+func test_gravity_off_when_frozen_even_above_bound() -> void:
+	_ball.position = Vector2(0.0, -200.0)
+	_ball.freeze = true
+	_ball._physics_process(0.016)
+	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)
+
+
+func test_gravity_toggles_on_crossing() -> void:
+	_ball.position = Vector2(0.0, -200.0)
+	_ball._physics_process(0.016)
+	assert_gt(_ball.gravity_scale, 0.0)
+	_ball.position = Vector2(0.0, 50.0)
+	_ball._physics_process(0.016)
+	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)

--- a/tests/unit/ball/test_ball_apex_return.gd
+++ b/tests/unit/ball/test_ball_apex_return.gd
@@ -1,7 +1,11 @@
 extends GutTest
 
 # Apex return: gravity engages above the friendship-bound, disengages below.
-# The per-frame speed-lock turns gravity into directional curvature, not energy gain.
+# Trajectory tests drive _physics_process across a real bound crossing to assert the
+# ball arcs back into play; the speed-lock holds magnitude steady so gravity is curvature, not energy.
+
+const TICK: float = 1.0 / 60.0
+const MAX_TICKS: int = 600
 
 var _ball: Ball
 var _manager: Node
@@ -38,27 +42,102 @@ func before_each() -> void:
 
 func test_gravity_off_below_bound() -> void:
 	_ball.position = Vector2(0.0, 0.0)
-	_ball._physics_process(0.016)
+	_ball._physics_process(TICK)
 	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)
 
 
 func test_gravity_on_above_bound() -> void:
 	_ball.position = Vector2(0.0, -200.0)
-	_ball._physics_process(0.016)
+	_ball._physics_process(TICK)
 	assert_almost_eq(_ball.gravity_scale, _ball.apex_gravity_scale, 0.001)
 
 
 func test_gravity_off_when_frozen_even_above_bound() -> void:
 	_ball.position = Vector2(0.0, -200.0)
 	_ball.freeze = true
-	_ball._physics_process(0.016)
+	_ball._physics_process(TICK)
 	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)
 
 
-func test_gravity_toggles_on_crossing() -> void:
-	_ball.position = Vector2(0.0, -200.0)
-	_ball._physics_process(0.016)
-	assert_gt(_ball.gravity_scale, 0.0)
-	_ball.position = Vector2(0.0, 50.0)
-	_ball._physics_process(0.016)
-	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)
+func test_gravity_on_at_exact_bound() -> void:
+	# Strict-less would let a ball at exactly the bound float; closed bound (<=) catches it.
+	_ball.position = Vector2(0.0, _ball.apex_bound_y)
+	_ball.linear_velocity = Vector2(_ball.speed, 0.0)
+	_ball._physics_process(TICK)
+	assert_gt(_ball.gravity_scale, 0.0, "ball at exactly the bound should be pulled back")
+
+
+func test_high_velocity_overshoot_engages_via_prediction() -> void:
+	# A fast-rising ball can skip the above-bound sample; predicted-y closes the gap.
+	# Position is below the bound, but next-step y will be above it.
+	_ball.position = Vector2(0.0, _ball.apex_bound_y + 10.0)
+	_ball.linear_velocity = Vector2(0.0, -2000.0)
+	_ball._physics_process(TICK)
+	assert_gt(_ball.gravity_scale, 0.0, "predicted overshoot should engage gravity")
+
+
+func test_uses_global_position_so_reparent_safe() -> void:
+	# global_position must drive the toggle: setting global_position above the bound while local
+	# position is below proves the gate uses world coords, not parent-relative coords.
+	_ball.global_position = Vector2(0.0, -500.0)
+	_ball._physics_process(TICK)
+	assert_gt(_ball.gravity_scale, 0.0, "global_position above bound must engage gravity")
+
+
+func test_ball_arcs_back_into_play_across_bound() -> void:
+	# AC1 integrated trajectory: launch above the bound rising, gravity must turn it and bring it back.
+	# Production order: physics integrator applies gravity + advances position, then _physics_process speed-locks.
+	_ball.position = Vector2(0.0, _ball.apex_bound_y - 50.0)
+	var initial_speed: float = _ball.speed
+	# Diagonal kick — pure-vertical is a degenerate axis-aligned case where speed-lock perfectly
+	# undoes gravity each tick. Real rallies always have horizontal velocity to break the symmetry.
+	_ball.linear_velocity = Vector2(initial_speed * 0.7, -initial_speed * 0.7)
+	var min_y_seen: float = _ball.position.y
+	var returned_below: bool = false
+	for i in MAX_TICKS:
+		# Integrator-style step: gravity + position advance happen before speed-lock.
+		_ball.linear_velocity += Vector2(0.0, _ball.gravity_scale * 980.0 * TICK)
+		_ball.position += _ball.linear_velocity * TICK
+		_ball._physics_process(TICK)
+		min_y_seen = min(min_y_seen, _ball.position.y)
+		if min_y_seen < _ball.apex_bound_y and _ball.position.y > _ball.apex_bound_y:
+			returned_below = true
+			break
+	assert_true(returned_below, "ball must rise above bound then arc back below it")
+
+
+func test_speed_locked_across_arc() -> void:
+	# AC: speed-lock holds magnitude steady; gravity curves direction without energy gain.
+	_ball.position = Vector2(0.0, _ball.apex_bound_y - 50.0)
+	var locked_speed: float = _ball.speed
+	_ball.linear_velocity = Vector2(locked_speed * 0.7, -locked_speed * 0.7)
+	var max_post_lock_speed: float = 0.0
+	for i in 120:
+		_ball.linear_velocity += Vector2(0.0, _ball.gravity_scale * 980.0 * TICK)
+		_ball.position += _ball.linear_velocity * TICK
+		_ball._physics_process(TICK)
+		# After _physics_process the speed-lock has run; magnitude must equal locked_speed.
+		max_post_lock_speed = max(max_post_lock_speed, _ball.linear_velocity.length())
+	assert_almost_eq(max_post_lock_speed, locked_speed, 0.001, "speed must stay locked across arc")
+
+
+func test_paddle_hit_above_bound_preserves_rally() -> void:
+	# AC2: a paddle strike while the ball is above the bound still registers as a normal hit
+	# (no missed signal, increase_speed runs). _on_body_entered is the single hit gate, so we exercise it.
+	var missed_count: Array[int] = [0]
+	_ball.missed.connect(func() -> void: missed_count[0] += 1)
+	_ball.position = Vector2(0.0, _ball.apex_bound_y - 50.0)
+	# Bring speed off floor so increase_speed has headroom to bump.
+	_ball.speed = _ball.min_speed
+	var pre_speed: float = _ball.speed
+
+	var paddle_script: GDScript = GDScript.new()
+	paddle_script.source_code = "extends Node\nfunc on_ball_hit() -> bool:\n\treturn true\n"
+	paddle_script.reload()
+	var paddle_node: Node = Node.new()
+	paddle_node.set_script(paddle_script)
+	add_child_autofree(paddle_node)
+
+	_ball._on_body_entered(paddle_node)
+	assert_eq(missed_count[0], 0, "paddle hit above the bound must not trigger missed")
+	assert_gt(_ball.speed, pre_speed, "paddle hit above the bound must still increase speed")

--- a/tests/unit/ball/test_ball_apex_return.gd.uid
+++ b/tests/unit/ball/test_ball_apex_return.gd.uid
@@ -1,0 +1,1 @@
+uid://bncpltkabkej6

--- a/tests/unit/court/test_ball_tracker_apex.gd
+++ b/tests/unit/court/test_ball_tracker_apex.gd
@@ -1,0 +1,47 @@
+extends GutTest
+
+# BallTracker pushes the per-Court apex tuning down to every attached ball,
+# both newly-attached and balls already tracked when set_apex is called.
+
+const BallScript: GDScript = preload("res://scripts/entities/ball.gd")
+const TrackerScript: GDScript = preload("res://scripts/court/ball_tracker.gd")
+
+var _tracker: BallTracker
+
+
+func before_each() -> void:
+	_tracker = TrackerScript.new()
+	add_child_autofree(_tracker)
+
+
+func _make_ball() -> Ball:
+	var ball: Ball = BallScript.new()
+	ball.apex_bound_y = 0.0
+	ball.apex_gravity_scale = 0.0
+	add_child_autofree(ball)
+	return ball
+
+
+func test_attach_after_set_apex_propagates_values() -> void:
+	_tracker.set_apex(-250.0, 2.0)
+	var ball: Ball = _make_ball()
+	_tracker.attach(ball)
+	assert_almost_eq(ball.apex_bound_y, -250.0, 0.001)
+	assert_almost_eq(ball.apex_gravity_scale, 2.0, 0.001)
+
+
+func test_set_apex_updates_already_tracked_balls() -> void:
+	var ball: Ball = _make_ball()
+	_tracker.attach(ball)
+	_tracker.set_apex(-400.0, 0.75)
+	assert_almost_eq(ball.apex_bound_y, -400.0, 0.001)
+	assert_almost_eq(ball.apex_gravity_scale, 0.75, 0.001)
+
+
+func test_attach_without_configure_leaves_ball_defaults() -> void:
+	var ball: Ball = _make_ball()
+	ball.apex_bound_y = 999.0
+	ball.apex_gravity_scale = 3.0
+	_tracker.attach(ball)
+	assert_almost_eq(ball.apex_bound_y, 999.0, 0.001)
+	assert_almost_eq(ball.apex_gravity_scale, 3.0, 0.001)

--- a/tests/unit/court/test_ball_tracker_apex.gd
+++ b/tests/unit/court/test_ball_tracker_apex.gd
@@ -1,7 +1,7 @@
 extends GutTest
 
 # BallTracker pushes the per-Court apex tuning down to every attached ball,
-# both newly-attached and balls already tracked when set_apex is called.
+# both newly-attached and balls already tracked when configure_apex is called.
 
 const BallScript: GDScript = preload("res://scripts/entities/ball.gd")
 const TrackerScript: GDScript = preload("res://scripts/court/ball_tracker.gd")
@@ -22,26 +22,25 @@ func _make_ball() -> Ball:
 	return ball
 
 
-func test_attach_after_set_apex_propagates_values() -> void:
-	_tracker.set_apex(-250.0, 2.0)
+func test_attach_after_configure_apex_propagates_values() -> void:
+	_tracker.configure_apex(-250.0, 2.0)
 	var ball: Ball = _make_ball()
 	_tracker.attach(ball)
 	assert_almost_eq(ball.apex_bound_y, -250.0, 0.001)
 	assert_almost_eq(ball.apex_gravity_scale, 2.0, 0.001)
 
 
-func test_set_apex_updates_already_tracked_balls() -> void:
+func test_configure_apex_updates_already_tracked_balls() -> void:
 	var ball: Ball = _make_ball()
 	_tracker.attach(ball)
-	_tracker.set_apex(-400.0, 0.75)
+	_tracker.configure_apex(-400.0, 0.75)
 	assert_almost_eq(ball.apex_bound_y, -400.0, 0.001)
 	assert_almost_eq(ball.apex_gravity_scale, 0.75, 0.001)
 
 
-func test_attach_without_configure_leaves_ball_defaults() -> void:
+func test_attach_without_configure_apex_uses_tracker_defaults() -> void:
+	# Tracker's defaults match ApexDefaults; production wires Court before attach so this is a safety-net.
 	var ball: Ball = _make_ball()
-	ball.apex_bound_y = 999.0
-	ball.apex_gravity_scale = 3.0
 	_tracker.attach(ball)
-	assert_almost_eq(ball.apex_bound_y, 999.0, 0.001)
-	assert_almost_eq(ball.apex_gravity_scale, 3.0, 0.001)
+	assert_almost_eq(ball.apex_bound_y, ApexDefaults.BOUND_Y, 0.001)
+	assert_almost_eq(ball.apex_gravity_scale, ApexDefaults.GRAVITY_SCALE, 0.001)

--- a/tests/unit/court/test_ball_tracker_apex.gd.uid
+++ b/tests/unit/court/test_ball_tracker_apex.gd.uid
@@ -1,0 +1,1 @@
+uid://dlquqno4ofper


### PR DESCRIPTION
Replaces the top-wall pong-bounce with a per-Court friendship-bound height. Balls above the bound get a configurable `gravity_scale`; balls at or below get zero. The ball's per-frame speed-lock turns the gravity acceleration into directional curvature without adding kinetic energy, so the rally arcs back into play instead of ricocheting off an invisible ceiling.

`Court` exports `apex_bound_y` and `apex_gravity_scale` and pushes them through `BallTracker` to every attached ball, so multi-ball is covered by construction. The Top Wall collider is gone from `court.tscn`.

Live runtime verification (rally continues across the arc, volley counter and paddle hits remain valid mid-arc) needs a Tier 2 pass; that hand-off goes to the runtime-verifier.