### PR TITLE
SH-367 side miss bands replace court walls

### DIFF
--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -10,6 +10,7 @@
 [ext_resource type="PackedScene" uid="uid://mws700v36gko" path="res://scenes/gear_rack.tscn" id="9_c7axm"]
 [ext_resource type="PackedScene" uid="uid://3l88siilc0hu" path="res://scenes/shipment_mat.tscn" id="10_5mv5b"]
 [ext_resource type="PackedScene" path="res://scenes/miss_zone.tscn" id="10_miss_zone"]
+[ext_resource type="Script" uid="uid://dv6u410fejjs7" path="res://scripts/entities/miss_zone.gd" id="1_miss_zone_script"]
 [ext_resource type="Script" uid="uid://cp16q4n8se0mu" path="res://scripts/court/speed_bar.gd" id="11_2768l"]
 [ext_resource type="PackedScene" uid="uid://kyv43r8jy2b" path="res://scenes/recruit_panel.tscn" id="12_rnrgf"]
 [ext_resource type="Script" uid="uid://b8611ynp8yggm" path="res://scripts/court/volley_counter.gd" id="14_vc"]
@@ -37,7 +38,7 @@ ball_tracker = NodePath("BallTracker")
 player_paddle_scene = ExtResource("9_0tnpc")
 player_spawn = NodePath("PlayerSpawn")
 autoplay_controller = NodePath("AutoplayController")
-right_wall = NodePath("Bounds/Right Wall")
+right_wall = NodePath("Bounds/RightMissBand")
 partner_spawn = NodePath("PartnerSpawn")
 timeout_controller = NodePath("TimeoutController")
 
@@ -89,17 +90,23 @@ mouse_filter = 2
 position = Vector2(10.8, 441.6)
 shape = SubResource("RectangleShape2D_horz")
 
-[node name="Right Wall" type="StaticBody2D" parent="Bounds" unique_id=1091055427]
+[node name="RightMissBand" type="Area2D" parent="Bounds" groups=["miss_zones"] unique_id=1091055427]
 position = Vector2(420, -351.6)
-physics_material_override = ExtResource("1_0wfyh")
+script = ExtResource("1_miss_zone_script")
+releases_ball = true
 metadata/_edit_group_ = true
 
-[node name="ColorRect" type="ColorRect" parent="Bounds/Right Wall" unique_id=679820908]
-offset_right = 21.6
-offset_bottom = 703.2
-mouse_filter = 2
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Bounds/RightMissBand" unique_id=2042401507]
+position = Vector2(10.8, 351.6)
+shape = SubResource("RectangleShape2D_vert")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Bounds/Right Wall" unique_id=2042401507]
+[node name="LeftMissBand" type="Area2D" parent="Bounds" groups=["miss_zones"] unique_id=1091055428]
+position = Vector2(-441.6, -351.6)
+script = ExtResource("1_miss_zone_script")
+releases_ball = true
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Bounds/LeftMissBand" unique_id=2042401508]
 position = Vector2(10.8, 351.6)
 shape = SubResource("RectangleShape2D_vert")
 

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -14,7 +14,8 @@ const MissZoneScene: PackedScene = preload("res://scenes/miss_zone.tscn")
 @export var player_paddle_scene: PackedScene
 @export var player_spawn: Marker2D
 @export var autoplay_controller: AutoplayController
-@export var right_wall: StaticBody2D
+## Right side miss band; partner miss zone re-parents here when a partner activates.
+@export var right_wall: Node2D
 @export var partner_spawn: Marker2D
 @export var timeout_controller: TimeoutController
 
@@ -165,6 +166,7 @@ func _activate_partner() -> void:
 
 	if right_wall != null:
 		_partner_miss_zone = MissZoneScene.instantiate()
+		_partner_miss_zone.releases_ball = true
 		right_wall.add_child(_partner_miss_zone)
 		ball_tracker.register_miss_zone(_partner_miss_zone)
 

--- a/scripts/entities/ball.gd
+++ b/scripts/entities/ball.gd
@@ -7,6 +7,8 @@ signal speed_changed(speed: float, min_speed: float, max_speed: float)
 signal pressed(ball: Ball)
 
 const SPEED_EMIT_THRESHOLD := 10.0
+## Side bands raise gravity so the missed ball falls out of the weightless play volume.
+const _ROLL_OUT_LINEAR_DAMP: float = 1.5
 
 ## Item key this ball represents; the system reads this on adoption to find the matching ItemDefinition.
 @export var item_key: String = ""
@@ -27,6 +29,7 @@ var _was_at_max_speed := false
 var _last_emitted_speed: float = 0.0
 var _last_emitted_min: float = 0.0
 var _last_emitted_max: float = 0.0
+var _registered_miss_zones: Array[MissZone] = []
 
 
 func _ready() -> void:
@@ -77,13 +80,20 @@ func _on_body_entered(body: Node) -> void:
 
 
 func register_miss_zone(zone: MissZone) -> void:
-	if not zone.body_entered.is_connected(_on_miss_zone_body_entered):
-		zone.body_entered.connect(_on_miss_zone_body_entered)
+	if zone == null or _registered_miss_zones.has(zone):
+		return
+	_registered_miss_zones.append(zone)
+	zone.body_entered.connect(_on_miss_zone_body_entered.bind(zone))
 
 
-func _on_miss_zone_body_entered(body: Node) -> void:
-	if body == self:
-		missed.emit()
+func _on_miss_zone_body_entered(body: Node, zone: MissZone) -> void:
+	if body != self:
+		return
+	missed.emit()
+	if zone != null and zone.releases_ball:
+		# Side-miss: leave the weightless play volume so the ball rolls onto the venue floor.
+		gravity_scale = 1.0
+		linear_damp = _ROLL_OUT_LINEAR_DAMP
 
 
 func increase_speed() -> void:

--- a/scripts/entities/miss_zone.gd
+++ b/scripts/entities/miss_zone.gd
@@ -2,3 +2,6 @@ class_name MissZone
 extends Area2D
 
 ## Area that fires body_entered on overlap; the ball hooks in via register_miss_zone().
+
+## Side bands set this true so the ball falls out of the weightless play volume on cross.
+@export var releases_ball: bool = false

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -175,6 +175,33 @@ func test_register_miss_zone_is_idempotent() -> void:
 	assert_signal_emit_count(_ball, "missed", 1)
 
 
+# --- side-miss release behaviour ---
+func test_releasing_zone_raises_gravity_on_cross() -> void:
+	var zone := MissZone.new()
+	zone.releases_ball = true
+	add_child_autofree(zone)
+	_ball.register_miss_zone(zone)
+	_ball.gravity_scale = 0.0
+
+	zone.body_entered.emit(_ball)
+
+	assert_almost_eq(_ball.gravity_scale, 1.0, 0.001)
+	assert_gt(_ball.linear_damp, 0.0)
+
+
+func test_non_releasing_zone_keeps_weightless_state() -> void:
+	var zone := MissZone.new()
+	add_child_autofree(zone)
+	_ball.register_miss_zone(zone)
+	_ball.gravity_scale = 0.0
+	_ball.linear_damp = 0.0
+
+	zone.body_entered.emit(_ball)
+
+	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)
+	assert_almost_eq(_ball.linear_damp, 0.0, 0.001)
+
+
 # --- speed offset oscillation ---
 func test_oscillation_never_drops_below_min_speed() -> void:
 	var effect := _make_oscillation_effect(2.0)


### PR DESCRIPTION
The right court wall becomes a `RightMissBand` Area2D in the `miss_zones` group, paired with a mirrored `LeftMissBand`. `MissZone` gains a `releases_ball` flag that side bands flip on; when a ball crosses a releasing band, `gravity_scale` rises to 1.0 and a small linear damp engages so the ball falls out of the weightless play volume and rolls to rest. The back-miss zone behind the player paddle stays non-releasing, so its speed-reset path is unchanged. The partner miss zone instantiated on partner activation re-parents to the new right band and inherits the release behaviour.

Live verification (rally state, partner re-parenting, roll-out feel) belongs to the runtime-verifier; static GUT coverage on the gravity-on-release path lives in `tests/unit/ball/test_ball.gd`.