### PR TITLE
docs(court): collapse per-ball-state/apex/miss into Ball states with mermaid

### DIFF
--- a/ai/skills/minions/reviewers.md
+++ b/ai/skills/minions/reviewers.md
@@ -89,6 +89,7 @@ All replies stay inline.
 - One sentence naming the concern; one short clause naming the fix.
 - Hard cap: 30 words per inline. Two lines max. Three lines is a hard block on yourself; tighten.
 - One issue per inline. If you have two findings on different lines, post two inlines.
+- Every inline anchors to a specific line in the diff. The `line` field is **required and non-null**. A comment with `line: null` becomes a file-level orphan and breaks the discipline. If a finding spans multiple lines or is structural, pick the most representative line and name the spread in the body.
 
 ## Labels
 

--- a/designs/01-prototype/design/08-court-bounds.md
+++ b/designs/01-prototype/design/08-court-bounds.md
@@ -30,7 +30,7 @@ Balls can rest anywhere on the venue floor. The shop, workshop, and kit zones ab
 
 ## Drag-out distinguished from miss
 
-A live ball pulled mid-rally back onto the rack is not a miss. The ball enters the inactive state cleanly and the rally continues with whatever balls remain. A live ball dropped outside the court without landing on the rack counts as a miss.
+A live ball pulled mid-rally back onto the rack is not a miss; the ball enters the inactive state cleanly and the rally continues with whatever balls remain. A live ball dropped outside the court without landing on the rack also drops cleanly: it goes to rest on the venue floor and the rally counter is unchanged. Only crossing a side band fires a miss.
 
 ## Temporary balls
 

--- a/designs/01-prototype/tech/08-court-control.md
+++ b/designs/01-prototype/tech/08-court-control.md
@@ -35,15 +35,15 @@ stateDiagram-v2
 
 **PLAY-ARC** (above the friendship-bound). `gravity_scale = 1`, speed-lock off, damping on. A centripetal force scaled by speed acts perpendicular to velocity, toward the play area; it rotates velocity without doing work. Friendship is still acting here; the centripetal force is its work above the bound.
 
-While in PLAY, the ball tracks its pre-bound entry value: speed at the upward cross from NORMAL to ARC. Any speed change above the bound updates this value, so a paddle hit above the bound or a partner-active arc captures the post-event speed. On the downward cross back to NORMAL, speed ramps to the tracked entry value; rally energy is preserved across the apex visit.
+While in PLAY, the ball tracks its pre-bound entry value: speed at the upward cross from NORMAL to ARC. Any speed change above the bound updates this value, so a paddle hit above the bound or a partner-active return captures the post-event speed. On the downward cross back to NORMAL, speed ramps to the tracked entry value; rally energy is preserved across the apex visit.
 
-The apex mechanism is engaged-gravity-with-centripetal-bend, not a vertical-velocity flip. A flip reads as an invisible ceiling; the engaged form reads as a held arc. The ball stays in PLAY throughout; paddle hits register and the volley counter increments in ARC the same as in NORMAL.
+The apex mechanism is engaged-gravity-with-centripetal-bend, not a vertical-velocity flip. A flip reads as an invisible ceiling; the engaged form reads as a held curve. The ball stays in PLAY throughout; paddle hits register and the volley counter increments in ARC the same as in NORMAL.
 
-**OUT-REST.** Settled on the venue floor; the ball waits to be grabbed.
+**OUT-REST.** Out of play, on the venue floor. Includes the rolling-to-rest motion after a miss as well as the settled-and-still phase that follows. The ball waits to be grabbed.
 
 **OUT-HELD.** Drag controller owns; the ball follows the cursor.
 
-**Miss (PLAY → REST).** A ball whose centre arcs past either lateral side band fires a miss: speed-lock releases, gravity engages, damping engages, the rally counter resets. The ball keeps its velocity at the moment it arcs past, falls under gravity, and rolls to rest on the venue floor. Past either side band there is no centripetal and no relock ramp. Player-side and partner-side are the same event.
+**Miss (PLAY → REST).** A ball whose centre crosses either lateral side band fires a miss: speed-lock releases, gravity engages, damping engages, the rally counter resets. The ball keeps its velocity at the moment of the crossing, falls under gravity, and rolls to rest on the venue floor. Past either side band there is no centripetal and no relock ramp. Player-side and partner-side are the same event.
 
 **Mid-rally grab (PLAY → HELD).** The drag controller replaces the live ball with a held body before any side-band miss fires.
 
@@ -65,7 +65,7 @@ The friendship-bound height lives on a `CourtConfig` Resource from day one. Per-
 
 ## Drag-handoff frame window
 
-Miss does not fire while a grab is in flight. The drag controller's deferred swap creates a window where the live ball can arc past a side band before being replaced by the held body; during that window the side-miss check skips. The check resumes once the swap completes or the gesture cancels.
+Miss does not fire while a grab is in flight. The drag controller's deferred swap creates a window where the live ball can cross a side band before being replaced by the held body; during that window the side-miss check skips. The check resumes once the swap completes or the gesture cancels.
 
 ## Rest-roll energy loss
 

--- a/designs/01-prototype/tech/08-court-control.md
+++ b/designs/01-prototype/tech/08-court-control.md
@@ -2,33 +2,52 @@
 
 Implementation spec for the wall-less court: friendship-bound replaces the top collider, lateral side bands replace the side wall colliders, the ground is unchanged. Drives SH-309. Player-facing design lives in [`../design/08-court-bounds.md`](../design/08-court-bounds.md).
 
-## Per-ball state
+## Ball states
 
-Each live ball is in one of two states. The rule applies per ball, so multi-ball mixed-state is well-defined.
+Each ball runs an independent state machine. Multi-ball mixed-state is well-defined.
 
-**At or below the friendship-bound (held state).** `gravity_scale = 0`, speed is locked, linear damping is off.
+```mermaid
+stateDiagram-v2
+    [*] --> STORED
 
-**Above the friendship-bound (arcing state).** `gravity_scale = 1`, speed-lock releases, linear damping engages. A centripetal force scaled by speed acts perpendicular to velocity, toward the play area. The centripetal force rotates velocity without doing work; magnitude follows gravity, direction bends. Friendship is still acting here; the centripetal force is its work above the bound.
+    state PLAY {
+        NORMAL --> ARC: cross above bound
+        ARC --> NORMAL: cross below bound
+    }
 
-The bound is a per-Court height.
+    state OUT {
+        REST
+        HELD
+    }
 
-## Apex return
+    STORED --> PLAY: serve
+    PLAY --> REST: miss
+    PLAY --> HELD: mid-rally grab
+    REST --> HELD: rest pickup
+    HELD --> REST: drop on floor
+    HELD --> PLAY: release into court
+    HELD --> STORED: release into rack
+```
 
-A ball that arcs above the bound moves into the arcing state. Gravity decelerates the vertical component; the centripetal force redirects.
+**STORED.** On the rack, no body.
 
-The ball tracks its pre-bound entry value: speed at the moment it arcs above the bound. Any speed change above the bound updates this value, so a paddle hit above the bound or a partner-active arc captures the post-event speed.
+**PLAY-NORMAL** (at or below the friendship-bound). `gravity_scale = 0`, speed locked, linear damping off.
 
-Returning below the bound returns the ball to the held state: `gravity_scale = 0`, speed-lock relocks, damping disengages, speed ramps back up to the tracked entry value. Rally energy is preserved across the apex visit.
+**PLAY-ARC** (above the friendship-bound). `gravity_scale = 1`, speed-lock off, damping on. A centripetal force scaled by speed acts perpendicular to velocity, toward the play area; it rotates velocity without doing work. Friendship is still acting here; the centripetal force is its work above the bound.
 
-The mechanism is engaged-gravity-with-centripetal-bend, not a vertical-velocity flip. A flip reads as an invisible ceiling; the engaged form reads as a held arc. The ball stays a live ball throughout; paddle hits register and the volley counter increments above the bound the same as below.
+While in PLAY, the ball tracks its pre-bound entry value: speed at the upward cross from NORMAL to ARC. Any speed change above the bound updates this value, so a paddle hit above the bound or a partner-active arc captures the post-event speed. On the downward cross back to NORMAL, speed ramps to the tracked entry value; rally energy is preserved across the apex visit.
 
-## Miss
+The apex mechanism is engaged-gravity-with-centripetal-bend, not a vertical-velocity flip. A flip reads as an invisible ceiling; the engaged form reads as a held arc. The ball stays in PLAY throughout; paddle hits register and the volley counter increments in ARC the same as in NORMAL.
 
-A ball whose centre arcs past either lateral side band fires a miss: the held state releases, gravity engages, speed-lock releases, damping engages, the rally counter resets. The ball keeps its velocity at the moment it arcs past, falls under gravity, and rolls to rest on the venue floor. The player drags it back to the rack via the existing live-ball drag path. Past either side band there is no centripetal and no relock ramp.
+**OUT-REST.** Settled on the venue floor; the ball waits to be grabbed.
 
-Player-side and partner-side are the same event. The partner already has its own miss zone in code; the player-side gets the same treatment when its wall is removed.
+**OUT-HELD.** Drag controller owns; the ball follows the cursor.
 
-A live ball pulled to the rack mid-rally is not a miss; the drag controller replaces the live ball with a held body before any side-band miss fires.
+**Miss (PLAY → REST).** A ball whose centre arcs past either lateral side band fires a miss: speed-lock releases, gravity engages, damping engages, the rally counter resets. The ball keeps its velocity at the moment it arcs past, falls under gravity, and rolls to rest on the venue floor. Past either side band there is no centripetal and no relock ramp. Player-side and partner-side are the same event.
+
+**Mid-rally grab (PLAY → HELD).** The drag controller replaces the live ball with a held body before any side-band miss fires.
+
+The friendship-bound height lives on `CourtConfig`; see Bound-height data shape below.
 
 ## Cross-bound collisions
 

--- a/designs/01-prototype/tech/08-court-control.md
+++ b/designs/01-prototype/tech/08-court-control.md
@@ -35,7 +35,7 @@ stateDiagram-v2
 
 **PLAY-ARC** (above the friendship-bound). `gravity_scale = 1`, speed-lock off, damping on. A centripetal force scaled by speed acts perpendicular to velocity, toward the play area; it rotates velocity without doing work. Friendship is still acting here; the centripetal force is its work above the bound.
 
-While in PLAY, the ball tracks its pre-bound entry value: speed at the upward cross from NORMAL to ARC. Any speed change above the bound updates this value, so a paddle hit above the bound or a partner-active return captures the post-event speed. On the downward cross back to NORMAL, speed ramps to the tracked entry value; rally energy is preserved across the apex visit.
+The ball tracks its pre-bound entry value as a persistent register on the body: the first NORMAL→ARC upward cross sets it; subsequent crosses do not reset it. Speed-change events while in ARC (paddle hit, partner-active return) update the register to the post-event speed. On the downward cross back to NORMAL, speed ramps to the tracked value; rally energy is preserved across the apex visit.
 
 The apex mechanism is engaged-gravity-with-centripetal-bend, not a vertical-velocity flip. A flip reads as an invisible ceiling; the engaged form reads as a held curve. The ball stays in PLAY throughout; paddle hits register and the volley counter increments in ARC the same as in NORMAL.
 
@@ -46,6 +46,10 @@ The apex mechanism is engaged-gravity-with-centripetal-bend, not a vertical-velo
 **Miss (PLAY → REST).** A ball whose centre crosses either lateral side band fires a miss: speed-lock releases, gravity engages, damping engages, the rally counter resets. The ball keeps its velocity at the moment of the crossing, falls under gravity, and rolls to rest on the venue floor. Past either side band there is no centripetal and no relock ramp. Player-side and partner-side are the same event.
 
 **Mid-rally grab (PLAY → HELD).** The drag controller replaces the live ball with a held body before any side-band miss fires.
+
+**Release into court (HELD → PLAY).** The cursor's Y at release decides the destination sub-state: above the friendship-bound lands in ARC, at or below lands in NORMAL.
+
+**Drop on floor (HELD → REST).** A held ball released outside the court without landing on the rack drops cleanly into REST. No miss event fires; the rally counter is not reset.
 
 The friendship-bound height lives on `CourtConfig`; see Bound-height data shape below.
 


### PR DESCRIPTION
Follow-up to #603. The tech doc's three sections (Per-ball state, Apex return, Miss) each describe a slice of the same state machine. Restructures them into a single Ball states section anchored on a mermaid state diagram.

States: PLAY (NORMAL, ARC), OUT (REST, HELD), STORED. Transitions: serve, bound-cross, miss, mid-rally grab, rest pickup, release-onto-floor, release-into-court, release-into-rack.

Per-state physics consolidated next to the diagram. The diagram does the structural work; prose covers the friendship-acts-above-the-bound clarification, the entry-speed tracking and relock ramp on bound re-cross, and the miss / mid-rally-grab transitions.