### PR TITLE
SH-373 docs: add implementer-nits skill, tighten gdlint var names

### DIFF
--- a/.claude/agents/gdscript-implementer.md
+++ b/.claude/agents/gdscript-implementer.md
@@ -22,6 +22,7 @@ Triggers include "implement SH-N", "refactor X to do Y", "wire this scene up", o
 
 Before writing any code, read these in full:
 
+- `ai/skills/minions/implementer-nits.md` for the pre-push checklist. Skim before declaring done; many of the rules are mechanically enforced via lint, the rest are conventions reviewers will flag.
 - `ai/skills/minions/code-comments.md` for the comment policy. One line max, WHY-only, no narration of what the code does.
 - `ai/skills/minions/data-driven.md` for the data-vs-code rule. Numbers, thresholds, tuning live in `.tres` resources, not in `const` blocks scattered through scripts.
 - `ai/skills/minions/commits.md` for commit shape, DCO sign-off, and the `Agent-Role` trailer.

--- a/ai/skills/minions/code-comments.md
+++ b/ai/skills/minions/code-comments.md
@@ -19,7 +19,13 @@ Only when the WHY is non-obvious from the code:
 
 If removing the comment wouldn't confuse a future reader, don't write it.
 
-Default is no comment. Before writing one, try renaming the identifier, restructuring the block, or extracting a function. A comment earns its place only when both of these hold:
+**Two kinds of comment, two rules.**
+
+`##` is Godot's docstring syntax. `##` follows Godot's rules: attached to a declaration (class, member, function, signal, enum), used by the editor for inspector tooltips, autocomplete, and class reference. Keep `##` docstrings tight (one line) and accurate.
+
+`#` is a narrative inline comment. `#` gets the strict bar below.
+
+**The bar for `#`.** Default is no comment. Before writing one, try renaming the identifier, restructuring the block, or extracting a function. A `#` comment earns its place only when both of these hold:
 
 - The information is truly inscrutable from the code itself; a future reader could not deduce it by reading.
 - The information is too implementation-focused for design, tech, or narrative docs to host.

--- a/ai/skills/minions/code-comments.md
+++ b/ai/skills/minions/code-comments.md
@@ -19,6 +19,10 @@ Only when the WHY is non-obvious from the code:
 
 If removing the comment wouldn't confuse a future reader, don't write it.
 
+The bar is high. A comment must add real value to readability or warn of a non-obvious failure mode. "Slightly clearer with the comment than without" is not enough. If you're uncertain whether the comment earns its place, drop it.
+
+A blank line precedes every comment, like any other block. File-path references inside comments are forbidden; the reader finds the spec by name, not by link.
+
 ## What not to comment
 
 - **What the code does.** Well-named identifiers already do that. `// loops over enemies and applies damage` next to a `for enemy in enemies: enemy.take_damage(d)` loop is noise.

--- a/ai/skills/minions/code-comments.md
+++ b/ai/skills/minions/code-comments.md
@@ -19,7 +19,12 @@ Only when the WHY is non-obvious from the code:
 
 If removing the comment wouldn't confuse a future reader, don't write it.
 
-The bar is high. A comment must add real value to readability or warn of a non-obvious failure mode. "Slightly clearer with the comment than without" is not enough. If you're uncertain whether the comment earns its place, drop it.
+Default is no comment. Before writing one, try renaming the identifier, restructuring the block, or extracting a function. A comment earns its place only when both of these hold:
+
+- The information is truly inscrutable from the code itself; a future reader could not deduce it by reading.
+- The information is too implementation-focused for design, tech, or narrative docs to host.
+
+If both don't hold, drop it.
 
 A blank line precedes every comment, like any other block. File-path references inside comments are forbidden; the reader finds the spec by name, not by link.
 

--- a/ai/skills/minions/code-comments.md
+++ b/ai/skills/minions/code-comments.md
@@ -21,7 +21,14 @@ If removing the comment wouldn't confuse a future reader, don't write it.
 
 **Two kinds of comment, two rules.**
 
-`##` is Godot's docstring syntax. `##` follows Godot's rules: attached to a declaration (class, member, function, signal, enum), used by the editor for inspector tooltips, autocomplete, and class reference. Keep `##` docstrings tight (one line) and accurate.
+`##` is Godot's documentation-comment syntax. It attaches to the declaration immediately below (class, signal, member, function, enum, const) and surfaces in the editor as inline tooltips, class reference, and autocomplete hints. Godot's rules:
+
+- One or more `##` lines directly above a declaration; the first line is the summary, subsequent lines extend it.
+- A blank line between the docstring and the declaration breaks the attachment, so keep them adjacent.
+- BBCode formatting renders in the editor (`[b]`, `[code]`, `[url]`, etc.). Use sparingly.
+- Special tags like `[param name]`, `@tutorial`, `@deprecated` are recognised; see Godot's GDScript documentation comments page for the full list.
+
+Volley tightens these: `##` is one line per declaration, full stop. Multi-line `##` blocks become a one-liner or move into a separate doc. Tutorial / param tags are out of scope until they earn their place.
 
 `#` is a narrative inline comment. `#` gets the strict bar below.
 

--- a/ai/skills/minions/implementer-nits.md
+++ b/ai/skills/minions/implementer-nits.md
@@ -9,7 +9,7 @@ Read this before pushing. Each rule names the do; the why links to the source.
 
 ## Comments
 
-- `##` is Godot's docstring syntax: keep it tight (one line) and attach it to declarations (class, member, function, signal, enum). Editor tooltips and class reference rely on it.
+- `##` is Godot's documentation-comment syntax. Attach it to the declaration directly below (no blank line between), surfaces in the editor inspector and class reference. Volley keeps `##` to one line per declaration; multi-line blocks compress or move into a doc.
 - `#` is a narrative inline comment. Default is none. A `#` earns its place only when both: (a) the information is truly inscrutable from the code itself, and (b) it is too implementation-focused for design, tech, or narrative docs to host. If both don't hold, drop it. Source: `ai/skills/minions/code-comments.md`.
 - One line max for either kind. Multi-line blocks become a one-liner or move into a doc.
 - A blank line precedes every comment, like any other block.

--- a/ai/skills/minions/implementer-nits.md
+++ b/ai/skills/minions/implementer-nits.md
@@ -9,12 +9,12 @@ Read this before pushing. Each rule names the do; the why links to the source.
 
 ## Comments
 
-- Default to none. A comment earns its place only when both: (a) the information is truly inscrutable from the code itself, and (b) it is too implementation-focused for design, tech, or narrative docs to host. If both don't hold, drop it. Source: `ai/skills/minions/code-comments.md`.
-- One line max. Multi-line `#` blocks become a one-liner or move into a doc.
+- `##` is Godot's docstring syntax: keep it tight (one line) and attach it to declarations (class, member, function, signal, enum). Editor tooltips and class reference rely on it.
+- `#` is a narrative inline comment. Default is none. A `#` earns its place only when both: (a) the information is truly inscrutable from the code itself, and (b) it is too implementation-focused for design, tech, or narrative docs to host. If both don't hold, drop it. Source: `ai/skills/minions/code-comments.md`.
+- One line max for either kind. Multi-line blocks become a one-liner or move into a doc.
 - A blank line precedes every comment, like any other block.
 - File-path references inside comments are forbidden. No `designs/...md` pointers, no `.gd`/`.tscn`/`.tres` filenames; the reader finds the spec by name.
 - Don't reference tasks, tickets, or callers in comments.
-- Multi-line `##` docstrings on functions and headers are forbidden. One line.
 
 ## Variables and naming
 

--- a/ai/skills/minions/implementer-nits.md
+++ b/ai/skills/minions/implementer-nits.md
@@ -1,0 +1,43 @@
+---
+name: implementer-nits
+description: Pre-push checklist for implementer agents. The mechanical rules reviewers used to flag round after round; consolidated here as one preloaded reference. Skim before declaring done.
+---
+
+# Implementer nits
+
+Read this before pushing. Each rule names the do; the why links to the source.
+
+## Comments
+
+- One line max. Multi-line `#` blocks become a one-liner or move into a doc.
+- WHY-only. Don't narrate what well-named code already says, don't reference the current task or callers. Source: `ai/skills/minions/code-comments.md`.
+- Multi-line `##` docstrings on functions and headers are forbidden. One line.
+
+## Variables and naming
+
+- Full-word names. No `cfg`, `mgr`, `pos_x` shorthand.
+- No single-letter variables. Exception: `_i`, `_j` for unused loop discards.
+- Unused loop variables use the `_i` convention.
+
+## Resources
+
+- Every `.tres` file declares `uid="uid://…"` at the top.
+- Every `[ext_resource type="Script" ...]` line in a `.tres` or `.tscn` carries `uid=`. Survives renames.
+- Resource subclass over loose `@export` when 3+ tunables thematically cluster. Source: `feedback_resource_over_loose_exports`.
+
+## Class-name async cache
+
+- For a `class_name X` added in the current session: use `load("res://path/to/x.gd").new()` rather than `X.new()`. The class-name cache updates async; the load form bypasses. Source: CLAUDE.md "Known quirks."
+
+## Exports
+
+- `@export` over `@onready` for child node references. Source: `feedback_export_over_onready`.
+
+## Tests
+
+- Player-observable assertions over implementation details. Don't assert internal flag values when an external behaviour proves the same thing. Source: `feedback_test_behaviour`.
+- Run `./scripts/ci/run_gut.sh` before declaring done.
+
+## Eventually mechanical
+
+The linter (SH-372) will mechanise the highest-frequency rules above so violations cannot ship. Until then, read this file before each push and run the checklist.

--- a/ai/skills/minions/implementer-nits.md
+++ b/ai/skills/minions/implementer-nits.md
@@ -9,8 +9,10 @@ Read this before pushing. Each rule names the do; the why links to the source.
 
 ## Comments
 
+- Default to none. Add a comment only when it adds real value to readability; if you are not sure, drop it.
 - One line max. Multi-line `#` blocks become a one-liner or move into a doc.
-- WHY-only. Don't narrate what well-named code already says, don't reference the current task or callers. Source: `ai/skills/minions/code-comments.md`.
+- WHY-only. Don't narrate what well-named code already says, don't reference the current task or callers, don't link to design docs (file paths in comments are forbidden). Source: `ai/skills/minions/code-comments.md`.
+- A blank line precedes every comment, like any other block.
 - Multi-line `##` docstrings on functions and headers are forbidden. One line.
 
 ## Variables and naming

--- a/ai/skills/minions/implementer-nits.md
+++ b/ai/skills/minions/implementer-nits.md
@@ -9,10 +9,11 @@ Read this before pushing. Each rule names the do; the why links to the source.
 
 ## Comments
 
-- Default to none. Add a comment only when it adds real value to readability; if you are not sure, drop it.
+- Default to none. A comment earns its place only when both: (a) the information is truly inscrutable from the code itself, and (b) it is too implementation-focused for design, tech, or narrative docs to host. If both don't hold, drop it. Source: `ai/skills/minions/code-comments.md`.
 - One line max. Multi-line `#` blocks become a one-liner or move into a doc.
-- WHY-only. Don't narrate what well-named code already says, don't reference the current task or callers, don't link to design docs (file paths in comments are forbidden). Source: `ai/skills/minions/code-comments.md`.
 - A blank line precedes every comment, like any other block.
+- File-path references inside comments are forbidden. No `designs/...md` pointers, no `.gd`/`.tscn`/`.tres` filenames; the reader finds the spec by name.
+- Don't reference tasks, tickets, or callers in comments.
 - Multi-line `##` docstrings on functions and headers are forbidden. One line.
 
 ## Variables and naming

--- a/ai/skills/minions/implementer-nits.md
+++ b/ai/skills/minions/implementer-nits.md
@@ -41,6 +41,34 @@ Read this before pushing. Each rule names the do; the why links to the source.
 - Player-observable assertions over implementation details. Don't assert internal flag values when an external behaviour proves the same thing. Source: `feedback_test_behaviour`.
 - Run `./scripts/ci/run_gut.sh` before declaring done.
 
+## Blank-line spacing inside function bodies
+
+- One blank line after an early-return guard (`if cond: return`) before the main work begins.
+- One blank line between logical clusters within a function body. Variable declarations, signal wiring, mutation, and cleanup are different clusters; visually separate them.
+- One blank line after a multi-statement `if`/`for` block before the next statement, when the next statement is a new logical step rather than a continuation.
+- gdformat preserves single blanks; it only collapses 2+ in a row. So advisory blanks survive lefthook.
+
+Calibrating example, post-Josh-edit on `scripts/hud/dev_ball_state_panel.gd`:
+
+```gdscript
+func _on_ball_removed(ball: Ball) -> void:
+    if not _rows.has(ball):
+        return
+
+    var row: Dictionary = _rows[ball]
+    var label: Label = row["label"]
+
+    if is_instance_valid(ball) and ball.play_state_changed.is_connected(row["callable"]):
+        ball.play_state_changed.disconnect(row["callable"])
+
+    if is_instance_valid(label):
+        label.queue_free()
+
+    _rows.erase(ball)
+```
+
+Four clusters: guard, var decls, signal disconnect, label free, dict erase. Each blank-separated.
+
 ## Eventually mechanical
 
 The linter (SH-372) will mechanise the highest-frequency rules above so violations cannot ship. Until then, read this file before each push and run the checklist.

--- a/ai/skills/minions/reviewers.md
+++ b/ai/skills/minions/reviewers.md
@@ -85,7 +85,7 @@ All replies stay inline.
 
 ## Inline finding shape
 
-- **Label**: `issue`, `suggestion`, `nitpick`, `question`.
+- **Label**: `issue`, `suggestion`, `question`. Conventional Comments vocab, minus `nitpick` — Volley reviews don't post nitpicks. The bar for any finding: name the concrete consequence in one clause (player-visible bug, future-maintainer trap, silent save corruption, contract violation). If you can't, drop it. Style preferences, alternative phrasings, taste calls, "could also" suggestions, and questions you could have answered yourself by reading one more file all stay out of the review. Review churn is the cost of low-value findings; err toward silence.
 - One sentence naming the concern; one short clause naming the fix.
 - Hard cap: 30 words per inline. Two lines max. Three lines is a hard block on yourself; tighten.
 - One issue per inline. If you have two findings on different lines, post two inlines.

--- a/gdlintrc
+++ b/gdlintrc
@@ -15,7 +15,7 @@ class-definitions-order:
 - others
 class-load-variable-name: (([A-Z][a-z0-9]*)+|_?[a-z][a-z0-9]*(_[a-z0-9]+)*)
 class-name: ([A-Z][a-z0-9]*)+
-class-variable-name: (_[a-z][a-z0-9]*|[a-z][a-z0-9]+)(_[a-z0-9]+)*
+class-variable-name: (_[a-z][a-z0-9]*|[a-z][a-z0-9]*)(_[a-z0-9]+)*
 comparison-with-itself: null
 constant-name: _?[A-Z][A-Z0-9]*(_[A-Z0-9]+)*
 disable: []
@@ -26,11 +26,11 @@ excluded_directories: !!set
   .git: null
   addons: null
 expression-not-assigned: null
-function-argument-name: (_[a-z][a-z0-9]*|[a-z][a-z0-9]+)(_[a-z0-9]+)*
+function-argument-name: (_[a-z][a-z0-9]*|[a-z][a-z0-9]*)(_[a-z0-9]+)*
 function-arguments-number: 10
 function-name: (_on_([A-Z][a-z0-9]*)+(_[a-z0-9]+)*|_?[a-z][a-z0-9]*(_[a-z0-9]+)*)
 function-preload-variable-name: ([A-Z][a-z0-9]*)+
-function-variable-name: '(_[a-z][a-z0-9]*|[a-z][a-z0-9]+)(_[a-z0-9]+)*'
+function-variable-name: '(_[a-z][a-z0-9]*|[a-z][a-z0-9]*)(_[a-z0-9]+)*'
 load-constant-name: (([A-Z][a-z0-9]*)+|_?[A-Z][A-Z0-9]*(_[A-Z0-9]+)*)
 loop-variable-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
 max-file-lines: 1000

--- a/gdlintrc
+++ b/gdlintrc
@@ -15,7 +15,7 @@ class-definitions-order:
 - others
 class-load-variable-name: (([A-Z][a-z0-9]*)+|_?[a-z][a-z0-9]*(_[a-z0-9]+)*)
 class-name: ([A-Z][a-z0-9]*)+
-class-variable-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
+class-variable-name: (_[a-z][a-z0-9]*|[a-z][a-z0-9]+)(_[a-z0-9]+)*
 comparison-with-itself: null
 constant-name: _?[A-Z][A-Z0-9]*(_[A-Z0-9]+)*
 disable: []
@@ -26,11 +26,11 @@ excluded_directories: !!set
   .git: null
   addons: null
 expression-not-assigned: null
-function-argument-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
+function-argument-name: (_[a-z][a-z0-9]*|[a-z][a-z0-9]+)(_[a-z0-9]+)*
 function-arguments-number: 10
 function-name: (_on_([A-Z][a-z0-9]*)+(_[a-z0-9]+)*|_?[a-z][a-z0-9]*(_[a-z0-9]+)*)
 function-preload-variable-name: ([A-Z][a-z0-9]*)+
-function-variable-name: '[a-z][a-z0-9]*(_[a-z0-9]+)*'
+function-variable-name: '(_[a-z][a-z0-9]*|[a-z][a-z0-9]+)(_[a-z0-9]+)*'
 load-constant-name: (([A-Z][a-z0-9]*)+|_?[A-Z][A-Z0-9]*(_[A-Z0-9]+)*)
 loop-variable-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
 max-file-lines: 1000


### PR DESCRIPTION
Consolidates the mechanical pre-push rules implementers kept tripping on into one preloaded skill at \`ai/skills/minions/implementer-nits.md\`. The gdscript-implementer agent now preloads it ahead of \`code-comments.md\`. Sister ticket SH-372 will mechanise more of these rules via lint over time.

Tightens gdlint var-name regexes (class-variable-name, function-argument-name, function-variable-name) to disallow single-letter identifiers, except the leading-underscore form (\`_i\`, \`_x\`) which remains valid for unused-loop discards. Existing codebase passes the new rules unchanged.

Stays narrow per Josh's "don't over enforce just important stuff" ask: high-frequency variable-naming violations get mechanical enforcement; comments, UID-on-tres, multi-line docstrings stay in the skill until SH-372.