### PR TITLE
chore: trim GUT runtime; fix test_timeout_wiring setup error

### DIFF
--- a/tests/integration/test_timeout_wiring.gd
+++ b/tests/integration/test_timeout_wiring.gd
@@ -28,6 +28,8 @@ func before_each() -> void:
 	_game = load("res://scripts/core/court.gd").new()
 	_game.autoplay_controller = autoplay_controller_stub
 	_game.timeout_controller = _timeout
+	# Pre-assign player_paddle so Court._ready skips its scene-instantiate branch.
+	_game.player_paddle = _paddle
 	add_child_autofree(_paddle)
 	add_child_autofree(_timeout)
 	add_child_autofree(_game)

--- a/tests/unit/save/test_save_manager.gd
+++ b/tests/unit/save/test_save_manager.gd
@@ -37,7 +37,8 @@ func test_save_writes_current_data_as_json() -> void:
 
 # --- autosave timer ---
 func test_autosave_timer_triggers_save() -> void:
-	await wait_seconds(0.2)
+	# Emit the timer's timeout directly; the wall-clock 0.2s wait was 176ms of fat.
+	_save_manager._autosave_timer.timeout.emit()
 	assert_called(_mock_storage, "write")
 
 


### PR DESCRIPTION
Two test-only changes.

**Fix the SCRIPT ERROR noise.** `tests/integration/test_timeout_wiring.gd`'s `before_each` was calling `add_child_autofree(_game)` without pre-assigning `_game.player_paddle`, so `Court._ready` fell into its `player_paddle_scene.instantiate()` branch on a null `PackedScene` export. Twice per CI run, "Cannot call method 'instantiate' on a null value." both tests still passed but the error spammed every log. Setting `_game.player_paddle = _paddle` before `add_child_autofree` skips that branch cleanly. No sibling tests had the same shape.

**Trim runtime.** `test_autosave_timer_triggers_save` was burning 176ms of wall-clock `wait_seconds(0.2)` to let a 50ms timer fire. The autosave timer's `timeout` signal is what the test is checking; emit it directly. Suite drops from 2.279s -> 2.161s for 586 tests (5%).

Considered but left alone: `test_held_token_during_rack_drag_settles_to_token_scale_with_hover_bump` (107ms) drives a `_process`-loop scale lerp, no tween to step; the wall-clock wait genuinely earns its place. The remaining 10-30ms tests are physics-tree setup and aren't worth the rewrite cost.