### PR TITLE
refactor: BallReconciler parents the balls it spawns

### DIFF
--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -15,27 +15,25 @@ const PRESERVED_SPEED_NONE: float = -1.0
 @export var ball_scene: PackedScene = BallScene
 
 var _item_manager: Node
-var _ball_host: Node
 var _balls_by_key: Dictionary = {}
 var _initial_reconcile_pending: bool = true
 ## Prevents court_changed from clearing _initial_reconcile_pending before _reconcile_initial_state runs.
 var _adopting_pre_existing: bool = false
 
 
-func configure(item_manager: Node, ball_host: Node) -> void:
+# Deprecated ball_host arg ignored; reconciler parents its own balls. Retired in step 6 of the lifecycle refactor.
+func configure(item_manager: Node, _ball_host: Node = null) -> void:
 	_item_manager = item_manager
-	_ball_host = ball_host
 
 
+# Compatibility shim for callers still enumerating loose bodies via the legacy host indirection. Retired in step 6.
 func get_ball_host() -> Node:
-	return _ball_host
+	return self
 
 
 func _ready() -> void:
 	if _item_manager == null:
 		_item_manager = ItemManager
-	if _ball_host == null:
-		_ball_host = get_parent()
 
 	_item_manager.court_changed.connect(_on_court_changed)
 
@@ -56,7 +54,7 @@ func _has_save_manager_autoload() -> bool:
 
 
 ## Snapshot of live ball positions keyed by item_key. Loose HeldBody children
-## of the ball host are included so dropped items reload at their resting spot.
+## are included so dropped items reload at their resting spot.
 func collect_item_positions() -> Dictionary[String, Vector2]:
 	var positions: Dictionary[String, Vector2] = {}
 	for key: String in _balls_by_key:
@@ -65,23 +63,24 @@ func collect_item_positions() -> Dictionary[String, Vector2]:
 			continue
 		var ball: Ball = raw
 		positions[key] = ball.global_position
-	if _ball_host != null:
-		for child in _ball_host.get_children():
-			if not (child is HeldBody):
-				continue
-			var body: HeldBody = child
-			if body.item_key == "" or body.phase != HeldBody.Phase.LOOSE:
-				continue
-			positions[body.item_key] = body.global_position
+	for child in get_children():
+		if not (child is HeldBody):
+			continue
+		var body: HeldBody = child
+		if body.item_key == "" or body.phase != HeldBody.Phase.LOOSE:
+			continue
+		positions[body.item_key] = body.global_position
 	return positions
 
 
-## Idempotent; safe to call repeatedly across scene reloads.
+## Idempotent; safe to call repeatedly across scene reloads. Authored Balls live as
+## siblings of the reconciler in the scene tree, so scan the parent here.
 func adopt_pre_existing_balls() -> void:
-	if _ball_host == null:
+	var parent: Node = get_parent()
+	if parent == null:
 		return
 	_adopting_pre_existing = true
-	for child in _ball_host.get_children():
+	for child in parent.get_children():
 		if not (child is Ball):
 			continue
 		var ball: Ball = child
@@ -144,7 +143,7 @@ func ensure_ball_for_key(
 		return existing
 
 	var ball: Ball = ball_scene.instantiate()
-	_ball_host.add_child(ball)
+	add_child(ball)
 	ball.global_position = spawn_position
 	ball.linear_velocity = initial_velocity
 	_apply_item_art(ball, item_key)
@@ -228,8 +227,9 @@ func _reconcile_initial_state() -> void:
 
 
 func _default_spawn_position() -> Vector2:
-	if _ball_host is Node2D:
-		return (_ball_host as Node2D).global_position
+	var parent: Node = get_parent()
+	if parent is Node2D:
+		return (parent as Node2D).global_position
 	return Vector2.ZERO
 
 

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -45,7 +45,8 @@ func before_each() -> void:
 
 	_reconciler = BallReconcilerScript.new()
 	_reconciler.configure(_manager, _host)
-	add_child_autofree(_reconciler)
+	# Mirror court.tscn topology so adopt_pre_existing_balls finds authored siblings under _host.
+	_host.add_child(_reconciler)
 
 	_drag = BallDragControllerScript.new()
 	_drag.configure(_manager, _rack, _drop_target, _reconciler)
@@ -84,7 +85,11 @@ func _build_drop_target(center: Vector2, size: Vector2) -> Area2D:
 
 
 func _permanent_balls() -> Array:
+	# Includes both reconciler-spawned and authored-adopted balls (the latter keep their original parent).
 	var result: Array = []
+	for child in _reconciler.get_children():
+		if child is Ball and not (child as Ball).is_temporary:
+			result.append(child)
 	for child in _host.get_children():
 		if child is Ball and not (child as Ball).is_temporary:
 			result.append(child)
@@ -93,6 +98,9 @@ func _permanent_balls() -> Array:
 
 func _all_balls_under_host() -> Array:
 	var result: Array = []
+	for child in _reconciler.get_children():
+		if child is Ball:
+			result.append(child)
 	for child in _host.get_children():
 		if child is Ball:
 			result.append(child)
@@ -189,12 +197,12 @@ func test_drag_ball_onto_mid_venue_position_drops_loose() -> void:
 	assert_true(released, "release inside venue always resolves")
 	assert_false(_manager.is_on_court("training_ball"), "loose release does not flip placement")
 	assert_eq(_permanent_balls().size(), 0, "no rally Ball spawns from a loose release")
-	var loose_under_host: Array = []
-	for child in _host.get_children():
+	var loose_under_reconciler: Array = []
+	for child in _reconciler.get_children():
 		if child is HeldBody:
-			loose_under_host.append(child)
-	assert_eq(loose_under_host.size(), 1, "loose body is reparented under the ball host")
-	var body: HeldBody = loose_under_host[0]
+			loose_under_reconciler.append(child)
+	assert_eq(loose_under_reconciler.size(), 1, "loose body is parented under the reconciler")
+	var body: HeldBody = loose_under_reconciler[0]
 	assert_false(body.freeze, "loose body unfreezes so gravity integrates")
 	assert_gt(body.gravity_scale, 0.0)
 
@@ -268,13 +276,13 @@ func test_release_from_far_outside_cursor_drops_loose_at_venue_edge() -> void:
 	assert_false(_manager.is_on_court("training_ball"))
 	assert_eq(_permanent_balls().size(), 0, "loose drop does not spawn a rally Ball")
 	var venue_max: Vector2 = VENUE_BOUNDS.position + VENUE_BOUNDS.size
-	var loose_under_host: Array = []
-	for child in _host.get_children():
+	var loose_under_reconciler: Array = []
+	for child in _reconciler.get_children():
 		if child is HeldBody:
-			loose_under_host.append(child)
-	assert_eq(loose_under_host.size(), 1)
+			loose_under_reconciler.append(child)
+	assert_eq(loose_under_reconciler.size(), 1)
 	assert_eq(
-		loose_under_host[0].global_position,
+		loose_under_reconciler[0].global_position,
 		venue_max,
 		"loose body lands at the venue's far corner after the cursor clamp",
 	)
@@ -309,7 +317,7 @@ func test_save_round_trip_preserves_live_ball_placement() -> void:
 
 	var reloaded_reconciler: BallReconciler = BallReconcilerScript.new()
 	reloaded_reconciler.configure(reloaded_manager, reloaded_host)
-	add_child_autofree(reloaded_reconciler)
+	reloaded_host.add_child(reloaded_reconciler)
 	await get_tree().process_frame
 
 	assert_true(
@@ -319,8 +327,8 @@ func test_save_round_trip_preserves_live_ball_placement() -> void:
 	var reloaded_ball: Ball = reloaded_reconciler.get_ball_for_key("training_ball")
 	assert_not_null(reloaded_ball, "reconciler re-spawned the ball from progression on load")
 	assert_true(
-		reloaded_ball.get_parent() == reloaded_host,
-		"the live ball is parented under the reloaded host",
+		reloaded_ball.get_parent() == reloaded_reconciler,
+		"the live ball is parented under the reconciler",
 	)
 	assert_almost_eq(
 		reloaded_manager.get_stat(&"ball_speed_min"),

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -130,7 +130,7 @@ func _setup_ball_drag() -> void:
 
 func _permanent_balls() -> Array:
 	var result: Array = []
-	for child in _host.get_children():
+	for child in _reconciler.get_children():
 		if child is Ball:
 			result.append(child)
 	return result

--- a/tests/unit/items/test_ball_drag_controller.gd
+++ b/tests/unit/items/test_ball_drag_controller.gd
@@ -68,7 +68,7 @@ func before_each() -> void:
 
 func _permanent_balls() -> Array:
 	var result: Array = []
-	for child in _host.get_children():
+	for child in _reconciler.get_children():
 		if child is Ball:
 			result.append(child)
 	return result
@@ -76,7 +76,7 @@ func _permanent_balls() -> Array:
 
 func _loose_bodies_under_host() -> Array:
 	var result: Array = []
-	for child in _host.get_children():
+	for child in _reconciler.get_children():
 		if child is HeldBody:
 			result.append(child)
 	return result

--- a/tests/unit/items/test_ball_drag_controller_sh287.gd
+++ b/tests/unit/items/test_ball_drag_controller_sh287.gd
@@ -69,7 +69,7 @@ func before_each() -> void:
 
 func _permanent_balls() -> Array:
 	var result: Array = []
-	for child in _host.get_children():
+	for child in _reconciler.get_children():
 		if child is Ball:
 			result.append(child)
 	return result

--- a/tests/unit/items/test_ball_reconciler.gd
+++ b/tests/unit/items/test_ball_reconciler.gd
@@ -28,7 +28,7 @@ func before_each() -> void:
 
 func _permanent_ball_count() -> int:
 	var count := 0
-	for child in _host.get_children():
+	for child in _reconciler.get_children():
 		if child is Ball:
 			count += 1
 	return count
@@ -268,7 +268,8 @@ func test_reconcile_spawns_saved_on_court_ball_when_authored_sibling_triggers_co
 
 	var fresh_reconciler: BallReconciler = BallReconcilerScript.new()
 	fresh_reconciler.configure(saved_manager, fresh_host)
-	add_child_autofree(fresh_reconciler)
+	# Reconciler parented under the host so adopt_pre_existing_balls sees the authored sibling.
+	fresh_host.add_child(fresh_reconciler)
 
 	# Flush both deferred calls: adopt_pre_existing_balls then _reconcile_initial_state.
 	await get_tree().process_frame
@@ -286,3 +287,17 @@ func test_ensure_ball_for_key_moves_existing_ball_without_duplicating() -> void:
 	assert_eq(second.global_position, Vector2(42, -7))
 	assert_eq(second.linear_velocity, Vector2(3, 4))
 	assert_eq(_permanent_ball_count(), 1)
+
+
+func test_reconciler_parents_new_balls_and_ignores_ball_host_arg() -> void:
+	var first: Ball = _reconciler.ensure_ball_for_key("ball_alpha", Vector2.ZERO, Vector2.ZERO)
+	assert_eq(first.get_parent(), _reconciler, "ensure_ball_for_key parents under the reconciler")
+	assert_eq(_reconciler.get_ball_host(), _reconciler, "get_ball_host is a self-shim until step 6")
+
+	# Re-configure with an unrelated host; the reconciler must still own parenting.
+	var stranger := Node2D.new()
+	add_child_autofree(stranger)
+	_reconciler.configure(_manager, stranger)
+	var second: Ball = _reconciler.ensure_ball_for_key("ball_beta", Vector2.ZERO, Vector2.ZERO)
+	assert_eq(second.get_parent(), _reconciler, "ball_host arg is ignored on subsequent configure")
+	assert_eq(stranger.get_child_count(), 0, "stranger host receives no balls")

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -76,7 +76,7 @@ func before_each() -> void:
 
 func _permanent_balls() -> Array:
 	var result: Array = []
-	for child in _host.get_children():
+	for child in _reconciler.get_children():
 		if child is Ball:
 			result.append(child)
 	return result
@@ -84,7 +84,7 @@ func _permanent_balls() -> Array:
 
 func _loose_bodies_under_host() -> Array:
 	var result: Array = []
-	for child in _host.get_children():
+	for child in _reconciler.get_children():
 		if child is HeldBody:
 			result.append(child)
 	return result

--- a/tests/unit/items/test_sh_332_regressions.gd
+++ b/tests/unit/items/test_sh_332_regressions.gd
@@ -95,7 +95,7 @@ func before_each() -> void:
 
 func _loose_bodies_under_host() -> Array:
 	var result: Array = []
-	for child in _host.get_children():
+	for child in _reconciler.get_children():
 		if child is HeldBody:
 			result.append(child)
 	return result


### PR DESCRIPTION
Step 2 of the ball-lifecycle refactor (`designs/01-prototype/tech/02-ball-lifecycle.md`). The reconciler becomes the scene-tree parent of every Ball it spawns; `_ball_host` retires from production code paths. `configure(item_manager, _ball_host)` accepts and ignores the host arg for one PR; `get_ball_host()` returns `self`. Both shims retire in step 6.

Authored Balls in `scenes/court.tscn` still adopt cleanly — `adopt_pre_existing_balls` enumerates the reconciler's parent, matching the scene topology where the authored Ball and the BallReconciler are siblings under Court.

Stacked on Ford's step 1 PR (#617); draft until that base merges.