### PR TITLE
refactor: live-ball grab keeps the same Ball across the gesture

### DIFF
--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -34,6 +34,8 @@ const NEUTRAL_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
 
 var _item_manager: Node
 var _held_body: HeldBody = null
+## Live-grab keeps the existing Ball alive across the gesture; rack/temp grabs spawn a HeldBody instead.
+var _held_ball: Ball = null
 var _held_key: String = ""
 var _held_is_temporary: bool = false
 var _held_was_on_court: bool = false
@@ -103,7 +105,8 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
-	if _held_body == null:
+	var drag_target: Node2D = _drag_target()
+	if drag_target == null:
 		_set_cursor_state(CursorStateScript.State.DEFAULT, _cursor_position())
 		return
 
@@ -112,7 +115,7 @@ func _process(delta: float) -> void:
 	var ease_progress: float = _grab_ease_progress()
 	_apply_grab_ease(ease_progress, cursor_target)
 
-	var follow_position: Vector2 = _held_body.global_position
+	var follow_position: Vector2 = drag_target.global_position
 	_track_cursor_motion(follow_position)
 	if _gesture_below_threshold:
 		if follow_position.distance_to(_press_position) >= COMMIT_MOVEMENT_THRESHOLD_PX:
@@ -143,7 +146,7 @@ func _input(event: InputEvent) -> void:
 		return
 
 	_mouse_button_down = mouse_button.pressed
-	if mouse_button.pressed or _held_body == null:
+	if mouse_button.pressed or _drag_target() == null:
 		return
 
 	# Use event position so a Camera2D in the venue doesn't break rack hit-testing.
@@ -153,7 +156,14 @@ func _input(event: InputEvent) -> void:
 
 
 func is_dragging() -> bool:
-	return _held_body != null
+	return _drag_target() != null
+
+
+## Returns the active drag-target node for cursor follow / ease / hover; HeldBody for rack+temp grabs, Ball for live grabs.
+func _drag_target() -> Node2D:
+	if _held_ball != null:
+		return _held_ball
+	return _held_body
 
 
 func get_held_key() -> String:
@@ -189,7 +199,7 @@ func get_registered_targets() -> Array[DropTarget]:
 
 ## Activation defers to release-over-court so a click-without-movement is a no-op.
 func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
-	if _held_body != null:
+	if _drag_target() != null:
 		return false
 	if _item_manager.get_level(item_key) <= 0:
 		return false
@@ -210,33 +220,54 @@ func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
 
 
 func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
-	if _held_body != null:
+	if _drag_target() != null:
 		return false
 
 	var existing: Ball = null
 	if reconciler != null:
 		existing = reconciler.get_ball_for_key(item_key)
 
-	var spawn_position: Vector2 = _cursor_position()
-	if existing != null:
-		spawn_position = existing.global_position
-		# Capture rally speed before freeing the live ball so the released ball inherits it.
-		_held_preserved_speed = existing.speed
-		if reconciler != null:
-			reconciler.release_ball(item_key)
-		# The frozen body lingers a frame before queue_free settles; exclude its RID so
-		# the projection at release does not self-overlap and snap the cursor off-court.
-		_set_court_exclude_rids([existing.get_rid()])
-		existing.freeze = true
-		existing.call_deferred("queue_free")
+	# Temporary balls bypass the reconciler; keep the legacy HeldBody spawn so the gesture
+	# does not survive into a tracked entity.
+	if is_temporary or existing == null:
+		var spawn_position: Vector2 = (
+			existing.global_position if existing != null else _cursor_position()
+		)
+		if not _spawn_held_body(item_key, spawn_position, is_temporary):
+			return false
+		_held_was_on_court = not is_temporary
+		_held_origin = &"live"
+		_mouse_button_down = true
+		pickup_started.emit(item_key)
+		return true
 
-	if not _spawn_held_body(item_key, spawn_position, is_temporary):
-		return false
-	_held_was_on_court = not is_temporary
+	# Live grab: the existing Ball IS the drag target across the whole gesture. No HeldBody spawn,
+	# no queue_free, no ball_removed; the ball stays in _balls_by_key in OUT_HELD state.
+	existing.enter_out_held()
+	# Self-overlap exclusion: the held ball's own body would otherwise reject the release projection.
+	_set_court_exclude_rids([existing.get_rid()])
+	_adopt_live_ball_as_held(existing, item_key)
+	_held_was_on_court = true
 	_held_origin = &"live"
 	_mouse_button_down = true
 	pickup_started.emit(item_key)
 	return true
+
+
+func _adopt_live_ball_as_held(ball: Ball, item_key: String) -> void:
+	var spawn_position: Vector2 = ball.global_position
+	_held_ball = ball
+	_held_key = item_key
+	_held_is_temporary = false
+	_press_position = spawn_position
+	_gesture_below_threshold = true
+	_grab_origin_position = spawn_position
+	_grab_ease_elapsed = 0.0
+	# Live grabs keep the ball's existing scale (typically Vector2.ONE; art lives on the ItemArtHolder).
+	_grab_target_scale = ball.scale
+	_expansion_started_at = -1.0
+	_cursor_samples.clear()
+	_track_cursor_motion(spawn_position)
 
 
 ## Routes a just-purchased item to whatever target accepts the release position; venue/rack/court all valid.
@@ -276,12 +307,13 @@ func _spawn_loose_body_at(
 
 ## Returns false on no valid target so the held body stays with the cursor.
 func attempt_release(release_position: Vector2) -> bool:
-	if _held_body == null:
+	if _drag_target() == null:
 		return false
 
 	var clamped_position: Vector2 = _clamp_to_venue(release_position)
 	var item_key: String = _held_key
 	var was_temporary: bool = _held_is_temporary
+	var has_live_ball: bool = _held_ball != null
 
 	# Direct callers bypass _process; re-check distance to keep the no-op gate honest.
 	var below_threshold: bool = _gesture_below_threshold
@@ -309,14 +341,23 @@ func attempt_release(release_position: Vector2) -> bool:
 		if was_temporary:
 			# Temporary balls bypass the reconciler so they don't survive the gesture.
 			pass
+		elif has_live_ball:
+			# Same Ball survives the gesture; transition OUT_HELD → PLAY in place at the release point.
+			_release_live_ball_to_court(clamped_position, velocity)
 		else:
 			target.accept(item_key, clamped_position, velocity)
 			_apply_preserved_speed_after_accept(item_key)
 	elif target is VenueDropTarget:
+		if has_live_ball:
+			_release_live_ball_to_rest(clamped_position, _compute_release_velocity())
+			_finalise_gesture(item_key, clamped_position, false)
+			return true
 		_release_loose(clamped_position, was_temporary)
 		_finalise_loose_gesture(item_key, clamped_position, false)
 		return true
 	else:
+		# Rack accept: deactivate path fires court_changed which prompts the reconciler to queue_free
+		# the live ball. The HeldBody-based rack token visual retires fully in step 7.
 		target.accept(item_key, clamped_position, Vector2.ZERO)
 
 	var over_court: bool = target is CourtDropTarget
@@ -324,6 +365,38 @@ func attempt_release(release_position: Vector2) -> bool:
 		over_court = false
 	_finalise_gesture(item_key, clamped_position, over_court)
 	return true
+
+
+# Transitions the held Ball from OUT_HELD → PLAY_NORMAL/PLAY_ARC at the release point with gesture velocity.
+func _release_live_ball_to_court(release_position: Vector2, velocity: Vector2) -> void:
+	var ball: Ball = _held_ball
+	if ball == null:
+		return
+	# Capture rally tempo before any state transition; the OUT_HELD freeze suppressed _physics_process,
+	# so ball.speed still holds the value the player was rallying at.
+	var preserved_speed: float = ball.speed
+	ball.global_position = release_position
+	# enter_play unfreezes the body and picks NORMAL/ARC based on Y; apply velocity after so the
+	# write lands on an unfrozen body and the next physics tick integrates from the gesture.
+	ball.enter_play()
+	# Re-normalise the gesture velocity onto the preserved rally tempo so the released ball matches.
+	if preserved_speed > 0.0 and velocity.length() > 0.0:
+		ball.linear_velocity = velocity.normalized() * preserved_speed
+	else:
+		ball.linear_velocity = velocity
+	ball.speed = preserved_speed
+	if ball.effect_processor != null:
+		ball.effect_processor.sync_base_speed()
+
+
+# Transitions the held Ball from OUT_HELD → OUT_REST so a floor drop rolls to rest in the venue.
+func _release_live_ball_to_rest(release_position: Vector2, velocity: Vector2) -> void:
+	var ball: Ball = _held_ball
+	if ball == null:
+		return
+	ball.global_position = release_position
+	ball.enter_out_rest()
+	ball.linear_velocity = velocity
 
 
 func _release_loose(release_position: Vector2, was_temporary: bool) -> void:
@@ -379,7 +452,7 @@ func can_court_accept_at(item_key: String, world_position: Vector2) -> bool:
 
 ## Re-grabs a loose body the player pressed; reuses the same body so the gesture stays diegetic.
 func _on_loose_body_grabbed(body: HeldBody) -> void:
-	if _held_body != null:
+	if _drag_target() != null:
 		return
 	var item_key: String = body.item_key
 
@@ -464,21 +537,22 @@ func _find_accepting_target(
 
 
 func _update_hover_feedback(world_position: Vector2) -> void:
-	if _held_body == null:
+	var drag_target: Node2D = _drag_target()
+	if drag_target == null:
 		return
 	var hovering: bool = _find_accepting_target(_held_key, world_position, 1.0) != null
 	# Use the grab's target scale so loose-body re-grabs keep their at-rest size; rack pickups still ride token_scale.
 	var base_scale: Vector2 = _grab_target_scale
 	if hovering:
-		_held_body.scale = base_scale * HOVER_SCALE_BUMP
-		_held_body.modulate = HOVER_MODULATE
+		drag_target.scale = base_scale * HOVER_SCALE_BUMP
+		drag_target.modulate = HOVER_MODULATE
 	else:
-		_held_body.scale = base_scale
-		_held_body.modulate = NEUTRAL_MODULATE
+		drag_target.scale = base_scale
+		drag_target.modulate = NEUTRAL_MODULATE
 
 
 func _update_expansion_state(world_position: Vector2) -> void:
-	if _held_body == null:
+	if _drag_target() == null:
 		return
 	if _expansion_started_at < 0.0:
 		_expansion_started_at = _now_seconds()
@@ -504,8 +578,9 @@ func _cancel_to_source() -> void:
 	var item_key: String = _held_key
 	var was_on_court: bool = _held_was_on_court
 	var origin: StringName = _held_origin
+	var drag_target: Node2D = _drag_target()
 	var release_position: Vector2 = (
-		_held_body.global_position if _held_body != null else _press_position
+		drag_target.global_position if drag_target != null else _press_position
 	)
 
 	if origin == &"live" and was_on_court:
@@ -516,6 +591,7 @@ func _cancel_to_source() -> void:
 
 
 func _finalise_gesture(item_key: String, release_position: Vector2, over_court: bool) -> void:
+	# Live-grab path: the Ball survives or was queue_freed by the reconciler via court_changed; do not free here.
 	if _held_body != null:
 		_held_body.queue_free()
 	_reset_gesture_state()
@@ -525,6 +601,7 @@ func _finalise_gesture(item_key: String, release_position: Vector2, over_court: 
 
 func _reset_gesture_state() -> void:
 	_held_body = null
+	_held_ball = null
 	_held_key = ""
 	_held_is_temporary = false
 	_held_was_on_court = false
@@ -681,15 +758,16 @@ func _grab_ease_progress() -> float:
 
 
 func _apply_grab_ease(progress: float, cursor_target: Vector2) -> void:
-	if _held_body == null:
+	var drag_target: Node2D = _drag_target()
+	if drag_target == null:
 		return
 	# Cubic ease-out: 1 - (1 - t)^3.
 	var inv: float = 1.0 - progress
 	var eased: float = 1.0 - inv * inv * inv
-	_held_body.global_position = _grab_origin_position.lerp(cursor_target, eased)
-	_held_body.scale = (grab_ease_start_scale * _grab_target_scale).lerp(_grab_target_scale, eased)
-	_held_body.modulate = grab_ease_start_modulate.lerp(grab_ease_end_modulate, eased)
-	if progress >= 1.0 and _held_body.phase == HeldBody.Phase.LIFTING:
+	drag_target.global_position = _grab_origin_position.lerp(cursor_target, eased)
+	drag_target.scale = (grab_ease_start_scale * _grab_target_scale).lerp(_grab_target_scale, eased)
+	drag_target.modulate = grab_ease_start_modulate.lerp(grab_ease_end_modulate, eased)
+	if progress >= 1.0 and _held_body != null and _held_body.phase == HeldBody.Phase.LIFTING:
 		_held_body.mark_held()
 
 
@@ -699,7 +777,7 @@ func _update_cursor_state(world_position: Vector2) -> void:
 
 
 func _derive_cursor_state(world_position: Vector2) -> int:
-	if _held_body == null:
+	if _drag_target() == null:
 		return CursorStateScript.State.DEFAULT
 	# The held body is clamped to venue but the raw cursor can drift outside.
 	if not _is_within_venue(_cursor_position()):

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -399,10 +399,12 @@ func test_real_press_on_live_ball_starts_mid_rally_grab_and_release_reinstates()
 
 	assert_true(_drag.is_dragging(), "press on a live ball flips into drag mode")
 	await get_tree().process_frame
-	assert_false(
+	# Step 3: the live Ball IS the drag target; it survives the grab in OUT_HELD until release.
+	assert_true(
 		is_instance_valid(live),
-		"the live ball is freed during the hold; held body takes over the cursor",
+		"live ball survives the mid-rally grab as the drag target",
 	)
+	assert_eq(live.play_state, Ball.PlayState.OUT_HELD)
 
 	var court_point := Vector2(50, -25)
 	var released: bool = _drag.attempt_release(court_point)
@@ -441,10 +443,12 @@ func test_pre_existing_court_ball_is_grabbable_mid_rally() -> void:
 		"pressing a pre-existing scene Ball must flip the drag controller into mid-rally grab",
 	)
 	await get_tree().process_frame
-	assert_false(
+	# Step 3: the pre-existing Ball IS the drag target; it survives the grab in OUT_HELD.
+	assert_true(
 		is_instance_valid(pre_existing),
-		"the pre-existing ball is freed during the hold; held body takes over the cursor",
+		"the pre-existing Ball survives the grab as the drag target",
 	)
+	assert_eq(pre_existing.play_state, Ball.PlayState.OUT_HELD)
 
 
 func _find_slot_for_key(item_key: String) -> Node2D:

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -320,7 +320,9 @@ func test_real_press_on_live_ball_then_drag_to_rack_returns_token() -> void:
 	assert_true(_drag.is_dragging(), "live ball press must hand off to the drag controller")
 
 	await get_tree().process_frame
-	assert_false(is_instance_valid(live), "live ball must be freed during the mid-rally grab")
+	# Step 3: the live Ball IS the drag target; it survives the grab in OUT_HELD until release.
+	assert_true(is_instance_valid(live), "live ball survives the mid-rally grab as the drag target")
+	assert_eq(live.play_state, Ball.PlayState.OUT_HELD)
 
 	# Release at the rack drop target via a real mouse-up event with the rack as cursor.
 	_drag._input(_release_event_at(RACK_CENTER))

--- a/tests/unit/items/test_ball_drag_controller.gd
+++ b/tests/unit/items/test_ball_drag_controller.gd
@@ -226,16 +226,22 @@ func test_mid_rally_grab_suspends_live_ball_and_takes_over_cursor() -> void:
 	assert_true(ok)
 	assert_true(_drag.is_dragging())
 	await get_tree().process_frame
-	assert_false(is_instance_valid(live), "live ball should be freed on mid-rally grab")
-	assert_null(
+	# Step 3: the live Ball is the drag target across the gesture; no queue_free on grab.
+	assert_true(
+		is_instance_valid(live), "live ball must survive the grab (single-entity ball model)"
+	)
+	assert_eq(live.play_state, Ball.PlayState.OUT_HELD, "grabbed ball transitions to OUT_HELD")
+	assert_eq(
 		_reconciler.get_ball_for_key("ball_alpha"),
-		"reconciler should release its tracked live ball during the hold",
+		live,
+		"reconciler keeps the same instance tracked through the gesture",
 	)
 
 
 func test_mid_rally_grab_then_release_over_court_reinstates_a_ball() -> void:
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
+	var live_before: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	_drag.grab_live_ball("ball_alpha", false)
 	await get_tree().process_frame
 
@@ -244,8 +250,14 @@ func test_mid_rally_grab_then_release_over_court_reinstates_a_ball() -> void:
 
 	assert_true(released)
 	var reinstated: Ball = _reconciler.get_ball_for_key("ball_alpha")
-	assert_not_null(reinstated, "court release should reinstate a Ball via the reconciler")
+	assert_not_null(reinstated, "court release should keep the Ball tracked by the reconciler")
+	assert_eq(reinstated, live_before, "same Ball instance survives the grab → court release")
 	assert_eq(reinstated.global_position, court_point)
+	assert_ne(
+		reinstated.play_state,
+		Ball.PlayState.OUT_HELD,
+		"court release transitions the Ball out of OUT_HELD into PLAY",
+	)
 
 
 func test_temporary_ball_release_over_court_does_not_spawn_through_reconciler() -> void:

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -172,7 +172,7 @@ func test_release_into_venue_floor_unfreezes_held_body_with_gravity_active() -> 
 	assert_false(_manager.is_on_court("ball_alpha"))
 
 
-func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_carryover() -> void:
+func test_mid_rally_grab_keeps_same_ball_in_out_held_with_velocity_carryover() -> void:
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
@@ -185,22 +185,19 @@ func test_mid_rally_grab_spawns_held_body_at_live_ball_position_with_velocity_ca
 
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
 
-	var body: HeldBody = _drag.get_held_body()
-	assert_not_null(body, "mid-rally grab spawns a HeldBody, not a plain Node2D")
-	assert_eq(
-		body.global_position,
-		Vector2(75, 30),
-		"held body spawns at the live ball's world position",
-	)
-	assert_eq(body.phase, HeldBody.Phase.LIFTING)
-	assert_true(body.freeze, "frozen-kinematic during the cursor follow")
+	# Step 3: no HeldBody spawn on a live grab; the Ball is the drag target.
+	assert_null(_drag.get_held_body(), "live grab does not spawn a HeldBody")
+	assert_eq(live.play_state, Ball.PlayState.OUT_HELD, "grabbed ball transitions to OUT_HELD")
+	assert_eq(live.global_position, Vector2(75, 30), "ball stays at its pre-grab world position")
+	assert_true(live.freeze, "OUT_HELD freezes the body so the controller drives position")
+	assert_eq(live.collision_layer, 0, "OUT_HELD suppresses collision")
 	await get_tree().process_frame
 
 	_seed_release_velocity(Vector2(75, 30), Vector2(155, 30))
 	assert_true(_drag.attempt_release(Vector2(50, 25)))
 	await get_tree().process_frame
 	var released: Ball = _reconciler.get_ball_for_key("ball_alpha")
-	assert_not_null(released, "court release spawns the rally Ball")
+	assert_eq(released, live, "same Ball instance survives the grab → court release")
 	assert_almost_eq(released.linear_velocity.length(), carry_speed, 0.5)
 
 
@@ -264,9 +261,9 @@ func test_loose_body_press_re_grabs_via_controller() -> void:
 	assert_true(body.freeze, "re-grabbed body re-freezes for cursor follow")
 
 
-func test_grab_live_ball_excludes_old_body_rid_from_court_projection() -> void:
-	# SH-332: the about-to-be-freed live Ball lingers a frame; its RID must be excluded
-	# from the court projection so the next release does not self-overlap and snap off-court.
+func test_grab_live_ball_excludes_held_ball_rid_from_court_projection() -> void:
+	# Step 3: the held Ball is the same instance across the gesture; its RID must be excluded from
+	# the court projection so the next release does not self-overlap and snap off-court.
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
@@ -283,5 +280,5 @@ func test_grab_live_ball_excludes_old_body_rid_from_court_projection() -> void:
 	assert_not_null(court_target, "controller registers a CourtDropTarget")
 	assert_true(
 		court_target._exclude_rids.has(live_rid),
-		"old live ball's RID is excluded from the court projection during the grab",
+		"the held Ball's RID is excluded from the court projection during the grab",
 	)

--- a/tests/unit/items/test_live_grab_preserves_ball_identity.gd
+++ b/tests/unit/items/test_live_grab_preserves_ball_identity.gd
@@ -1,0 +1,122 @@
+# Single-entity ball model: a live grab keeps the same Ball across grab → release.
+# Canon: designs/01-prototype/tech/02-ball-lifecycle.md.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+
+
+func _make_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _make_drop_target(position: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [ball_alpha]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_rack = _make_rack(_manager)
+	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	add_child_autofree(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	add_child_autofree(_drag)
+
+
+func test_grab_keeps_same_ball_instance_in_registry() -> void:
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	var before: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(before, "precondition: live ball exists")
+
+	assert_true(_drag.grab_live_ball("ball_alpha", false))
+
+	var during: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_eq(during, before, "registry still tracks the same instance during the grab")
+	assert_eq(during.play_state, Ball.PlayState.OUT_HELD)
+
+
+func test_court_release_keeps_same_ball_instance() -> void:
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	var before: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	_drag.grab_live_ball("ball_alpha", false)
+	await get_tree().process_frame
+
+	assert_true(_drag.attempt_release(Vector2(50, -25)))
+
+	var after: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_eq(after, before, "same Ball instance survives grab → court release")
+	assert_ne(after.play_state, Ball.PlayState.OUT_HELD, "release transitions out of OUT_HELD")
+	assert_false(after.freeze, "released ball unfreezes for physics")
+
+
+func test_ball_removed_does_not_fire_on_live_grab() -> void:
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	var removed_count: int = 0
+	_reconciler.ball_removed.connect(func(_ball: Ball) -> void: removed_count += 1)
+
+	assert_true(_drag.grab_live_ball("ball_alpha", false))
+	await get_tree().process_frame
+
+	assert_eq(
+		removed_count, 0, "live grab must not emit ball_removed; the Ball stays in the registry"
+	)
+
+
+func test_venue_drop_transitions_live_ball_to_out_rest() -> void:
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	var before: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	_drag.grab_live_ball("ball_alpha", false)
+	await get_tree().process_frame
+
+	# Inside venue bounds, outside court bounds.
+	assert_true(_drag.attempt_release(Vector2(1500, 50)))
+
+	var after: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_eq(after, before, "same Ball survives the floor drop")
+	assert_eq(after.play_state, Ball.PlayState.OUT_REST)
+	assert_false(after.freeze, "OUT_REST unfreezes so gravity integrates")

--- a/tests/unit/items/test_live_grab_preserves_ball_identity.gd.uid
+++ b/tests/unit/items/test_live_grab_preserves_ball_identity.gd.uid
@@ -1,0 +1,1 @@
+uid://b62cu51ujm3fu


### PR DESCRIPTION
Step 3 of the ball-lifecycle refactor (stacked on Trillian's step 2 branch). `BallDragController.grab_live_ball` now transitions the existing `Ball` to `OUT_HELD` and treats it as the drag target across the whole gesture, rather than queue_freeing it and spawning a `HeldBody`.

The Ball stays in `BallReconciler._balls_by_key` from grab through release; `ball_removed` does not fire on a live grab. Court release transitions OUT_HELD → PLAY in place at the cursor, preserving rally speed via the Ball's own `.speed` field. Venue-floor drop transitions OUT_HELD → OUT_REST. Rack return keeps the legacy deactivate path (which queue_frees via court_changed) until step 7 retires the rack-token seam.

Temporary balls keep the legacy `_spawn_held_body` path so they don't enter the tracked set. Rack-origin grabs and loose-body re-grabs are unchanged.

Spec: `designs/01-prototype/tech/02-ball-lifecycle.md`.

Note: live runtime verification still pending — needs `runtime-verifier` after merge to confirm the gesture feels right on the real input pipeline.