### PR TITLE
refactor: add BallReconciler.adopt_stored opt-in surface

### DIFF
--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -13,6 +13,8 @@ const BallScene: PackedScene = preload("res://scenes/ball.tscn")
 const PRESERVED_SPEED_NONE: float = -1.0
 
 @export var ball_scene: PackedScene = BallScene
+## Opt-in surface for step 7; while false, adopt_stored is a no-op so callers can be wired ahead of the flip.
+@export var stored_balls_in_registry: bool = false
 
 var _item_manager: Node
 var _balls_by_key: Dictionary = {}
@@ -151,6 +153,21 @@ func ensure_ball_for_key(
 	ball_spawned.emit(item_key, ball)
 	ball_added.emit(ball)
 	_apply_preserved_speed(ball, preserved_speed)
+	return ball
+
+
+## Spawns a STORED ball at `spawn_position` and registers it under `item_key`. Step 7 flips the opt-in flag and wires production callers.
+func adopt_stored(item_key: String, spawn_position: Vector2) -> Ball:
+	if not stored_balls_in_registry:
+		return null
+	var ball: Ball = ball_scene.instantiate()
+	add_child(ball)
+	ball.enter_stored()
+	ball.global_position = spawn_position
+	_apply_item_art(ball, item_key)
+	_balls_by_key[item_key] = ball
+	ball_spawned.emit(item_key, ball)
+	ball_added.emit(ball)
 	return ball
 
 

--- a/tests/unit/items/test_adopt_stored_membership.gd
+++ b/tests/unit/items/test_adopt_stored_membership.gd
@@ -1,0 +1,69 @@
+## Step 4 of the ball-lifecycle refactor: stored-surface opt-in.
+## Verifies BallReconciler.adopt_stored honours the stored_balls_in_registry flag.
+extends GutTest
+
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _reconciler: BallReconciler
+var _added_count: int
+var _spawned_count: int
+var _last_spawned_key: String
+var _last_spawned_ball: Ball
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [alpha]
+	_manager.items.assign(typed_items)
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	add_child_autofree(_reconciler)
+
+	_added_count = 0
+	_spawned_count = 0
+	_last_spawned_key = ""
+	_last_spawned_ball = null
+	_reconciler.ball_added.connect(_on_ball_added)
+	_reconciler.ball_spawned.connect(_on_ball_spawned)
+
+
+func _on_ball_added(_ball: Ball) -> void:
+	_added_count += 1
+
+
+func _on_ball_spawned(item_key: String, ball: Ball) -> void:
+	_spawned_count += 1
+	_last_spawned_key = item_key
+	_last_spawned_ball = ball
+
+
+func test_adopt_stored_is_inert_when_flag_off() -> void:
+	assert_false(_reconciler.stored_balls_in_registry, "precondition: opt-in flag defaults off")
+	var ball: Ball = _reconciler.adopt_stored("ball_alpha", Vector2(10, 20))
+	assert_null(ball, "adopt_stored returns null when the flag is off")
+	assert_eq(_added_count, 0, "ball_added must not fire when flag is off")
+	assert_eq(_spawned_count, 0, "ball_spawned must not fire when flag is off")
+	assert_null(_reconciler.get_ball_for_key("ball_alpha"), "no registry entry when flag is off")
+
+
+func test_adopt_stored_spawns_and_registers_when_flag_on() -> void:
+	_reconciler.stored_balls_in_registry = true
+
+	var ball: Ball = _reconciler.adopt_stored("ball_alpha", Vector2(10, 20))
+	assert_not_null(ball, "adopt_stored returns the spawned ball when flag is on")
+	assert_eq(ball.get_parent(), _reconciler, "spawned ball parented to the reconciler")
+	assert_eq(ball.play_state, Ball.PlayState.STORED, "spawned ball enters STORED state")
+	assert_eq(ball.global_position, Vector2(10, 20), "spawned ball lands at spawn_position")
+	assert_eq(
+		_reconciler.get_ball_for_key("ball_alpha"),
+		ball,
+		"reconciler tracks the ball under its item key",
+	)
+	assert_eq(_added_count, 1, "ball_added fires once")
+	assert_eq(_spawned_count, 1, "ball_spawned fires once")
+	assert_eq(_last_spawned_key, "ball_alpha", "ball_spawned carries the item key")
+	assert_eq(_last_spawned_ball, ball, "ball_spawned carries the spawned instance")

--- a/tests/unit/items/test_adopt_stored_membership.gd.uid
+++ b/tests/unit/items/test_adopt_stored_membership.gd.uid
@@ -1,0 +1,1 @@
+uid://5o8qoehx3tk6


### PR DESCRIPTION
Step 4 of the ball-lifecycle refactor (`designs/01-prototype/tech/02-ball-lifecycle.md`).

Adds an opt-in `@export var stored_balls_in_registry` flag and a new `adopt_stored(item_key, spawn_position)` method on `BallReconciler`. With the flag off (default) the method returns null and emits nothing — pure surface so step 7 can flip the flag and wire callers without re-plumbing. With the flag on, it spawns a Ball under the reconciler, calls `enter_stored()`, applies item art, registers under the key, and emits `ball_added` / `ball_spawned` consistently with the existing spawn paths.

Stacked on `refactor/live-grab-keeps-ball` (step 3). No production callers in this PR.