### PR TITLE
refactor: loose body retires for ball-role venue releases

### DIFF
--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -243,6 +243,10 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 
 	# Live grab: the existing Ball IS the drag target across the whole gesture. No HeldBody spawn,
 	# no queue_free, no ball_removed; the ball stays in _balls_by_key in OUT_HELD state.
+	# OUT_REST pickup also routes through here; clear the loose-in-venue overlay so a release-over-rack
+	# (or any non-venue target) restores the slot exactly like a live-grab originating from the court.
+	if _item_manager != null:
+		_item_manager.clear_loose_in_venue(item_key)
 	existing.enter_out_held()
 	# Self-overlap exclusion: the held ball's own body would otherwise reject the release projection.
 	_set_court_exclude_rids([existing.get_rid()])
@@ -281,15 +285,55 @@ func spawn_purchased_at(
 		target.accept(item_key, world_position, gesture_velocity)
 		return true
 	if target is VenueDropTarget:
-		# Venue accepts as a loose-body release; spawn a HeldBody and let it fall.
-		_spawn_loose_body_at(item_key, world_position, gesture_velocity)
+		# Ball-role venue releases lift the entity into the registry as OUT_REST; equipment keeps the
+		# legacy HeldBody loose path until step 7 unifies it.
+		if _is_ball_role(item_key):
+			_release_to_rest(item_key, world_position, gesture_velocity, false)
+		else:
+			_release_loose_body_at(item_key, world_position, gesture_velocity)
 		return true
 	# Rack/shop targets accept by activating; the ball reconciler handles the live spawn.
 	target.accept(item_key, world_position, gesture_velocity)
 	return true
 
 
-func _spawn_loose_body_at(
+## Step 5: ball-role venue-floor releases funnel here. Equipment retains the HeldBody path until step 7.
+## Reconciler creates or transitions the Ball into OUT_REST; the rack hides via on-court (live grab)
+## or loose-in-venue (rack origin), so the player never sees both a slot and a venue body.
+func _release_to_rest(
+	item_key: String, world_position: Vector2, gesture_velocity: Vector2, was_live: bool
+) -> void:
+	if reconciler == null:
+		return
+	reconciler.release_into_rest(item_key, world_position, gesture_velocity)
+	# Rack-origin paths arrive with the item not on-court; flip the overlay so the rack filter hides
+	# the slot. Live grabs keep their on-court flag — touching it would tear the Ball down via the
+	# reconciler's court_changed handler.
+	if not was_live and _item_manager != null:
+		_item_manager.mark_loose_in_venue(item_key)
+
+
+## Equipment attempt_release: rehome the in-flight HeldBody as loose at the release point.
+func _release_held_body_as_loose(release_position: Vector2) -> void:
+	if _held_body == null:
+		return
+	var release_velocity: Vector2 = _compute_release_velocity()
+	var body: HeldBody = _held_body
+	var host: Node = get_loose_body_host()
+	if host != null and body.get_parent() != host:
+		body.get_parent().remove_child(body)
+		host.add_child(body)
+	body.global_position = release_position
+	body.modulate = grab_ease_end_modulate
+	body.go_loose(release_velocity)
+	register_loose_body(body)
+	# Drop the handle so finalisation does not free the loose body.
+	_held_body = null
+
+
+## Equipment still rides the HeldBody path; step 7 unifies the surfaces. Spawns a loose body at the
+## release point, wires re-grab + loose-in-venue overlay through register_loose_body.
+func _release_loose_body_at(
 	item_key: String, world_position: Vector2, gesture_velocity: Vector2
 ) -> void:
 	var definition: ItemDefinition = _get_item_definition(item_key)
@@ -303,6 +347,13 @@ func _spawn_loose_body_at(
 	host.add_child(body)
 	body.go_loose(gesture_velocity)
 	register_loose_body(body)
+
+
+func _is_ball_role(item_key: String) -> bool:
+	var definition: ItemDefinition = _get_item_definition(item_key)
+	if definition == null:
+		return false
+	return definition.role == &"ball"
 
 
 ## Returns false on no valid target so the held body stays with the cursor.
@@ -348,12 +399,15 @@ func attempt_release(release_position: Vector2) -> bool:
 			target.accept(item_key, clamped_position, velocity)
 			_apply_preserved_speed_after_accept(item_key)
 	elif target is VenueDropTarget:
-		if has_live_ball:
-			_release_live_ball_to_rest(clamped_position, _compute_release_velocity())
-			_finalise_gesture(item_key, clamped_position, false)
-			return true
-		_release_loose(clamped_position, was_temporary)
-		_finalise_loose_gesture(item_key, clamped_position, false)
+		if was_temporary:
+			# Temporary balls never join the registry; fall through to finalise (which frees the HeldBody).
+			pass
+		elif _is_ball_role(item_key):
+			_release_to_rest(item_key, clamped_position, _compute_release_velocity(), has_live_ball)
+		else:
+			# Equipment keeps the HeldBody loose path; rehome the existing held body rather than spawning a new one.
+			_release_held_body_as_loose(clamped_position)
+		_finalise_gesture(item_key, clamped_position, false)
 		return true
 	else:
 		# Rack accept: deactivate path fires court_changed which prompts the reconciler to queue_free
@@ -389,34 +443,10 @@ func _release_live_ball_to_court(release_position: Vector2, velocity: Vector2) -
 		ball.effect_processor.sync_base_speed()
 
 
-# Transitions the held Ball from OUT_HELD → OUT_REST so a floor drop rolls to rest in the venue.
-func _release_live_ball_to_rest(release_position: Vector2, velocity: Vector2) -> void:
-	var ball: Ball = _held_ball
-	if ball == null:
-		return
-	ball.global_position = release_position
-	ball.enter_out_rest()
-	ball.linear_velocity = velocity
-
-
-func _release_loose(release_position: Vector2, was_temporary: bool) -> void:
-	if _held_body == null or was_temporary:
-		return
-	var release_velocity: Vector2 = _compute_release_velocity()
-	var body: HeldBody = _held_body
-	var host: Node = get_loose_body_host()
-	if host != null and body.get_parent() != host:
-		body.get_parent().remove_child(body)
-		host.add_child(body)
-	body.global_position = release_position
-	body.modulate = grab_ease_end_modulate
-	body.go_loose(release_velocity)
-	register_loose_body(body)
-	# Drop the handle so finalisation does not free the loose body.
-	_held_body = null
-
-
-## Public seam so subsystems that spawn their own loose bodies (Shop) can wire re-grab through this controller.
+## Step 5 seam: venue-floor releases no longer spawn loose HeldBodies, but Shop's `_drop_falling_body`
+## still does (retires at step 7). The five helpers below — track_loose_body, register_loose_body,
+## get_loose_body_host, _on_loose_body_grabbed, _adopt_loose_body_as_held, _on_loose_body_freed — keep
+## that path alive. Removing them would crash purchased-item drops.
 func track_loose_body(body: HeldBody) -> void:
 	if not body.grabbed.is_connected(_on_loose_body_grabbed):
 		body.grabbed.connect(_on_loose_body_grabbed)
@@ -494,12 +524,6 @@ func _adopt_loose_body_as_held(body: HeldBody) -> void:
 	if body.get_parent() != self:
 		body.get_parent().remove_child(body)
 		add_child(body)
-
-
-func _finalise_loose_gesture(item_key: String, release_position: Vector2, over_court: bool) -> void:
-	_reset_gesture_state()
-	_set_cursor_state(CursorStateScript.State.DEFAULT, release_position)
-	drop_completed.emit(item_key, release_position, over_court)
 
 
 func _loose_body_host() -> Node:

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -53,8 +53,8 @@ func _has_save_manager_autoload() -> bool:
 	return get_tree() != null and get_tree().root.has_node("SaveManager")
 
 
-## Snapshot of live ball positions keyed by item_key. Loose HeldBody children
-## are included so dropped items reload at their resting spot.
+## Snapshot of live ball positions keyed by item_key. Every loose / at-rest / in-play
+## ball lives in the registry post-step-5, so the registry walk is the whole story.
 func collect_item_positions() -> Dictionary[String, Vector2]:
 	var positions: Dictionary[String, Vector2] = {}
 	for key: String in _balls_by_key:
@@ -63,13 +63,6 @@ func collect_item_positions() -> Dictionary[String, Vector2]:
 			continue
 		var ball: Ball = raw
 		positions[key] = ball.global_position
-	for child in get_children():
-		if not (child is HeldBody):
-			continue
-		var body: HeldBody = child
-		if body.item_key == "" or body.phase != HeldBody.Phase.LOOSE:
-			continue
-		positions[body.item_key] = body.global_position
 	return positions
 
 
@@ -151,6 +144,24 @@ func ensure_ball_for_key(
 	ball_spawned.emit(item_key, ball)
 	ball_added.emit(ball)
 	_apply_preserved_speed(ball, preserved_speed)
+	return ball
+
+
+## Step 5: venue-floor release path. Ensures a registry Ball at `position`, in OUT_REST,
+## carrying `velocity`. Does not touch ItemManager state; callers flip loose-in-venue / on-court
+## overlays as appropriate so the rack filters render the right slots.
+func release_into_rest(item_key: String, position: Vector2, velocity: Vector2) -> Ball:
+	var ball: Ball = get_ball_for_key(item_key)
+	if ball == null:
+		ball = ball_scene.instantiate()
+		add_child(ball)
+		_apply_item_art(ball, item_key)
+		_balls_by_key[item_key] = ball
+		ball_spawned.emit(item_key, ball)
+		ball_added.emit(ball)
+	ball.global_position = position
+	ball.enter_out_rest()
+	ball.linear_velocity = velocity
 	return ball
 
 

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -195,16 +195,18 @@ func test_drag_ball_onto_mid_venue_position_drops_loose() -> void:
 	var released: bool = _drag.attempt_release(in_venue_outside_court)
 
 	assert_true(released, "release inside venue always resolves")
-	assert_false(_manager.is_on_court("training_ball"), "loose release does not flip placement")
-	assert_eq(_permanent_balls().size(), 0, "no rally Ball spawns from a loose release")
-	var loose_under_reconciler: Array = []
-	for child in _reconciler.get_children():
-		if child is HeldBody:
-			loose_under_reconciler.append(child)
-	assert_eq(loose_under_reconciler.size(), 1, "loose body is parented under the reconciler")
-	var body: HeldBody = loose_under_reconciler[0]
-	assert_false(body.freeze, "loose body unfreezes so gravity integrates")
-	assert_gt(body.gravity_scale, 0.0)
+	# Step 5: the at-rest ball lives as a Ball in OUT_REST in the registry, not a HeldBody.
+	assert_false(
+		_manager.is_on_court("training_ball"), "rack-origin venue release does not flip on-court"
+	)
+	assert_true(
+		_manager.is_loose_in_venue("training_ball"), "rack filter relies on loose-in-venue overlay"
+	)
+	var ball: Ball = _reconciler.get_ball_for_key("training_ball")
+	assert_not_null(ball, "venue release registers the Ball with the reconciler")
+	assert_eq(ball.play_state, Ball.PlayState.OUT_REST)
+	assert_false(ball.freeze, "OUT_REST unfreezes so gravity integrates")
+	assert_gt(ball.gravity_scale, 0.0, "OUT_REST has gravity engaged")
 
 
 # --- Scenario 4: temporary balls live outside the reconciler's set ---------
@@ -274,17 +276,15 @@ func test_release_from_far_outside_cursor_drops_loose_at_venue_edge() -> void:
 
 	assert_true(released, "release always resolves, even from a far-outside cursor")
 	assert_false(_manager.is_on_court("training_ball"))
-	assert_eq(_permanent_balls().size(), 0, "loose drop does not spawn a rally Ball")
+	# Step 5: the cursor-clamped venue release lands the OUT_REST Ball at the venue corner.
 	var venue_max: Vector2 = VENUE_BOUNDS.position + VENUE_BOUNDS.size
-	var loose_under_reconciler: Array = []
-	for child in _reconciler.get_children():
-		if child is HeldBody:
-			loose_under_reconciler.append(child)
-	assert_eq(loose_under_reconciler.size(), 1)
+	var ball: Ball = _reconciler.get_ball_for_key("training_ball")
+	assert_not_null(ball, "venue release puts the Ball into the registry")
+	assert_eq(ball.play_state, Ball.PlayState.OUT_REST)
 	assert_eq(
-		loose_under_reconciler[0].global_position,
+		ball.global_position,
 		venue_max,
-		"loose body lands at the venue's far corner after the cursor clamp",
+		"Ball lands at the venue's far corner after the cursor clamp"
 	)
 
 

--- a/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd
+++ b/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd
@@ -1,0 +1,135 @@
+## Step 5: a Ball misses, rolls to OUT_REST, gets regrabbed, and returns to play —
+## one instance, one identity, registry-tracked across every transition.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemManagerScript: GDScript = preload("res://scripts/items/item_manager.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+const COURT_BOUNDS: Rect2 = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+const VENUE_BOUNDS: Rect2 = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+
+var _manager: Node
+var _host: Node2D
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+var _storage: SaveStorage
+
+
+func before_each() -> void:
+	_storage = double(SaveStorage).new()
+	stub(_storage.write).to_return(true)
+	stub(_storage.read).to_return("")
+
+	_manager = ItemManagerScript.new()
+	_manager._progression = ProgressionData.new(_storage)
+	_manager._effect_manager = EffectManager.new()
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [ball_alpha]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+	add_child_autofree(_manager)
+
+	_host = Node2D.new()
+	_host.name = "BallHost"
+	add_child_autofree(_host)
+
+	_rack = _build_rack(_manager)
+	_drop_target = _build_drop_target(Vector2(-1500, 0), Vector2(300, 200))
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager, _host)
+	_host.add_child(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = COURT_BOUNDS
+	_drag.venue_bounds = VENUE_BOUNDS
+	add_child_autofree(_drag)
+
+
+func _build_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _build_drop_target(center: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = center
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func _seed_release_velocity(start: Vector2, end: Vector2) -> void:
+	_drag._cursor_samples.clear()
+	_drag._cursor_samples.append({"time": 0.0, "position": start})
+	_drag._cursor_samples.append({"time": 0.04, "position": end})
+
+
+# Three transitions on one Ball: PLAY -> OUT_REST (miss/release) -> OUT_HELD (grab) -> PLAY (release over court).
+# Single instance throughout; reconciler always tracks the same node.
+func test_miss_to_rest_to_regrab_preserves_identity() -> void:
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(live, "precondition: an in-play Ball exists")
+	var live_id: int = live.get_instance_id()
+
+	# 1. Player drags the live ball to the venue floor (OUT_REST).
+	assert_true(_drag.grab_live_ball("ball_alpha", false))
+	await get_tree().process_frame
+	_drag._gesture_below_threshold = false
+	_seed_release_velocity(Vector2.ZERO, Vector2(10, 0))
+	var venue_floor := Vector2(1500, 100)
+	assert_true(_drag.attempt_release(venue_floor))
+	await get_tree().process_frame
+
+	var at_rest: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_eq(
+		at_rest.get_instance_id(), live_id, "registry still tracks the same Ball after OUT_REST"
+	)
+	assert_eq(at_rest.play_state, Ball.PlayState.OUT_REST)
+	assert_eq(at_rest.global_position, venue_floor)
+
+	# 2. Player picks the at-rest ball back up via grab_live_ball (the OUT_REST grab path).
+	assert_true(_drag.grab_live_ball("ball_alpha", false))
+	await get_tree().process_frame
+	var held: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_eq(
+		held.get_instance_id(), live_id, "registry still tracks the same Ball during OUT_HELD"
+	)
+	assert_eq(held.play_state, Ball.PlayState.OUT_HELD)
+
+	# 3. Player releases over the court; the same Ball returns to PLAY.
+	_drag._gesture_below_threshold = false
+	_seed_release_velocity(Vector2(1500, 100), Vector2(1580, 100))
+	var court_point := Vector2(50, 25)
+	assert_true(_drag.attempt_release(court_point))
+	await get_tree().process_frame
+
+	var played: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(played, "Ball survives the venue → court round trip")
+	assert_eq(played.get_instance_id(), live_id, "every transition kept the same Ball instance")
+	assert_ne(played.play_state, Ball.PlayState.OUT_HELD)
+	assert_ne(played.play_state, Ball.PlayState.OUT_REST)

--- a/tests/unit/items/test_ball_drag_controller.gd
+++ b/tests/unit/items/test_ball_drag_controller.gd
@@ -185,16 +185,18 @@ func test_release_far_outside_court_falls_loose_inside_venue() -> void:
 	var released: bool = _drag.attempt_release(off_world)
 
 	assert_true(released, "venue-clamped release resolves as a loose drop")
-	assert_null(
-		_reconciler.get_ball_for_key("ball_alpha"),
-		"loose release does not bring the item into play",
+	# Step 5: venue-floor release routes through reconciler; the Ball lives in OUT_REST in the registry.
+	assert_false(
+		_manager.is_on_court("ball_alpha"), "rack-origin venue release does not flip on-court"
 	)
-	assert_false(_manager.is_on_court("ball_alpha"), "loose release does not flip placement state")
-	var loose_bodies: Array = _loose_bodies_under_host()
-	assert_eq(loose_bodies.size(), 1, "exactly one loose body lands in the venue")
-	var body: HeldBody = loose_bodies[0]
-	assert_false(body.freeze, "loose body unfreezes so gravity integrates")
-	assert_gt(body.gravity_scale, 0.0, "loose body has gravity active")
+	assert_true(
+		_manager.is_loose_in_venue("ball_alpha"),
+		"rack-origin venue release marks loose-in-venue so the rack filter hides the slot",
+	)
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "venue release puts the Ball into the registry")
+	assert_eq(ball.play_state, Ball.PlayState.OUT_REST, "venue Ball is OUT_REST")
+	assert_eq(_loose_bodies_under_host().size(), 0, "no HeldBody loose body left behind")
 
 
 func test_release_over_rack_returns_a_court_ball_to_the_rack() -> void:
@@ -293,14 +295,14 @@ func test_release_inside_venue_outside_court_drops_loose() -> void:
 	var released: bool = _drag.attempt_release(in_venue_out_of_court)
 	assert_true(released, "release inside venue always resolves, never a no-op")
 
-	assert_null(
-		_reconciler.get_ball_for_key("ball_alpha"),
-		"loose release does not bring the item into play",
-	)
+	# Step 5: rack-origin venue release produces an OUT_REST Ball in the registry, not a HeldBody.
 	assert_false(_manager.is_on_court("ball_alpha"))
-	var loose_bodies: Array = _loose_bodies_under_host()
-	assert_eq(loose_bodies.size(), 1, "loose body lands at the release position")
-	assert_eq(loose_bodies[0].global_position, in_venue_out_of_court)
+	assert_true(_manager.is_loose_in_venue("ball_alpha"))
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "Ball lives in the registry at the release point")
+	assert_eq(ball.play_state, Ball.PlayState.OUT_REST)
+	assert_eq(ball.global_position, in_venue_out_of_court)
+	assert_eq(_loose_bodies_under_host().size(), 0, "no HeldBody loose body left behind")
 
 
 func test_mouse_button_release_event_triggers_release() -> void:

--- a/tests/unit/items/test_ball_reconciler_release_into_rest.gd
+++ b/tests/unit/items/test_ball_reconciler_release_into_rest.gd
@@ -1,0 +1,60 @@
+## Step 5: BallReconciler.release_into_rest is the registry seam venue-floor releases use.
+extends GutTest
+
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _host: Node2D
+var _reconciler: BallReconciler
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [ball_alpha]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_host = Node2D.new()
+	add_child_autofree(_host)
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager, _host)
+	add_child_autofree(_reconciler)
+
+
+func _permanent_ball_count() -> int:
+	var count := 0
+	for child in _reconciler.get_children():
+		if child is Ball:
+			count += 1
+	return count
+
+
+func test_release_into_rest_creates_a_registry_ball_in_out_rest() -> void:
+	_manager.take("ball_alpha")
+	var position := Vector2(800, 600)
+	var velocity := Vector2(15, 0)
+
+	var ball: Ball = _reconciler.release_into_rest("ball_alpha", position, velocity)
+
+	assert_not_null(ball, "release_into_rest returns the registry Ball")
+	assert_eq(ball.play_state, Ball.PlayState.OUT_REST)
+	assert_eq(ball.global_position, position)
+	assert_eq(ball.linear_velocity, velocity)
+	assert_eq(_reconciler.get_ball_for_key("ball_alpha"), ball, "registry tracks the at-rest ball")
+	assert_eq(_permanent_ball_count(), 1, "single registry entry post-release")
+
+
+func test_release_into_rest_reuses_existing_ball_for_key() -> void:
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	var live_id: int = live.get_instance_id()
+
+	var rested: Ball = _reconciler.release_into_rest("ball_alpha", Vector2(800, 600), Vector2.ZERO)
+
+	assert_eq(rested.get_instance_id(), live_id, "release_into_rest preserves identity")
+	assert_eq(rested.play_state, Ball.PlayState.OUT_REST)
+	assert_eq(_permanent_ball_count(), 1, "no duplicate spawn on already-tracked key")

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -153,7 +153,8 @@ func test_release_over_court_frees_held_body_and_spawns_active_movement_ball() -
 	assert_eq(ball.gravity_scale, 0.0, "active-movement has gravity off (frictionless rally)")
 
 
-func test_release_into_venue_floor_unfreezes_held_body_with_gravity_active() -> void:
+func test_release_into_venue_floor_lands_ball_in_out_rest() -> void:
+	# Step 5: rack-origin venue release transitions to an OUT_REST Ball, not a loose HeldBody.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
@@ -162,14 +163,14 @@ func test_release_into_venue_floor_unfreezes_held_body_with_gravity_active() -> 
 
 	var loose_position := Vector2(1500, 100)
 	assert_true(_drag.attempt_release(loose_position))
-	var loose_bodies: Array = _loose_bodies_under_host()
-	assert_eq(loose_bodies.size(), 1)
-	var body: HeldBody = loose_bodies[0]
-	assert_eq(body.phase, HeldBody.Phase.LOOSE)
-	assert_false(body.freeze)
-	assert_gt(body.gravity_scale, 0.0)
-	assert_null(_reconciler.get_ball_for_key("ball_alpha"), "loose drop bypasses the reconciler")
+	assert_eq(_loose_bodies_under_host().size(), 0, "no HeldBody loose body lingers post-release")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "Ball lives in the registry at the release position")
+	assert_eq(ball.play_state, Ball.PlayState.OUT_REST)
+	assert_false(ball.freeze)
+	assert_gt(ball.gravity_scale, 0.0)
 	assert_false(_manager.is_on_court("ball_alpha"))
+	assert_true(_manager.is_loose_in_venue("ball_alpha"))
 
 
 func test_mid_rally_grab_keeps_same_ball_in_out_held_with_velocity_carryover() -> void:
@@ -201,64 +202,47 @@ func test_mid_rally_grab_keeps_same_ball_in_out_held_with_velocity_carryover() -
 	assert_almost_eq(released.linear_velocity.length(), carry_speed, 0.5)
 
 
-func test_loose_body_transfers_visual_scale_onto_art_holder_after_release() -> void:
+func test_out_rest_ball_has_grab_area_enabled() -> void:
+	# Step 5: the OUT_REST Ball's grab area routes pickups through the live-grab path.
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	for ball in _permanent_balls():
 		ball.queue_free()
 	await get_tree().process_frame
-	# Settle the lift so body.scale equals token_scale before the release.
-	_drag._grab_ease_elapsed = _drag.grab_ease_duration_s
-	_drag._apply_grab_ease(1.0, Vector2(1500, 100))
-	var held: HeldBody = _drag.get_held_body()
-	var pre_loose_scale: Vector2 = held.scale
+	assert_true(_drag.attempt_release(Vector2(1500, 100)), "venue release succeeds")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "venue release puts a Ball into the registry")
+	assert_eq(ball.play_state, Ball.PlayState.OUT_REST)
+	assert_not_null(ball.grab_area, "Ball ships with a grab area for re-grab")
 
+
+func test_out_rest_ball_press_re_grabs_through_live_grab_path() -> void:
+	# Step 5: pressing an OUT_REST Ball routes through grab_live_ball, preserving identity.
+	_manager.take("ball_alpha")
+	_drag.grab_from_rack("ball_alpha")
+	for ball in _permanent_balls():
+		ball.queue_free()
+	await get_tree().process_frame
 	assert_true(_drag.attempt_release(Vector2(1500, 100)))
-	var bodies: Array = _loose_bodies_under_host()
-	assert_eq(bodies.size(), 1)
-	var body: HeldBody = bodies[0]
-	assert_eq(body.scale, Vector2.ONE, "loose body sheds its lift-time scale onto the ArtHolder")
-	var art_holder: Node2D = body.get_node("ArtHolder") as Node2D
-	assert_not_null(art_holder, "loose body keeps an ArtHolder for the visual")
+	var resting: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(resting)
+	assert_eq(resting.play_state, Ball.PlayState.OUT_REST)
+
+	# Synthesise the grab signal the ball's grab area would emit.
+	resting.grabbed.emit(resting)
+	await get_tree().process_frame
+
 	assert_eq(
-		art_holder.scale,
-		pre_loose_scale,
-		"ArtHolder receives the body's pre-loose scale so the visual does not pop",
+		_reconciler.get_ball_for_key("ball_alpha"),
+		resting,
+		"OUT_REST re-grab keeps the same Ball instance — live-grab path",
 	)
-
-
-func test_loose_body_has_grab_area_enabled_when_loose() -> void:
-	# SH-332: a loose body's GrabArea is the entry point for re-grab.
-	_manager.take("ball_alpha")
-	_drag.grab_from_rack("ball_alpha")
-	for ball in _permanent_balls():
-		ball.queue_free()
-	await get_tree().process_frame
-	assert_true(_drag.attempt_release(Vector2(1500, 100)), "loose drop succeeds")
-	var bodies: Array = _loose_bodies_under_host()
-	assert_eq(bodies.size(), 1)
-	var body: HeldBody = bodies[0]
-	assert_not_null(body.grab_area, "loose body has a grab area for re-grab")
-	assert_true(body.grab_area.input_pickable, "grab area is enabled when LOOSE")
-
-
-func test_loose_body_press_re_grabs_via_controller() -> void:
-	# SH-332: pressing a loose body adopts it as the held body so the player can re-grab.
-	_manager.take("ball_alpha")
-	_drag.grab_from_rack("ball_alpha")
-	for ball in _permanent_balls():
-		ball.queue_free()
-	await get_tree().process_frame
-	assert_true(_drag.attempt_release(Vector2(1500, 100)))
-	var bodies: Array = _loose_bodies_under_host()
-	var body: HeldBody = bodies[0]
-	assert_null(_drag.get_held_body(), "controller has no held body after the loose release")
-
-	body.grabbed.emit(body)
-
-	assert_eq(_drag.get_held_body(), body, "loose press re-grabs the same body")
-	assert_eq(body.phase, HeldBody.Phase.LIFTING, "re-grabbed body returns to LIFTING")
-	assert_true(body.freeze, "re-grabbed body re-freezes for cursor follow")
+	assert_eq(resting.play_state, Ball.PlayState.OUT_HELD, "re-grab transitions to OUT_HELD")
+	assert_true(resting.freeze, "OUT_HELD freezes the body for controller follow")
+	assert_false(
+		_manager.is_loose_in_venue("ball_alpha"),
+		"grab clears the loose-in-venue overlay so a later non-venue release restores the rack slot",
+	)
 
 
 func test_grab_live_ball_excludes_held_ball_rid_from_court_projection() -> void:

--- a/tests/unit/items/test_sh_332_regressions.gd
+++ b/tests/unit/items/test_sh_332_regressions.gd
@@ -101,6 +101,14 @@ func _loose_bodies_under_host() -> Array:
 	return result
 
 
+func _rest_balls_under_host() -> Array:
+	var result: Array = []
+	for child in _reconciler.get_children():
+		if child is Ball and (child as Ball).play_state == Ball.PlayState.OUT_REST:
+			result.append(child)
+	return result
+
+
 # Bug 1: gear-rack press on an item without at_rest_shape must not crash.
 func test_grab_from_rack_refuses_equipment_without_shape() -> void:
 	_manager.take("gear_legacy")
@@ -144,9 +152,12 @@ func test_venue_release_does_not_reveal_rack_slot() -> void:
 		-1,
 		"rack does not render a slot for a loose-in-venue key",
 	)
-	# A loose body must exist under the reconciler ball-host as the canonical instance.
+	# Step 5: the canonical instance is a Ball in OUT_REST under the reconciler.
+	assert_eq(_loose_bodies_under_host().size(), 0, "no HeldBody loose body lingers post-release")
 	assert_eq(
-		_loose_bodies_under_host().size(), 1, "exactly one loose body persists at the release point"
+		_rest_balls_under_host().size(),
+		1,
+		"exactly one OUT_REST Ball persists at the release point"
 	)
 
 
@@ -174,7 +185,7 @@ func test_purchase_spawn_at_venue_does_not_render_rack_slot() -> void:
 	)
 
 
-# Re-grabbing a loose body clears the LOOSE_IN_VENUE overlay so the slot returns on release.
+# Step 5: re-grabbing the OUT_REST Ball clears the LOOSE_IN_VENUE overlay so a non-venue release restores the slot.
 func test_regrab_clears_loose_in_venue_overlay() -> void:
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
@@ -182,32 +193,31 @@ func test_regrab_clears_loose_in_venue_overlay() -> void:
 	_drag.attempt_release(Vector2(800, 600))
 	assert_true(_manager.is_loose_in_venue("ball_alpha"))
 
-	var bodies: Array = _loose_bodies_under_host()
-	assert_eq(bodies.size(), 1)
-	var loose_body: HeldBody = bodies[0]
-	# Synthesise the grab signal the live grab area would emit.
-	loose_body.grabbed.emit(loose_body)
+	var resting_balls: Array = _rest_balls_under_host()
+	assert_eq(resting_balls.size(), 1)
+	var ball: Ball = resting_balls[0]
+	# Synthesise the grab signal the Ball's grab area would emit on press.
+	ball.grabbed.emit(ball)
 	assert_false(
 		_manager.is_loose_in_venue("ball_alpha"),
-		"re-grabbing a loose body clears the placement overlay",
+		"re-grabbing an OUT_REST Ball clears the placement overlay",
 	)
 
 
-# Free of the loose body (queue_free outside re-grab) clears the overlay too.
-func test_loose_body_free_clears_overlay() -> void:
+# Step 5 obsoletes the "free the loose HeldBody" test — the loose Ball lives in the registry
+# under reconciler control, not as a free-standing HeldBody, so there is no tree_exited handler
+# to assert here. Re-grab and rack-release exercise the lifecycle now.
+func test_clear_loose_in_venue_restores_rack_filter() -> void:
 	_manager.take("ball_alpha")
 	_drag.grab_from_rack("ball_alpha")
 	_drag._gesture_below_threshold = false
 	_drag.attempt_release(Vector2(800, 600))
 	assert_true(_manager.is_loose_in_venue("ball_alpha"))
 
-	var bodies: Array = _loose_bodies_under_host()
-	assert_eq(bodies.size(), 1)
-	bodies[0].queue_free()
-	await get_tree().process_frame
+	_manager.clear_loose_in_venue("ball_alpha")
 	assert_false(
 		_manager.is_loose_in_venue("ball_alpha"),
-		"freeing the loose body clears the placement overlay",
+		"clearing the placement overlay returns the rack slot to the kit view",
 	)
 
 


### PR DESCRIPTION
Ball-role venue-floor releases land the same Ball in OUT_REST instead of spawning a loose HeldBody. The Ball lives in the registry across PLAY → OUT_REST → OUT_HELD → PLAY, preserving identity across the full lifecycle (step 5 of the ball-lifecycle refactor in `designs/01-prototype/tech/02-ball-lifecycle.md`).

Equipment keeps the legacy HeldBody loose path until step 7 unifies it; the shop-loose helpers (`register_loose_body`, `track_loose_body`, `get_loose_body_host`, `_on_loose_body_grabbed`, `_adopt_loose_body_as_held`, `_on_loose_body_freed`) stay alive for `shop_item._drop_falling_body` and are documented as a step-7 seam in `ball_drag_controller.gd`.

Stacked on `refactor/live-grab-keeps-ball`.