### PR TITLE
refactor: retire ball_host shim from BallReconciler

### DIFF
--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -528,9 +528,7 @@ func _adopt_loose_body_as_held(body: HeldBody) -> void:
 
 func _loose_body_host() -> Node:
 	if reconciler != null:
-		var host: Node = reconciler.get_ball_host()
-		if host != null:
-			return host
+		return reconciler
 	return get_parent()
 
 

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -21,14 +21,8 @@ var _initial_reconcile_pending: bool = true
 var _adopting_pre_existing: bool = false
 
 
-# Deprecated ball_host arg ignored; reconciler parents its own balls. Retired in step 6 of the lifecycle refactor.
-func configure(item_manager: Node, _ball_host: Node = null) -> void:
+func configure(item_manager: Node) -> void:
 	_item_manager = item_manager
-
-
-# Compatibility shim for callers still enumerating loose bodies via the legacy host indirection. Retired in step 6.
-func get_ball_host() -> Node:
-	return self
 
 
 func _ready() -> void:

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -44,7 +44,7 @@ func before_each() -> void:
 	_drop_target = _build_drop_target(RACK_CENTER, RACK_SIZE)
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	# Mirror court.tscn topology so adopt_pre_existing_balls finds authored siblings under _host.
 	_host.add_child(_reconciler)
 
@@ -316,7 +316,7 @@ func test_save_round_trip_preserves_live_ball_placement() -> void:
 	add_child_autofree(reloaded_host)
 
 	var reloaded_reconciler: BallReconciler = BallReconcilerScript.new()
-	reloaded_reconciler.configure(reloaded_manager, reloaded_host)
+	reloaded_reconciler.configure(reloaded_manager)
 	reloaded_host.add_child(reloaded_reconciler)
 	await get_tree().process_frame
 

--- a/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd
+++ b/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd
@@ -42,7 +42,7 @@ func before_each() -> void:
 	_drop_target = _build_drop_target(Vector2(-1500, 0), Vector2(300, 200))
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	_host.add_child(_reconciler)
 
 	_drag = BallDragControllerScript.new()

--- a/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd.uid
+++ b/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd.uid
@@ -1,0 +1,1 @@
+uid://cbs2wt6od2sm8

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -118,7 +118,7 @@ func _setup_ball_drag() -> void:
 	add_child_autofree(_drop_target)
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 	_drag = BallDragControllerScript.new()

--- a/tests/integration/test_shop_drag_drop.gd
+++ b/tests/integration/test_shop_drag_drop.gd
@@ -242,7 +242,7 @@ func test_shop_to_court_release_spawns_ball_at_release_position() -> void:
 	var host := Node2D.new()
 	add_child_autofree(host)
 	var reconciler: BallReconciler = BallReconcilerScript.new()
-	reconciler.configure(_item_manager, host)
+	reconciler.configure(_item_manager)
 	add_child_autofree(reconciler)
 
 	var drag: BallDragController = BallDragControllerScript.new()
@@ -281,7 +281,7 @@ func test_shop_release_outside_court_falls_through_to_rack_default() -> void:
 	var host := Node2D.new()
 	add_child_autofree(host)
 	var reconciler: BallReconciler = BallReconcilerScript.new()
-	reconciler.configure(_item_manager, host)
+	reconciler.configure(_item_manager)
 	add_child_autofree(reconciler)
 
 	var drag: BallDragController = BallDragControllerScript.new()

--- a/tests/integration/test_speed_bar_flows.gd
+++ b/tests/integration/test_speed_bar_flows.gd
@@ -96,7 +96,7 @@ func test_bar_shows_highest_speed_across_two_tracked_balls() -> void:
 	var host := Node2D.new()
 	add_child_autofree(host)
 	var reconciler: BallReconciler = BallReconcilerScript.new()
-	reconciler.configure(multi_manager, host)
+	reconciler.configure(multi_manager)
 	add_child_autofree(reconciler)
 
 	var bar: Control = SpeedBarScript.new()

--- a/tests/unit/ball/test_ball_state_transitions.gd.uid
+++ b/tests/unit/ball/test_ball_state_transitions.gd.uid
@@ -1,0 +1,1 @@
+uid://ct3a1qmc5e2r5

--- a/tests/unit/court/test_court_multi_ball.gd
+++ b/tests/unit/court/test_court_multi_ball.gd
@@ -33,7 +33,7 @@ func before_each() -> void:
 	add_child_autofree(_host)
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 	_paddle = load("res://scripts/entities/paddle.gd").new()

--- a/tests/unit/items/test_ball_drag_controller.gd
+++ b/tests/unit/items/test_ball_drag_controller.gd
@@ -56,7 +56,7 @@ func before_each() -> void:
 	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 	_drag = BallDragControllerScript.new()

--- a/tests/unit/items/test_ball_drag_controller_sh287.gd
+++ b/tests/unit/items/test_ball_drag_controller_sh287.gd
@@ -57,7 +57,7 @@ func before_each() -> void:
 	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 	_drag = BallDragControllerScript.new()

--- a/tests/unit/items/test_ball_reconciler.gd
+++ b/tests/unit/items/test_ball_reconciler.gd
@@ -22,7 +22,7 @@ func before_each() -> void:
 	add_child_autofree(_host)
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 
@@ -150,7 +150,7 @@ func test_reload_reconciles_on_court_items_without_authored_ball_node() -> void:
 	var preloaded_host := Node2D.new()
 	add_child_autofree(preloaded_host)
 	var fresh: BallReconciler = BallReconcilerScript.new()
-	fresh.configure(_manager, preloaded_host)
+	fresh.configure(_manager)
 	add_child_autofree(fresh)
 	# Flush deferred calls (adopt_pre_existing_balls + _reconcile_initial_state).
 	await get_tree().process_frame
@@ -161,16 +161,16 @@ func test_reload_reconciles_on_court_items_without_authored_ball_node() -> void:
 	)
 
 
-func test_default_spawn_position_falls_back_to_zero_for_non_node2d_host() -> void:
-	var plain_host := Node.new()
-	add_child_autofree(plain_host)
+func test_default_spawn_position_falls_back_to_zero_for_non_node2d_parent() -> void:
+	var plain_parent := Node.new()
+	add_child_autofree(plain_parent)
 	var non_spatial: BallReconciler = BallReconcilerScript.new()
-	non_spatial.configure(_manager, plain_host)
-	add_child_autofree(non_spatial)
+	non_spatial.configure(_manager)
+	plain_parent.add_child(non_spatial)
 	assert_eq(
 		non_spatial._default_spawn_position(),
 		Vector2.ZERO,
-		"non-Node2D hosts yield the zero-vector fallback",
+		"non-Node2D parents yield the zero-vector fallback",
 	)
 
 
@@ -267,7 +267,7 @@ func test_reconcile_spawns_saved_on_court_ball_when_authored_sibling_triggers_co
 	fresh_host.add_child(authored_ball)
 
 	var fresh_reconciler: BallReconciler = BallReconcilerScript.new()
-	fresh_reconciler.configure(saved_manager, fresh_host)
+	fresh_reconciler.configure(saved_manager)
 	# Reconciler parented under the host so adopt_pre_existing_balls sees the authored sibling.
 	fresh_host.add_child(fresh_reconciler)
 
@@ -289,15 +289,12 @@ func test_ensure_ball_for_key_moves_existing_ball_without_duplicating() -> void:
 	assert_eq(_permanent_ball_count(), 1)
 
 
-func test_reconciler_parents_new_balls_and_ignores_ball_host_arg() -> void:
+func test_reconciler_parents_new_balls_under_itself() -> void:
 	var first: Ball = _reconciler.ensure_ball_for_key("ball_alpha", Vector2.ZERO, Vector2.ZERO)
 	assert_eq(first.get_parent(), _reconciler, "ensure_ball_for_key parents under the reconciler")
-	assert_eq(_reconciler.get_ball_host(), _reconciler, "get_ball_host is a self-shim until step 6")
-
-	# Re-configure with an unrelated host; the reconciler must still own parenting.
-	var stranger := Node2D.new()
-	add_child_autofree(stranger)
-	_reconciler.configure(_manager, stranger)
 	var second: Ball = _reconciler.ensure_ball_for_key("ball_beta", Vector2.ZERO, Vector2.ZERO)
-	assert_eq(second.get_parent(), _reconciler, "ball_host arg is ignored on subsequent configure")
-	assert_eq(stranger.get_child_count(), 0, "stranger host receives no balls")
+	assert_eq(
+		second.get_parent(),
+		_reconciler,
+		"subsequent ensure_ball_for_key also parents under the reconciler"
+	)

--- a/tests/unit/items/test_ball_reconciler_release_into_rest.gd
+++ b/tests/unit/items/test_ball_reconciler_release_into_rest.gd
@@ -20,7 +20,7 @@ func before_each() -> void:
 	add_child_autofree(_host)
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 

--- a/tests/unit/items/test_ball_reconciler_release_into_rest.gd.uid
+++ b/tests/unit/items/test_ball_reconciler_release_into_rest.gd.uid
@@ -1,0 +1,1 @@
+uid://bmbj7343fyvlr

--- a/tests/unit/items/test_court_drop_target_scaling.gd
+++ b/tests/unit/items/test_court_drop_target_scaling.gd
@@ -34,7 +34,7 @@ func _make_harness(definitions: Array) -> Dictionary:
 	var host := Node2D.new()
 	add_child_autofree(host)
 	var reconciler: BallReconciler = BallReconcilerScript.new()
-	reconciler.configure(manager, host)
+	reconciler.configure(manager)
 	add_child_autofree(reconciler)
 	var target: CourtDropTarget = CourtDropTargetScript.new()
 	(
@@ -95,7 +95,7 @@ func test_court_target_zero_bounds_guard_passes_through_position() -> void:
 	var host := Node2D.new()
 	add_child_autofree(host)
 	var reconciler: BallReconciler = BallReconcilerScript.new()
-	reconciler.configure(manager, host)
+	reconciler.configure(manager)
 	add_child_autofree(reconciler)
 	var target: CourtDropTarget = CourtDropTargetScript.new()
 	target.configure(manager, reconciler, host.get_world_2d(), Rect2())

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -64,7 +64,7 @@ func before_each() -> void:
 	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 	_drag = BallDragControllerScript.new()

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -148,7 +148,7 @@ func test_venue_drop_target_accepts_ball_inside_venue_bounds() -> void:
 	var host := Node.new()
 	add_child_autofree(host)
 	var reconciler: BallReconciler = BallReconcilerScript.new()
-	reconciler.configure(manager, host)
+	reconciler.configure(manager)
 	add_child_autofree(reconciler)
 
 	var venue := Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
@@ -185,7 +185,7 @@ class _PhysicsHarness:
 		var host := Node2D.new()
 		test.add_child_autofree(host)
 		var reconciler: BallReconciler = BallReconcilerScript.new()
-		reconciler.configure(manager, host)
+		reconciler.configure(manager)
 		test.add_child_autofree(reconciler)
 		var target: CourtDropTarget = CourtDropTargetScript.new()
 		(

--- a/tests/unit/items/test_grab_feel.gd
+++ b/tests/unit/items/test_grab_feel.gd
@@ -60,7 +60,7 @@ func before_each() -> void:
 	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 	_drag = BallDragControllerScript.new()

--- a/tests/unit/items/test_sh_332_regressions.gd
+++ b/tests/unit/items/test_sh_332_regressions.gd
@@ -81,7 +81,7 @@ func before_each() -> void:
 	_gear_drop_target = _make_drop_target(Vector2(1000, 0), Vector2(300, 200))
 
 	_reconciler = BallReconcilerScript.new()
-	_reconciler.configure(_manager, _host)
+	_reconciler.configure(_manager)
 	add_child_autofree(_reconciler)
 
 	_drag = BallDragControllerScript.new()


### PR DESCRIPTION
Step 6 of the ball-lifecycle refactor (`designs/01-prototype/tech/02-ball-lifecycle.md`). With step 5 landed, no production code depends on the `ball_host` indirection; `BallReconciler.configure` drops its ignored second arg and `get_ball_host()` is gone. `_loose_body_host` in `BallDragController` now returns the reconciler directly.

Stacked on `refactor/loose-body-retires`; draft until base merges.