### PR TITLE
refactor: rack reads STORED-ball art from reconciler

### DIFF
--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -93,11 +93,13 @@ position = Vector2(300, 0)
 [node name="PlayerSpawn" type="Marker2D" parent="." unique_id=1995993314]
 position = Vector2(-300, 0)
 
-[node name="BallRack" parent="." unique_id=949376876 instance=ExtResource("8_h0b8m")]
+[node name="BallRack" parent="." unique_id=949376876 node_paths=PackedStringArray("reconciler") instance=ExtResource("8_h0b8m")]
 position = Vector2(-600, 349.8)
+reconciler = NodePath("../BallReconciler")
 
-[node name="GearRack" parent="." unique_id=445509089 instance=ExtResource("9_c7axm")]
+[node name="GearRack" parent="." unique_id=445509089 node_paths=PackedStringArray("reconciler") instance=ExtResource("9_c7axm")]
 position = Vector2(600, 349.8)
+reconciler = NodePath("../BallReconciler")
 
 [node name="ShipmentMat" parent="." unique_id=530264883 instance=ExtResource("10_5mv5b")]
 position = Vector2(870, 349.8)

--- a/scripts/items/rack_display.gd
+++ b/scripts/items/rack_display.gd
@@ -7,6 +7,8 @@ const SLOT_HIT_SIZE: Vector2 = Vector2(36, 36)
 
 @export var role: StringName = &"ball"
 @export var slot_container: Node2D
+## Optional. When set, the rack can source slot art from STORED Balls in the registry (step 7.1+).
+@export var reconciler: BallReconciler
 
 var _item_manager: Node
 var _slots: Array[Node2D] = []
@@ -20,12 +22,20 @@ func _ready() -> void:
 	_cache_slot_markers()
 	_item_manager.item_level_changed.connect(_on_item_level_changed)
 	_item_manager.item_placement_changed.connect(_on_item_placement_changed)
+	if reconciler != null:
+		reconciler.ball_spawned.connect(_on_ball_spawned)
+		reconciler.ball_removed.connect(_on_ball_removed)
 	refresh()
 
 
 ## Injects a non-autoload ItemManager for tests. Must be called before adding to tree.
 func configure(item_manager: Node) -> void:
 	_item_manager = item_manager
+
+
+## Injects a reconciler so the rack can source STORED-ball art from the registry. Test seam.
+func configure_reconciler(p_reconciler: BallReconciler) -> void:
+	reconciler = p_reconciler
 
 
 func refresh() -> void:
@@ -77,11 +87,49 @@ func _build_slot(definition: ItemDefinition, slot_position: Vector2) -> Node2D:
 	var art_holder: Node2D = Node2D.new()
 	art_holder.name = "ArtHolder"
 	art_holder.scale = definition.token_scale
-	var art_instance: Node = definition.art.instantiate()
-	art_holder.add_child(art_instance)
+	_populate_art_holder(art_holder, definition)
 	slot.add_child(art_holder)
 	_attach_slot_input(slot, definition.key)
 	return slot
+
+
+## When the registry owns STORED balls, the Ball's ItemArtHolder is the visual source of truth.
+func _populate_art_holder(art_holder: Node2D, definition: ItemDefinition) -> void:
+	var ball: Ball = _stored_ball_for(definition.key)
+	if ball != null:
+		var source: Node = ball.get_node_or_null("ItemArtHolder")
+		if source != null:
+			art_holder.set_meta(&"source", &"ball")
+			for child in source.get_children():
+				art_holder.add_child(child.duplicate())
+			return
+	art_holder.set_meta(&"source", &"definition")
+	art_holder.add_child(definition.art.instantiate())
+
+
+func _stored_ball_for(item_key: String) -> Ball:
+	if reconciler == null or not reconciler.stored_balls_in_registry:
+		return null
+	var ball: Ball = reconciler.get_ball_for_key(item_key)
+	if ball == null:
+		return null
+	if ball.play_state != Ball.PlayState.STORED:
+		return null
+	return ball
+
+
+## World position of the slot for `item_key` under the rack's current ordering. Returns Vector2.ZERO if unknown.
+func get_slot_position_for(item_key: String) -> Vector2:
+	if slot_container == null:
+		return Vector2.ZERO
+	if _slot_markers.is_empty():
+		_cache_slot_markers()
+	var kit_keys: Array[String] = _item_manager.get_kit_items(role)
+	var index: int = kit_keys.find(item_key)
+	if index < 0 or _slot_markers.is_empty():
+		return Vector2.ZERO
+	var marker_index: int = min(index, _slot_markers.size() - 1)
+	return _slot_markers[marker_index].global_position
 
 
 func _attach_slot_input(slot: Node2D, item_key: String) -> void:
@@ -150,6 +198,7 @@ func _apply_slot_visibility() -> void:
 func _clear_slots() -> void:
 	for slot in _slots:
 		if slot != null and is_instance_valid(slot):
+			slot_container.remove_child(slot)
 			slot.queue_free()
 	_slots.clear()
 
@@ -166,4 +215,12 @@ func _on_item_level_changed(_item_key: String) -> void:
 
 
 func _on_item_placement_changed(_item_key: String, _placement: int) -> void:
+	refresh()
+
+
+func _on_ball_spawned(_item_key: String, _ball: Ball) -> void:
+	refresh()
+
+
+func _on_ball_removed(_ball: Ball) -> void:
 	refresh()

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -2,6 +2,7 @@
 extends GutTest
 
 const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
 
 
 func _stub_art() -> PackedScene:
@@ -233,3 +234,101 @@ func test_reveal_slot_for_restores_visibility() -> void:
 	for child in rack.slot_container.get_children():
 		if child is Node2D and String(child.name).begins_with("Slot_"):
 			assert_true(child.visible, "drop_completed reveals the slot again")
+
+
+func test_get_slot_position_for_returns_world_position_for_known_key() -> void:
+	var ball := _make_item("ball_alpha", &"ball")
+	var manager: Node = _make_manager_with([ball])
+	manager._progression.friendship_point_balance = 1000
+	var rack := _make_rack(&"ball", manager)
+	manager.take(ball.key)
+
+	var position: Vector2 = rack.get_slot_position_for(ball.key)
+	# First slot marker sits at local (0, 0); rack is at the origin so global == local.
+	assert_eq(position, Vector2.ZERO, "first kit item resolves to the first slot marker")
+
+
+func test_get_slot_position_for_returns_zero_for_unknown_key() -> void:
+	var manager: Node = _make_manager_with([])
+	var rack := _make_rack(&"ball", manager)
+
+	assert_eq(
+		rack.get_slot_position_for("nonexistent"),
+		Vector2.ZERO,
+		"unknown keys return the sentinel Vector2.ZERO",
+	)
+
+
+func _make_reconciler(manager: Node) -> BallReconciler:
+	var reconciler: BallReconciler = BallReconcilerScript.new()
+	reconciler.configure(manager)
+	add_child_autofree(reconciler)
+	return reconciler
+
+
+func _make_rack_with_reconciler(
+	role: StringName, manager: Node, reconciler: BallReconciler
+) -> Node2D:
+	var rack: Node2D = RackDisplayScript.new()
+	rack.role = role
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	rack.configure_reconciler(reconciler)
+	add_child_autofree(rack)
+	return rack
+
+
+func test_flag_off_rack_sources_art_from_definition() -> void:
+	var ball := _make_item("ball_alpha", &"ball")
+	var manager: Node = _make_manager_with([ball])
+	manager._progression.friendship_point_balance = 1000
+	var reconciler: BallReconciler = _make_reconciler(manager)
+	reconciler.stored_balls_in_registry = false
+	var rack: Node2D = _make_rack_with_reconciler(&"ball", manager, reconciler)
+	manager.take(ball.key)
+
+	var slot: Node2D = _find_slot(rack, ball.key)
+	assert_not_null(slot, "slot was rendered")
+	var art_holder: Node2D = slot.get_node("ArtHolder")
+	assert_eq(
+		art_holder.get_meta(&"source", ""),
+		&"definition",
+		"with the flag off the rack sources art from the ItemDefinition",
+	)
+
+
+func test_flag_on_with_stored_ball_rack_sources_art_from_ball() -> void:
+	var ball_item := _make_item("ball_alpha", &"ball")
+	var manager: Node = _make_manager_with([ball_item])
+	manager._progression.friendship_point_balance = 1000
+	var reconciler: BallReconciler = _make_reconciler(manager)
+	reconciler.stored_balls_in_registry = true
+	var rack: Node2D = _make_rack_with_reconciler(&"ball", manager, reconciler)
+	manager.take(ball_item.key)
+	# adopt_stored registers a STORED Ball under the key; rack picks it up via ball_spawned.
+	var stored: Ball = reconciler.adopt_stored(ball_item.key, Vector2.ZERO)
+	assert_not_null(stored, "adopt_stored returns a Ball when the flag is on")
+
+	var slot: Node2D = _find_slot(rack, ball_item.key)
+	assert_not_null(slot, "slot was rendered")
+	var art_holder: Node2D = slot.get_node("ArtHolder")
+	assert_eq(
+		art_holder.get_meta(&"source", ""),
+		&"ball",
+		"with the flag on and a STORED ball registered the rack reads art from the Ball",
+	)
+
+
+func _find_slot(rack: Node2D, item_key: String) -> Node2D:
+	for child in rack.slot_container.get_children():
+		if child is Node2D and child.get_meta(&"item_key", "") == item_key:
+			return child
+	return null


### PR DESCRIPTION
Step 7.1 of the ball-lifecycle refactor. RackDisplay can now source slot art from a STORED Ball's `ItemArtHolder` via the reconciler registry. The flag (`BallReconciler.stored_balls_in_registry`) stays false in this PR; production behaviour is unchanged.

Also adds `RackDisplay.get_slot_position_for(item_key)` for sub-step 7.2.

Stacked beneath #608; will rebase onto main when 608 lands.