### PR TITLE
refactor: reconciler stored-branch initial population

### DIFF
--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -172,8 +172,9 @@ offset_top = -240.0
 offset_right = -529.0
 offset_bottom = -172.0
 
-[node name="BallReconciler" type="Node" parent="." unique_id=1902001001]
+[node name="BallReconciler" type="Node" parent="." unique_id=1902001001 node_paths=PackedStringArray("ball_rack")]
 script = ExtResource("21_reconciler")
+ball_rack = NodePath("../BallRack")
 
 [node name="BallTracker" type="Node" parent="." unique_id=1902001003 node_paths=PackedStringArray("ball_system")]
 script = ExtResource("23_tracker")

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -15,12 +15,15 @@ const PRESERVED_SPEED_NONE: float = -1.0
 @export var ball_scene: PackedScene = BallScene
 ## Opt-in surface for step 7; while false, adopt_stored is a no-op so callers can be wired ahead of the flip.
 @export var stored_balls_in_registry: bool = false
+## Ball-role rack consulted for STORED slot positions when stored_balls_in_registry is true.
+@export var ball_rack: RackDisplay
 
 var _item_manager: Node
 var _balls_by_key: Dictionary = {}
 var _initial_reconcile_pending: bool = true
 ## Prevents court_changed from clearing _initial_reconcile_pending before _reconcile_initial_state runs.
 var _adopting_pre_existing: bool = false
+var _stored_kit_reconciled: bool = false
 
 
 func configure(item_manager: Node) -> void:
@@ -58,6 +61,9 @@ func collect_item_positions() -> Dictionary[String, Vector2]:
 		if not is_instance_valid(raw):
 			continue
 		var ball: Ball = raw
+		# STORED entries live at rack-slot positions reconstructed from rack_slot_index_by_key on load.
+		if ball.play_state == Ball.PlayState.STORED:
+			continue
 		positions[key] = ball.global_position
 	return positions
 
@@ -236,16 +242,29 @@ func _on_court_changed(item_key: String, on_court: bool) -> void:
 
 ## One-shot: skipped once any signal-driven court_changed activity has begun.
 func _reconcile_initial_state() -> void:
-	if not _initial_reconcile_pending:
+	if _initial_reconcile_pending:
+		_initial_reconcile_pending = false
+		for key in _item_manager.get_court_items():
+			if get_ball_for_key(key) == null:
+				ensure_ball_for_key(
+					key,
+					_spawn_position_for(key),
+					_item_manager.get_default_ball_launch_velocity(),
+				)
+	# STORED kit items are independent of the court-pending flag; court_changed cannot spawn them.
+	if stored_balls_in_registry and not _stored_kit_reconciled:
+		_stored_kit_reconciled = true
+		_reconcile_stored_kit_items()
+
+
+## Populates STORED Balls for kit ball-role items absent from the court. Rack owns slot→world mapping.
+func _reconcile_stored_kit_items() -> void:
+	if ball_rack == null:
 		return
-	_initial_reconcile_pending = false
-	for key in _item_manager.get_court_items():
-		if get_ball_for_key(key) == null:
-			ensure_ball_for_key(
-				key,
-				_spawn_position_for(key),
-				_item_manager.get_default_ball_launch_velocity(),
-			)
+	for key in _item_manager.get_kit_items(&"ball"):
+		if get_ball_for_key(key) != null:
+			continue
+		adopt_stored(key, ball_rack.get_slot_position_for(key))
 
 
 func _default_spawn_position() -> Vector2:

--- a/scripts/progression/progression_data.gd
+++ b/scripts/progression/progression_data.gd
@@ -7,6 +7,8 @@ var item_levels: Dictionary[String, int] = {}
 var item_placements: Dictionary[String, int] = {}
 ## Per-item world position; balls and loose bodies reload where the player left them.
 var item_positions: Dictionary[String, Vector2] = {}
+## Rack slot index per STORED item; rack owns the slot→world mapping. Production reader lands at step 7.5.
+var rack_slot_index_by_key: Dictionary[String, int] = {}
 ## Keys of items currently dropped on the venue floor; survives the session so
 ## loose bodies respawn rather than vanishing back to the rack.
 var loose_in_venue: Array[String] = []
@@ -27,6 +29,7 @@ func clear() -> void:
 	item_levels = {}
 	item_placements = {}
 	item_positions = {}
+	rack_slot_index_by_key = {}
 	loose_in_venue = []
 	personal_volley_best = 0
 	shop_unlocked = false
@@ -65,6 +68,7 @@ func _try_load_content(content: String) -> bool:
 	item_levels = loaded.item_levels
 	item_placements = loaded.item_placements
 	item_positions = loaded.item_positions
+	rack_slot_index_by_key = loaded.rack_slot_index_by_key
 	loose_in_venue = loaded.loose_in_venue
 	personal_volley_best = loaded.personal_volley_best
 	shop_unlocked = loaded.shop_unlocked
@@ -83,6 +87,7 @@ func to_dict() -> Dictionary:
 		"item_levels": item_levels,
 		"item_placements": item_placements,
 		"item_positions": _serialize_positions(item_positions),
+		"rack_slot_index_by_key": rack_slot_index_by_key,
 		"loose_in_venue": loose_in_venue,
 		"personal_volley_best": personal_volley_best,
 		"shop_unlocked": shop_unlocked,
@@ -101,6 +106,7 @@ static func from_dict(data: Dictionary) -> ProgressionData:
 	progression.item_levels = _to_typed_dict(data.get("item_levels", {}))
 	progression.item_placements = _to_typed_dict(data.get("item_placements", {}))
 	progression.item_positions = _parse_positions(data.get("item_positions", {}))
+	progression.rack_slot_index_by_key = _to_typed_dict(data.get("rack_slot_index_by_key", {}))
 	progression.loose_in_venue = _to_typed_string_array(data.get("loose_in_venue", []))
 	progression.personal_volley_best = data.get("personal_volley_best", 0)
 	progression.shop_unlocked = data.get("shop_unlocked", false)

--- a/tests/unit/items/test_ball_reconciler_stored_population.gd
+++ b/tests/unit/items/test_ball_reconciler_stored_population.gd
@@ -1,0 +1,119 @@
+## SH-374 step 7.2: stored-branch initial population for the ball reconciler.
+extends GutTest
+
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _host: Node2D
+var _reconciler: BallReconciler
+var _rack: RackDisplay
+
+
+func _make_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var ball_beta: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_beta")
+	var typed_items: Array[ItemDefinition] = [ball_alpha, ball_beta]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_host = Node2D.new()
+	add_child_autofree(_host)
+
+	_rack = _make_rack(_manager)
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	_reconciler.ball_rack = _rack
+	add_child_autofree(_reconciler)
+
+
+func _ball_count() -> int:
+	var count := 0
+	for child in _reconciler.get_children():
+		if child is Ball:
+			count += 1
+	return count
+
+
+func test_flag_off_does_not_populate_stored_kit_items() -> void:
+	# Owned but not on-court; with flag off, no STORED ball spawns.
+	_manager.take("ball_alpha")
+	_manager.take("ball_beta")
+	await get_tree().process_frame
+	assert_eq(_ball_count(), 0, "flag off keeps stored-population dormant")
+
+
+func test_flag_on_populates_stored_balls_for_kit_ball_items() -> void:
+	_reconciler.stored_balls_in_registry = true
+	_manager.take("ball_alpha")
+	_manager.take("ball_beta")
+	await get_tree().process_frame
+
+	var alpha: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	var beta: Ball = _reconciler.get_ball_for_key("ball_beta")
+	assert_not_null(alpha, "stored-population spawns ball_alpha")
+	assert_not_null(beta, "stored-population spawns ball_beta")
+	assert_eq(alpha.play_state, Ball.PlayState.STORED, "stored-populated ball is in STORED state")
+	assert_eq(beta.play_state, Ball.PlayState.STORED)
+	assert_eq(alpha.get_parent(), _reconciler, "stored-populated ball parented under reconciler")
+	# Slot positions are the rack's slot-marker globals; ball_alpha is the first kit entry.
+	assert_eq(
+		alpha.global_position,
+		_rack.get_slot_position_for("ball_alpha"),
+		"stored ball positioned at its rack slot"
+	)
+
+
+func test_mixed_kit_and_court_population_uses_both_branches() -> void:
+	_reconciler.stored_balls_in_registry = true
+	_manager.take("ball_alpha")
+	_manager.take("ball_beta")
+	# Drive ball_alpha onto the court; the existing court branch handles it, kit branch handles ball_beta.
+	_manager.activate("ball_alpha")
+	await get_tree().process_frame
+
+	var alpha: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	var beta: Ball = _reconciler.get_ball_for_key("ball_beta")
+	assert_not_null(alpha, "court-branch spawn covers ball_alpha")
+	assert_not_null(beta, "kit-branch spawn covers ball_beta")
+	assert_ne(
+		alpha.play_state,
+		Ball.PlayState.STORED,
+		"court item stays in a play state, not STORED",
+	)
+	assert_eq(beta.play_state, Ball.PlayState.STORED, "non-court kit item lands as STORED")
+
+
+func test_collect_item_positions_skips_stored_balls() -> void:
+	_reconciler.stored_balls_in_registry = true
+	_manager.take("ball_alpha")
+	_manager.take("ball_beta")
+	_manager.activate("ball_alpha")
+	await get_tree().process_frame
+
+	var positions: Dictionary[String, Vector2] = _reconciler.collect_item_positions()
+	assert_true(positions.has("ball_alpha"), "on-court ball position included in snapshot")
+	assert_false(
+		positions.has("ball_beta"),
+		"STORED ball positions are reconstructed from rack slot index, not from world coords"
+	)

--- a/tests/unit/progression/test_progression_data_positions.gd
+++ b/tests/unit/progression/test_progression_data_positions.gd
@@ -57,3 +57,39 @@ func test_clear_resets_positions_and_loose_set() -> void:
 	_data.clear()
 	assert_eq(_data.item_positions, {} as Dictionary[String, Vector2])
 	assert_eq(_data.loose_in_venue, [] as Array[String])
+
+
+func test_rack_slot_index_by_key_defaults_empty() -> void:
+	assert_eq(_data.rack_slot_index_by_key, {} as Dictionary[String, int])
+
+
+func test_rack_slot_index_by_key_round_trips() -> void:
+	_data.rack_slot_index_by_key["base_ball"] = 0
+	_data.rack_slot_index_by_key["training_ball"] = 2
+	var restored := ProgressionData.from_dict(_data.to_dict())
+	assert_eq(restored.rack_slot_index_by_key["base_ball"], 0)
+	assert_eq(restored.rack_slot_index_by_key["training_ball"], 2)
+
+
+func test_rack_slot_index_by_key_survives_json_string_round_trip() -> void:
+	_data.rack_slot_index_by_key["base_ball"] = 1
+	var saved_json := JSON.stringify(_data.to_dict())
+	stub(_mock_storage.write).to_return(true)
+	_data.save_to_disk()
+
+	var loaded := ProgressionData.new(_mock_storage)
+	stub(_mock_storage.read).to_return(saved_json)
+	loaded.load_from_disk()
+	assert_eq(loaded.rack_slot_index_by_key["base_ball"], 1)
+
+
+func test_rack_slot_index_by_key_missing_defaults_empty() -> void:
+	var legacy: Dictionary = {"friendship_point_balance": 50}
+	var restored := ProgressionData.from_dict(legacy)
+	assert_eq(restored.rack_slot_index_by_key, {} as Dictionary[String, int])
+
+
+func test_clear_resets_rack_slot_index() -> void:
+	_data.rack_slot_index_by_key["base_ball"] = 3
+	_data.clear()
+	assert_eq(_data.rack_slot_index_by_key, {} as Dictionary[String, int])


### PR DESCRIPTION
## Summary
Step 7.2 of the ball-lifecycle refactor. `BallReconciler` grows a stored-branch initial population (flag-gated) that walks `get_kit_items(&"ball")` and `adopt_stored`s each at `ball_rack.get_slot_position_for(key)`. `collect_item_positions` skips STORED — their world position is reconstructed from the rack-slot index at load. `ProgressionData.rack_slot_index_by_key` reserves the save slot; production reader lands at 7.5.

Stacked on `refactor/rack-reads-stored-art` (Loonquawl). Flag stays `false`; no production behaviour change.