### PR TITLE
refactor: rack pickup adopts STORED ball as held when flag is on

### DIFF
--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -209,8 +209,20 @@ func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
 	var spawn_position: Vector2 = (
 		press_position if press_position is Vector2 else _cursor_position()
 	)
-	if not _spawn_held_body(item_key, spawn_position, false):
+
+	var stored: Ball = null
+	if reconciler != null and reconciler.stored_balls_in_registry:
+		stored = reconciler.get_ball_for_key(item_key)
+
+	if stored != null:
+		# Flag-on rack pickup: the STORED Ball IS the drag target. No HeldBody spawn; the ball
+		# stays in _balls_by_key, transitioned to OUT_HELD until release.
+		stored.enter_out_held()
+		_set_court_exclude_rids([stored.get_rid()])
+		_adopt_live_ball_as_held(stored, item_key)
+	elif not _spawn_held_body(item_key, spawn_position, false):
 		return false
+
 	_held_was_on_court = false
 	_held_origin = &"rack"
 	# A grab only happens on a press; assume mouse is down so polling waits for mouse-up.
@@ -375,6 +387,8 @@ func attempt_release(release_position: Vector2) -> bool:
 
 	# Rack-origin press-and-release without movement cancels back to source instead of activating.
 	if below_threshold and _held_origin == &"rack" and not _held_was_on_court and not was_temporary:
+		if has_live_ball:
+			_restore_held_ball_to_stored(item_key)
 		_finalise_gesture(item_key, clamped_position, false)
 		return true
 
@@ -413,6 +427,10 @@ func attempt_release(release_position: Vector2) -> bool:
 		# Rack accept: deactivate path fires court_changed which prompts the reconciler to queue_free
 		# the live ball. The HeldBody-based rack token visual retires fully in step 7.
 		target.accept(item_key, clamped_position, Vector2.ZERO)
+		# Flag-on rack-origin grabs are not on-court; rack accept is a no-op for them, so restore
+		# the held Ball to STORED at its slot explicitly.
+		if has_live_ball and _held_origin == &"rack":
+			_restore_held_ball_to_stored(item_key)
 
 	var over_court: bool = target is CourtDropTarget
 	if was_temporary:
@@ -596,6 +614,7 @@ func _update_expansion_state(world_position: Vector2) -> void:
 
 
 ## Live-ball cancels deactivate the on-court placement so the rack regrows the at-rest token.
+## STORED-origin cancels transition the held Ball back to STORED at its rack slot.
 func _cancel_to_source() -> void:
 	var item_key: String = _held_key
 	var was_on_court: bool = _held_was_on_court
@@ -608,8 +627,20 @@ func _cancel_to_source() -> void:
 	if origin == &"live" and was_on_court:
 		if _item_manager != null and _item_manager.is_on_court(item_key):
 			_item_manager.deactivate(item_key)
+	elif origin == &"rack" and _held_ball != null:
+		_restore_held_ball_to_stored(item_key)
 
 	_finalise_gesture(item_key, release_position, false)
+
+
+## Returns a STORED-origin held Ball to its rack slot in STORED state. Rack accept is a no-op for
+## items not on court, so flag-on rack-origin grabs reach this from cancel and release-over-rack.
+func _restore_held_ball_to_stored(item_key: String) -> void:
+	if _held_ball == null:
+		return
+	_held_ball.enter_stored()
+	if rack != null:
+		_held_ball.global_position = rack.get_slot_position_for(item_key)
 
 
 func _finalise_gesture(item_key: String, release_position: Vector2, over_court: bool) -> void:

--- a/tests/integration/test_rack_pickup_live.gd
+++ b/tests/integration/test_rack_pickup_live.gd
@@ -1,0 +1,125 @@
+# Step 7.4: flag-on rack pickups grab the STORED Ball directly; no HeldBody spawn.
+# Canon: designs/01-prototype/tech/02-ball-lifecycle.md.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+
+
+func _make_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _make_drop_target(position: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [ball_alpha]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_rack = _make_rack(_manager)
+	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	add_child_autofree(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	add_child_autofree(_drag)
+
+
+func _seed_stored_ball() -> Ball:
+	_manager.take("ball_alpha")
+	_reconciler.stored_balls_in_registry = true
+	var ball: Ball = _reconciler.adopt_stored("ball_alpha", Vector2(50, 0))
+	assert_not_null(ball, "precondition: adopt_stored returns a Ball when the flag is on")
+	return ball
+
+
+func test_flag_on_rack_grab_adopts_stored_ball_no_held_body() -> void:
+	var stored: Ball = _seed_stored_ball()
+
+	var removed_count: int = 0
+	_reconciler.ball_removed.connect(func(_b: Ball) -> void: removed_count += 1)
+
+	assert_true(_drag.grab_from_rack("ball_alpha", Vector2(50, 0)))
+
+	assert_eq(_drag._held_ball, stored, "flag-on rack grab adopts the STORED Ball as held")
+	assert_null(_drag._held_body, "no HeldBody spawn on flag-on rack grab")
+	assert_eq(stored.play_state, Ball.PlayState.OUT_HELD)
+	assert_eq(removed_count, 0, "rack pickup does not emit ball_removed")
+	assert_eq(_reconciler.get_ball_for_key("ball_alpha"), stored, "ball stays in registry")
+
+
+func test_flag_off_rack_grab_spawns_held_body() -> void:
+	_manager.take("ball_alpha")
+	# Flag stays false; reconciler holds no STORED ball.
+	assert_false(_reconciler.stored_balls_in_registry)
+
+	assert_true(_drag.grab_from_rack("ball_alpha", Vector2(50, 0)))
+
+	assert_not_null(_drag._held_body, "flag-off rack grab spawns a HeldBody")
+	assert_null(_drag._held_ball, "no Ball adopted when flag is off")
+
+
+func test_rack_grab_release_over_court_transitions_to_play() -> void:
+	var stored: Ball = _seed_stored_ball()
+	assert_true(_drag.grab_from_rack("ball_alpha", Vector2(50, 0)))
+	await get_tree().process_frame
+
+	assert_true(_drag.attempt_release(Vector2(50, -25)))
+
+	var after: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_eq(after, stored, "same Ball instance survives rack pickup → court release")
+	assert_ne(after.play_state, Ball.PlayState.OUT_HELD, "release transitions out of OUT_HELD")
+	assert_false(after.freeze, "play state unfreezes the body")
+
+
+func test_rack_grab_cancel_restores_stored_state() -> void:
+	var stored: Ball = _seed_stored_ball()
+	assert_true(_drag.grab_from_rack("ball_alpha", Vector2(50, 0)))
+	assert_eq(stored.play_state, Ball.PlayState.OUT_HELD)
+
+	# Press-and-release without movement: cancels back to source.
+	assert_true(_drag.attempt_release(Vector2(50, 0)))
+
+	var after: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_eq(after, stored, "cancelled rack pickup keeps the same Ball in the registry")
+	assert_eq(after.play_state, Ball.PlayState.STORED, "cancelled pickup returns to STORED")
+	assert_true(after.freeze, "STORED freezes the body")


### PR DESCRIPTION
Step 7.4 of the ball-lifecycle refactor. Stacked on Roosta's `refactor/court-changed-transitions`.

When `stored_balls_in_registry` is true and a STORED Ball is registered for the rack-pressed key, `grab_from_rack` transitions it to OUT_HELD and adopts it as the drag target — same shape as the live-grab path. No HeldBody spawn, no `ball_removed`, same instance survives the gesture.

`_cancel_to_source` and the `attempt_release` rack branch now restore the held Ball to STORED at its rack slot. `RackDropTarget.accept` is a no-op for items not on court, so flag-on rack-origin grabs need explicit restoration on cancel and release-over-rack.

Flag stays false in this PR. Production behaviour unchanged.

Canon: `designs/01-prototype/tech/02-ball-lifecycle.md`.