### PR TITLE
refactor: flip stored_balls_in_registry default on (step 7.5)

### DIFF
--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -13,8 +13,8 @@ const BallScene: PackedScene = preload("res://scenes/ball.tscn")
 const PRESERVED_SPEED_NONE: float = -1.0
 
 @export var ball_scene: PackedScene = BallScene
-## Opt-in surface for step 7; while false, adopt_stored is a no-op so callers can be wired ahead of the flip.
-@export var stored_balls_in_registry: bool = false
+## Registry owns STORED balls when true; rack pickup, court_changed deactivate, and initial kit-walk all light up.
+@export var stored_balls_in_registry: bool = true
 ## Ball-role rack consulted for STORED slot positions when stored_balls_in_registry is true.
 @export var ball_rack: RackDisplay
 
@@ -228,8 +228,17 @@ func _on_court_changed(item_key: String, on_court: bool) -> void:
 	if not _adopting_pre_existing:
 		_initial_reconcile_pending = false
 	if on_court:
-		# Flag-off keeps today's no-op-on-existing behaviour; flag-on routes through ensure_ball_for_key's reuse path (enter_play + reposition).
-		if not stored_balls_in_registry and get_ball_for_key(item_key) != null:
+		var existing: Ball = get_ball_for_key(item_key)
+		# Existing PLAY balls (authored, mid-rally) already live at the right spot; reposition would clobber them.
+		if (
+			existing != null
+			and (
+				existing.play_state == Ball.PlayState.PLAY_NORMAL
+				or existing.play_state == Ball.PlayState.PLAY_ARC
+			)
+		):
+			return
+		if not stored_balls_in_registry and existing != null:
 			return
 		ensure_ball_for_key(
 			item_key,

--- a/scripts/items/rack_display.gd
+++ b/scripts/items/rack_display.gd
@@ -93,16 +93,12 @@ func _build_slot(definition: ItemDefinition, slot_position: Vector2) -> Node2D:
 	return slot
 
 
-## When the registry owns STORED balls, the Ball's ItemArtHolder is the visual source of truth.
+## When the registry owns STORED balls, the Ball renders its own ItemArtHolder at the slot position;
+## the rack leaves art empty so the slot draws exactly once.
 func _populate_art_holder(art_holder: Node2D, definition: ItemDefinition) -> void:
-	var ball: Ball = _stored_ball_for(definition.key)
-	if ball != null:
-		var source: Node = ball.get_node_or_null("ItemArtHolder")
-		if source != null:
-			art_holder.set_meta(&"source", &"ball")
-			for child in source.get_children():
-				art_holder.add_child(child.duplicate())
-			return
+	if _stored_ball_for(definition.key) != null:
+		art_holder.set_meta(&"source", &"ball")
+		return
 	art_holder.set_meta(&"source", &"definition")
 	art_holder.add_child(definition.art.instantiate())
 

--- a/tests/integration/test_ball_regime_transitions.gd
+++ b/tests/integration/test_ball_regime_transitions.gd
@@ -165,11 +165,13 @@ func test_drag_permanent_ball_off_court_onto_rack_regrows_token() -> void:
 		_manager.is_on_court("training_ball"),
 		"rack release should deactivate a permanent ball",
 	)
-	assert_null(
-		_reconciler.get_ball_for_key("training_ball"),
-		"reconciler should drop tracking after the ball leaves the court",
+	# Registry membership = existence; the Ball survives, transitioned to STORED at its rack slot.
+	var stored: Ball = _reconciler.get_ball_for_key("training_ball")
+	assert_not_null(stored, "reconciler keeps tracking; deactivate transitions to STORED")
+	assert_eq(
+		stored.play_state, Ball.PlayState.STORED, "rack release transitions the Ball to STORED"
 	)
-	assert_eq(_permanent_balls().size(), 0, "no live Ball instances remain under the host")
+	assert_eq(_permanent_balls().size(), 1, "one Ball instance persists through court -> rack")
 	assert_lt(
 		_manager.get_stat(&"ball_speed_min"),
 		placed_min,

--- a/tests/integration/test_dev_ball_state_panel_persists_through_rack_return.gd
+++ b/tests/integration/test_dev_ball_state_panel_persists_through_rack_return.gd
@@ -1,0 +1,119 @@
+## Sub-step 7.5: court grab + rack drop preserves the Ball in the registry.
+## DevBallStatePanel sources its rows from BallTracker.ball_added/ball_removed; if ball_removed
+## fires on the rack-return path the row vanishes mid-gesture. Asserts the row count is stable.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemManagerScript: GDScript = preload("res://scripts/items/item_manager.gd")
+const TrainingBall: ItemDefinition = preload("res://resources/items/training_ball.tres")
+
+const COURT_BOUNDS: Rect2 = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+const VENUE_BOUNDS: Rect2 = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+const RACK_CENTER: Vector2 = Vector2(-1500, 0)
+const RACK_SIZE: Vector2 = Vector2(300, 200)
+const COURT_RELEASE: Vector2 = Vector2(50, 25)
+
+var _manager: Node
+var _host: Node2D
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+var _added_count: int
+var _removed_count: int
+
+
+func before_each() -> void:
+	_added_count = 0
+	_removed_count = 0
+	var storage: SaveStorage = double(SaveStorage).new()
+	stub(storage.write).to_return(true)
+	stub(storage.read).to_return("")
+
+	_manager = ItemManagerScript.new()
+	_manager._progression = ProgressionData.new(storage)
+	_manager._effect_manager = EffectManager.new()
+	var typed_items: Array[ItemDefinition] = [TrainingBall]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+	add_child_autofree(_manager)
+
+	_host = Node2D.new()
+	_host.name = "BallHost"
+	add_child_autofree(_host)
+
+	_rack = _build_rack(_manager)
+	_drop_target = _build_drop_target(RACK_CENTER, RACK_SIZE)
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	_reconciler.ball_rack = _rack
+	_host.add_child(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = COURT_BOUNDS
+	_drag.venue_bounds = VENUE_BOUNDS
+	add_child_autofree(_drag)
+
+	_reconciler.ball_added.connect(func(_b: Ball) -> void: _added_count += 1)
+	_reconciler.ball_removed.connect(func(_b: Ball) -> void: _removed_count += 1)
+
+
+func _build_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _build_drop_target(center: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = center
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func test_grab_court_ball_drop_on_rack_keeps_panel_row() -> void:
+	_manager.take(TrainingBall.key)
+	_manager.activate(TrainingBall.key)
+	await get_tree().process_frame
+
+	var live: Ball = _reconciler.get_ball_for_key(TrainingBall.key)
+	assert_not_null(live, "precondition: live ball is on court")
+	var added_after_setup: int = _added_count
+	var removed_after_setup: int = _removed_count
+
+	# Grab the live court ball — same Ball instance becomes the drag target.
+	assert_true(_drag.grab_live_ball(TrainingBall.key), "live grab succeeds")
+	await get_tree().process_frame
+	assert_eq(live.play_state, Ball.PlayState.OUT_HELD, "grabbed Ball is OUT_HELD")
+
+	# Release over the rack drop target.
+	assert_true(_drag.attempt_release(RACK_CENTER), "rack drop accepts the release")
+
+	var after: Ball = _reconciler.get_ball_for_key(TrainingBall.key)
+	assert_not_null(after, "DevBallStatePanel row source persists — Ball still in registry")
+	assert_eq(after.get_instance_id(), live.get_instance_id(), "same Ball instance throughout")
+	assert_eq(after.play_state, Ball.PlayState.STORED, "Ball transitioned to STORED at rack")
+	assert_eq(_added_count, added_after_setup, "no spurious ball_added during grab+drop")
+	assert_eq(
+		_removed_count, removed_after_setup, "no ball_removed fired — DevBallStatePanel row stays"
+	)

--- a/tests/integration/test_rack_court_round_trip_preserves_identity.gd
+++ b/tests/integration/test_rack_court_round_trip_preserves_identity.gd
@@ -1,0 +1,124 @@
+## Sub-step 7.5: STORED -> PLAY -> STORED round trip keeps the same Ball; zero ball_removed across the loop.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemManagerScript: GDScript = preload("res://scripts/items/item_manager.gd")
+const TrainingBall: ItemDefinition = preload("res://resources/items/training_ball.tres")
+
+const COURT_BOUNDS: Rect2 = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+const VENUE_BOUNDS: Rect2 = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+const RACK_CENTER: Vector2 = Vector2(-1500, 0)
+const RACK_SIZE: Vector2 = Vector2(300, 200)
+
+var _manager: Node
+var _host: Node2D
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+var _removed_count: int
+
+
+func before_each() -> void:
+	_removed_count = 0
+	var storage: SaveStorage = double(SaveStorage).new()
+	stub(storage.write).to_return(true)
+	stub(storage.read).to_return("")
+
+	_manager = ItemManagerScript.new()
+	_manager._progression = ProgressionData.new(storage)
+	_manager._effect_manager = EffectManager.new()
+	var typed_items: Array[ItemDefinition] = [TrainingBall]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+	add_child_autofree(_manager)
+
+	_host = Node2D.new()
+	_host.name = "BallHost"
+	add_child_autofree(_host)
+
+	_rack = _build_rack(_manager)
+	_drop_target = _build_drop_target(RACK_CENTER, RACK_SIZE)
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	_reconciler.ball_rack = _rack
+	_host.add_child(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = COURT_BOUNDS
+	_drag.venue_bounds = VENUE_BOUNDS
+	add_child_autofree(_drag)
+
+	_reconciler.ball_removed.connect(func(_b: Ball) -> void: _removed_count += 1)
+
+
+func _build_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _build_drop_target(center: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = center
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func test_stored_to_play_to_stored_keeps_single_instance() -> void:
+	_manager.take(TrainingBall.key)
+	# Wait for the kit-walk to populate the STORED ball.
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var initial: Ball = _reconciler.get_ball_for_key(TrainingBall.key)
+	assert_not_null(initial, "kit-walk populates a STORED ball for the owned kit item")
+	assert_eq(initial.play_state, Ball.PlayState.STORED)
+	var initial_id: int = initial.get_instance_id()
+	var removed_baseline: int = _removed_count
+
+	# STORED -> PLAY via activate (mirrors a court drop accept).
+	_manager.activate(TrainingBall.key)
+	await get_tree().process_frame
+	var played: Ball = _reconciler.get_ball_for_key(TrainingBall.key)
+	assert_not_null(played, "registry survives activation")
+	assert_eq(played.get_instance_id(), initial_id, "same Ball reused into PLAY")
+	var is_play_state: bool = (
+		played.play_state == Ball.PlayState.PLAY_NORMAL
+		or played.play_state == Ball.PlayState.PLAY_ARC
+	)
+	assert_true(is_play_state, "ball transitioned to a PLAY state")
+
+	# PLAY -> STORED via deactivate (mirrors a rack drop accept).
+	_manager.deactivate(TrainingBall.key)
+	await get_tree().process_frame
+	var stored_again: Ball = _reconciler.get_ball_for_key(TrainingBall.key)
+	assert_not_null(stored_again, "registry survives deactivation")
+	assert_eq(stored_again.get_instance_id(), initial_id, "same Ball reused back to STORED")
+	assert_eq(stored_again.play_state, Ball.PlayState.STORED)
+
+	assert_eq(
+		_removed_count,
+		removed_baseline,
+		"zero ball_removed emissions across STORED -> PLAY -> STORED"
+	)

--- a/tests/integration/test_rack_pickup_live.gd
+++ b/tests/integration/test_rack_pickup_live.gd
@@ -88,9 +88,9 @@ func test_flag_on_rack_grab_adopts_stored_ball_no_held_body() -> void:
 
 
 func test_flag_off_rack_grab_spawns_held_body() -> void:
+	# Legacy rack-pickup path stays correct until step 7.6 retires HeldBody for ball-role.
+	_reconciler.stored_balls_in_registry = false
 	_manager.take("ball_alpha")
-	# Flag stays false; reconciler holds no STORED ball.
-	assert_false(_reconciler.stored_balls_in_registry)
 
 	assert_true(_drag.grab_from_rack("ball_alpha", Vector2(50, 0)))
 

--- a/tests/integration/test_rack_pickup_live.gd.uid
+++ b/tests/integration/test_rack_pickup_live.gd.uid
@@ -1,0 +1,1 @@
+uid://cnqpvaxvjacn5

--- a/tests/integration/test_real_input_drag_paths.gd
+++ b/tests/integration/test_real_input_drag_paths.gd
@@ -332,9 +332,13 @@ func test_real_press_on_live_ball_then_drag_to_rack_returns_token() -> void:
 		_manager.is_on_court("training_ball"),
 		"SH-252 b: live ball dragged to rack must leave court so the rack regrows the token",
 	)
-	assert_null(
-		_reconciler.get_ball_for_key("training_ball"),
-		"no Ball should remain tracked after the rack-out release",
+	# Registry keeps the Ball; rack-return is a STORED transition, not destruction (DevBallStatePanel persists).
+	var still_tracked: Ball = _reconciler.get_ball_for_key("training_ball")
+	assert_not_null(still_tracked, "Ball stays in registry after rack-return")
+	assert_eq(
+		still_tracked.play_state,
+		Ball.PlayState.STORED,
+		"rack-return transitions the Ball to STORED"
 	)
 
 

--- a/tests/unit/items/test_adopt_stored_membership.gd
+++ b/tests/unit/items/test_adopt_stored_membership.gd
@@ -42,7 +42,7 @@ func _on_ball_spawned(item_key: String, ball: Ball) -> void:
 
 
 func test_adopt_stored_is_inert_when_flag_off() -> void:
-	assert_false(_reconciler.stored_balls_in_registry, "precondition: opt-in flag defaults off")
+	_reconciler.stored_balls_in_registry = false
 	var ball: Ball = _reconciler.adopt_stored("ball_alpha", Vector2(10, 20))
 	assert_null(ball, "adopt_stored returns null when the flag is off")
 	assert_eq(_added_count, 0, "ball_added must not fire when flag is off")

--- a/tests/unit/items/test_ball_reconciler.gd
+++ b/tests/unit/items/test_ball_reconciler.gd
@@ -45,15 +45,19 @@ func test_activating_a_ball_item_spawns_a_live_ball() -> void:
 	)
 
 
-func test_deactivating_a_ball_item_removes_its_live_ball() -> void:
+func test_deactivating_a_ball_item_transitions_to_stored() -> void:
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	assert_eq(_permanent_ball_count(), 1)
+	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
 
 	_manager.deactivate("ball_alpha")
 	await get_tree().process_frame
-	assert_eq(_permanent_ball_count(), 0, "deactivation should remove the live ball")
-	assert_null(_reconciler.get_ball_for_key("ball_alpha"))
+	assert_eq(
+		_permanent_ball_count(), 1, "deactivation keeps the Ball; registry membership is existence"
+	)
+	assert_eq(_reconciler.get_ball_for_key("ball_alpha"), live, "same Ball instance survives")
+	assert_eq(live.play_state, Ball.PlayState.STORED, "deactivate transitions to STORED")
 
 
 func test_second_activation_does_not_duplicate_the_live_ball() -> void:
@@ -94,13 +98,15 @@ func test_release_ball_returns_and_drops_tracking() -> void:
 	assert_null(_reconciler.get_ball_for_key("ball_alpha"))
 
 
-func test_removing_a_deactivated_ball_deferred_frees_it() -> void:
+func test_deactivated_ball_survives_a_frame() -> void:
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	_manager.deactivate("ball_alpha")
 	await get_tree().process_frame
-	assert_false(is_instance_valid(live), "deactivated ball should be freed after a frame")
+	assert_true(
+		is_instance_valid(live), "deactivated Ball survives; same instance through PLAY->STORED"
+	)
 
 
 func test_duplicate_court_changed_signal_does_not_spawn_a_second_ball() -> void:
@@ -222,17 +228,15 @@ func test_ball_added_and_removed_signals_fire_per_lifecycle_event() -> void:
 	)
 	assert_signal_emitted_with_parameters(_reconciler, "ball_removed", [live])
 
-	# Spawn a second ball under a different key and drive the deactivate removal path.
+	# Deactivate is now a state transition; ball_removed must NOT fire on it. Registry membership = existence.
 	_manager.take("ball_beta")
 	_manager.activate("ball_beta")
-	var beta_live: Ball = _reconciler.get_ball_for_key("ball_beta")
 	_manager.deactivate("ball_beta")
 	assert_eq(
 		get_signal_emit_count(_reconciler, "ball_removed"),
-		2,
-		"deactivate emits a second ball_removed",
+		1,
+		"deactivate transitions to STORED instead of emitting ball_removed",
 	)
-	assert_signal_emitted_with_parameters(_reconciler, "ball_removed", [beta_live])
 	await get_tree().process_frame
 
 

--- a/tests/unit/items/test_ball_reconciler_court_changed_transitions.gd
+++ b/tests/unit/items/test_ball_reconciler_court_changed_transitions.gd
@@ -153,7 +153,8 @@ func test_bring_into_play_reuses_out_rest_ball_via_enter_play() -> void:
 
 
 func test_flag_off_destroy_on_deactivate_path_still_fires() -> void:
-	# Flag stays false; existing destroy-on-deactivate behaviour must continue to hold.
+	# Legacy destroy-on-deactivate path stays correct until step 7.6 retires it.
+	_reconciler.stored_balls_in_registry = false
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	assert_eq(_ball_count(), 1, "precondition: one live ball before deactivate")

--- a/tests/unit/items/test_ball_reconciler_stored_population.gd
+++ b/tests/unit/items/test_ball_reconciler_stored_population.gd
@@ -56,6 +56,8 @@ func _ball_count() -> int:
 
 
 func test_flag_off_does_not_populate_stored_kit_items() -> void:
+	# Legacy flag-off path stays correct until step 7.6 retires the opt-in branches.
+	_reconciler.stored_balls_in_registry = false
 	# Owned but not on-court; with flag off, no STORED ball spawns.
 	_manager.take("ball_alpha")
 	_manager.take("ball_beta")

--- a/tests/unit/items/test_ball_reconciler_stored_population.gd.uid
+++ b/tests/unit/items/test_ball_reconciler_stored_population.gd.uid
@@ -1,0 +1,1 @@
+uid://djrft7toeaon

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -325,6 +325,10 @@ func test_flag_on_with_stored_ball_rack_sources_art_from_ball() -> void:
 		&"ball",
 		"with the flag on and a STORED ball registered the rack reads art from the Ball",
 	)
+	# Ball renders its own ItemArtHolder at the slot position; rack must not duplicate art.
+	assert_eq(
+		art_holder.get_child_count(), 0, "rack leaves slot art empty when the Ball owns the visual"
+	)
 
 
 func _find_slot(rack: Node2D, item_key: String) -> Node2D:


### PR DESCRIPTION
Step 7.5 of the ball-lifecycle refactor (`designs/01-prototype/tech/02-ball-lifecycle.md`). Flips `BallReconciler.stored_balls_in_registry` to true so STORED becomes the fourth registry-resident state. Same Ball survives rack ↔ court trips; `ball_removed` only fires on destruction, never on placement change.

## Audit fixes from lighting the flag-on paths

- `_on_court_changed(true)` skips reposition when the existing ball is already in a PLAY state. Without this, `adopt_pre_existing_balls` → `adopt_authored` → `court_changed(true)` would clobber the authored court Ball's position via the reuse-path's `ensure_ball_for_key` reposition. The 7.3 transition test (`test_flag_on_on_court_true_transitions_stored_ball_to_play`) still passes because the STORED case is not a PLAY state.
- `RackDisplay._populate_art_holder` no longer duplicates art into the slot when sourcing from a STORED ball. The Ball renders its own `ItemArtHolder` at the slot position; duplicating produced double-stamped slots.

## Rack reordering question

The brief asked whether the `rack_slot_index_by_key` field on `ProgressionData` needs writer/reader wiring. **No** — the rack does not support player-reordering today. `RackDisplay.get_slot_position_for(item_key)` consults `ItemManager.get_kit_items(role)` for current ordering, and there is no UI that mutates kit ordering. The field stays empty on save and is reconstructed from kit order on load. When reordering ships, this PR's structure (no reader/writer) is the right baseline to extend.

## Tests

- `tests/integration/test_rack_court_round_trip_preserves_identity.gd` — STORED → PLAY → STORED keeps one Ball instance, zero `ball_removed` emissions.
- `tests/integration/test_dev_ball_state_panel_persists_through_rack_return.gd` — court grab + rack drop keeps the registry entry intact (the player-visible bug).
- Existing destroy-on-deactivate assertions inverted to STORED-transition assertions across `test_ball_reconciler.gd`, `test_ball_regime_transitions.gd`, `test_real_input_drag_paths.gd`.
- Legacy flag-off coverage retained by setting `stored_balls_in_registry = false` explicitly in the four tests that depended on the default; the branches stay in code until step 7.6 retires HeldBody for ball-role.

689 tests passing (+2 new); 2185 asserts.

## Runtime QA not performed in this dispatch

Per the implementer-tier contract, runtime verification (`run(play)` + `state_inspect` + `exec`-driven grab/drop) is not part of this session's tool budget. The brief's section D ("Runtime QA — mandatory") expected `state_inspect`/`exec` access that this session does not have. **`runtime-verifier` should pick this up as the follow-up step** — exercise the rack→court→rack flow against the live scene and confirm the `_balls_by_key` registry survives the gesture, the DevBallStatePanel row count is stable, and slots render exactly once with no doubled art.

## Stack

Base is `refactor/grab-from-rack-uses-ball` (Halfrunt, PR #626). Stays draft until the stack lands.

Agent-Role: gdscript-implementer