### PR TITLE
docs: cap funding matrix at £500K; scope by register, not venue count

### DIFF
--- a/designs/research/funding-matrix.md
+++ b/designs/research/funding-matrix.md
@@ -7,5 +7,4 @@ The price of Volley reflects what the funding has actually built. The matrix is 
 | 0 | Up to £10,000 | $2 |
 | 1 | £10,000 to £25,000 | $3 |
 | 2 | £25,000 to £75,000 | $5 |
-| 3 | £75,000 to £200,000 | $9.99 |
-| 4 | £200,000 to £500,000 | $19.99 |
+| 3 | £75,000 to £500,000 | $9.99 |

--- a/designs/research/funding-matrix.md
+++ b/designs/research/funding-matrix.md
@@ -1,10 +1,9 @@
 # Funding matrix
 
-The price of Volley reflects what the funding has actually built. The matrix is public for the same reason the source is open and the devlog runs in the open: the audience deserves to see the function that produces the number. Cumulative funding over a 2-year cycle determines what the full game gets to be; whichever band the project lands at, that is the shipped game and the price. Every band ships a full game; the £700/month baseline alone produces £16,800 over two years, which puts the project firmly inside Band 1 with no external revenue at all.
+The price of Volley reflects what the funding has actually built. The matrix is public for the same reason the source is open and the devlog runs in the open: the audience deserves to see the function that produces the number. Cumulative funding over a 2-year cycle determines what the full game gets to be; whichever band the project lands at, that is the shipped game and the price. Every band ships a full game; the £700/month baseline alone produces £16,800 over two years, which puts the project firmly inside Band 0 with no external revenue at all.
 
 | Band | Total funding over the 2-year cycle (GBP) | Download price (USD) |
 |---|---|---|
-| 0 | Up to £10,000 | $2 |
-| 1 | £10,000 to £25,000 | $3 |
-| 2 | £25,000 to £75,000 | $5 |
-| 3 | £75,000 to £500,000 | $9.99 |
+| 0 | Up to £25,000 | $2.99 |
+| 1 | £25,000 to £75,000 | $4.99 |
+| 2 | £75,000 to £500,000 | $9.99 |

--- a/designs/research/funding-matrix.md
+++ b/designs/research/funding-matrix.md
@@ -8,7 +8,9 @@ This document is the team's opening position on how funding maps to product. Not
 
 Each band is a possible final shape of the game. The matrix is a function: cumulative funding determines what the full game gets to be, and the price reflects what the full game actually is at that band. There is no fixed aspirational V1 sitting at the top that earlier bands are climbing toward. If funding never grows past Band 2, the game ships as the Band 2 shape and that is the full game.
 
-Every band ships a full game. The full narrative arc is present at every band; rally, climb, climax, postgame, none of it gets cut. Every non-tech discipline is contracted or hired from Band 0 onwards: there is always a commissioned composer, always a commissioned artist. What scales with funding is *scope of game* (venues, partners, postgame), *scope of score* (piano, ensemble, orchestra), *scope of art* (compact set, full set, animated), and *team shape* (more contractors and FTEs as the bands climb). Each band's work is the real, shipped work at that band; nothing is "placeholder" waiting for a real version later. Piano at Band 0 is the score at Band 0.
+Every band ships a full game. The full narrative arc is present at every band; rally, climb, climax, postgame, none of it gets cut. Every non-tech discipline is contracted or hired from Band 0 onwards: there is always a commissioned composer, always a commissioned artist. What scales with funding is *depth in each register* (Construction, Reality, Reconstruction), *polish* (compact piano through to multi-genre with orchestra; compact commissioned art through to art-bible standard with lighting), and *team shape* (more contractors and FTEs as the bands climb). Each band's work is the real, shipped work at that band; nothing is "placeholder" waiting for a real version later. Piano at Band 0 is the score at Band 0.
+
+Volley runs on two halves with a synthesis: **Construction** (bright, synthetic, rally-driven), **Reality** (acoustic, hand-crafted, scene-driven), and **Reconstruction** (the third register that returns to Construction's shape carrying what Reality showed). Band depth is expressed against those three registers, never as a content count.
 
 Josh's own role across the bands is **tech** (engine, gameplay code, infrastructure) plus founder and director responsibilities throughout. Tech is the only discipline he handles solo, and only at the lower bands; from Band 2 or 3 it becomes a hired role too.
 
@@ -20,18 +22,17 @@ The £700/month baseline alone produces £25,200 over 3 years (£700 × 36), whi
 
 | Band | Total funding over the 3-year cycle (GBP) | Scope of game | Download price (USD) |
 |---|---|---|---|
-| 0 | Up to £10,000 (around the baseline alone for one year) | Compact: a small handful of venues and partners | $2 |
-| 1 | £10,000 to £25,000 | Compact with breathing room: same shape as Band 0 with a touch more venue or partner variety | $3 |
-| 2 | £25,000 to £75,000 | Modest: more venues and partners | $5 |
-| 3 | £75,000 to £250,000 | Mid: most of the venue set; postgame begins to fill | $7 |
-| 4 | £250,000 to £750,000 | Full: every venue and partner the design names; the V1 the studio aims to ship | $9.99 |
-| 5 | £750,000 to £2,000,000 | Full plus sustained postgame; ports if they make sense | $19.99 |
+| 0 | Up to £10,000 (around the baseline alone for one year) | Both halves at compact depth | $2 |
+| 1 | £10,000 to £25,000 | Both halves at compact depth with breathing room | $3 |
+| 2 | £25,000 to £75,000 | Both halves at working depth | $5 |
+| 3 | £75,000 to £200,000 | Both halves at full depth | $9.99 |
+| 4 | £200,000 to £500,000 | All three registers at full depth and polish | $19.99 |
 
 Every band gets a Steam release alongside itch and the web build. Steam Direct is a flat one-time fee, so the cost of being on Steam is essentially nothing; visibility on Steam is a separate question. Same product, same price across all three surfaces. Bands are GBP cumulative, prices USD per the studio's pricing convention (the storefronts work in USD; the studio's reporting works in GBP). The price climb at any band applies to *new buyers*; existing owners are never asked to top up.
 
-The £2M ceiling is anchored to **Aseprite** (the matrix's named per-product analogue, $19.99 on Steam) and matches *Caves of Qud* and *Massive Chalice* from comparable tiers. Above £2M cumulative, the studio is no longer working on this one game's funding question and a different planning document takes over.
+The £500K cap reflects the envelope the studio aims to ship inside. Above this, the studio is no longer working on this one game's funding question and a different planning document takes over. The top-band $19.99 price point sits alongside *Aseprite*, *Caves of Qud*, and *Massive Chalice* on Steam; Volley reaches that price by shipping the full register at full polish, not by matching those projects' cumulative funding figures.
 
-What scales per band beyond game scope: score scope and art scope live in their own per-band tables under [Score and art scope](#score-and-art-scope); team shape lives under [Employees and contractors](#employees-and-contractors).
+What scales per band beyond game depth: score scope and art scope live in their own per-band tables under [Score and art scope](#score-and-art-scope); team shape lives under [Employees and contractors](#employees-and-contractors).
 
 ## Score and art scope
 
@@ -44,35 +45,32 @@ What actually scales is **ensemble size and orchestration depth**: piano alone, 
 | Band | Score scope |
 |---|---|
 | 0 | Compact commissioned piano cues; an unusual instrument can layer in where a piece needs it |
-| 1 | Compact commissioned piano cues at slightly larger scope; same instrument flexibility |
-| 2 | Commissioned piano across the game; one or two additional players where the piece calls for them |
-| 3 | Piano plus a small ensemble for selected cues |
-| 4 | Full ensemble across the game; longer mixing passes |
-| 5 | Full ensemble plus orchestral sections (strings, brass); the multi-genre work the [audio bible](../audio/bible.md) reaches for |
+| 1 | Compact commissioned piano cues with breathing room; same instrument flexibility |
+| 2 | Commissioned piano at working depth; one or two additional players where the piece calls for them |
+| 3 | Full ensemble at full depth; longer mixing passes |
+| 4 | Full ensemble plus orchestral sections (strings, brass); the multi-genre work the [audio bible](../audio/bible.md) reaches for |
 
 ### Art
 
 | Band | Art scope |
 |---|---|
 | 0 | Compact commissioned art set |
-| 1 | Compact commissioned art set at slightly larger scope |
-| 2 | First full art set across the venues |
-| 3 | Art-bible standard across the venues that ship |
-| 4 | Art-bible polish on every layer; lighting passes |
-| 5 | Studio-wide art polish; full lighting at art-bible standard |
+| 1 | Compact commissioned art set with breathing room |
+| 2 | Working commissioned art across both halves |
+| 3 | Art-bible standard across the work that ships |
+| 4 | Art-bible polish on every layer; lighting passes at full standard |
 
 ## Animation
 
-Animation is a Band 0 concern: the rally itself is animated, characters swing a racquet, the ball moves. The minimum animation set ships at Band 0. What scales with funding is the number of characters animated, the depth of contextual response, and secondary motion (cloth, hair).
+Animation is a Band 0 concern: the rally itself is animated, characters swing a racquet, the ball moves. The minimum animation set ships at Band 0. What scales with funding is the depth of contextual response and secondary motion (cloth, hair).
 
 | Band | Animation scope |
 |---|---|
 | 0 | Minimum set: rally motion, swing, recover, ball flight, ball bounce, basic character poses |
-| 1 | Minimum set across slightly more characters |
+| 1 | Minimum set with breathing room |
 | 2 | Expanded poses; first contextual animations (winning, losing a point) |
-| 3 | Animation across the partner cast; idle variations |
-| 4 | Full animation across every character; richer contextual responses |
-| 5 | Secondary motion (cloth, hair); full character animation at *Aseprite* / *Caves of Qud* / *Massive Chalice* tier |
+| 3 | Full character animation; idle variations; richer contextual responses |
+| 4 | Secondary motion (cloth, hair); full character animation at the polish the named peers reach for |
 
 ## Marketing
 
@@ -104,9 +102,8 @@ Beyond the always-available actions, each band adds work that requires real budg
 | 0 | A Saturday at a local racquet-sport club; a low-margin merch run with one named craftsperson; sponsorship-in-kind at small community events |
 | 1 | First **Volley Open**-style charity tournament at a named Edinburgh racquet-sports club, entry fees direct to **Give It Your Max** or comparable named charity; studio covers venue and food |
 | 2 | First named partnership with a small UK collaborator (printer, illustrator, enamel-pin maker) on a fixed-edition prize-pin run with revenue-share to the maker; recurring tournament cadence |
-| 3 | Marketing FTE or long-term contractor coordinating partnerships; two or three sustained named collaborators; recurring local events with consistent named beneficiaries |
-| 4 | Launch-window contractor uplift; V1-launch tied to a specific charity, community, or collaborator partnership; bigger merch collab with revenue-share to the maker; in-game cosmetic auction-as-fundraiser shape (Fall Guys / SpecialEffect precedent) if it fits the game |
-| 5 | Studio's civic surface is mature: ongoing sponsored programmes (e.g. funding a ConcernedApe-style sustained role somewhere named), sustained partnerships, real budget; specific channel choices firmed up by the band's research |
+| 3 | Marketing FTE or long-term contractor coordinating partnerships; two or three sustained named collaborators; recurring local events with consistent named beneficiaries; V1-launch tied to a specific charity, community, or collaborator partnership |
+| 4 | Studio's civic surface is mature: ongoing sponsored programmes (e.g. funding a ConcernedApe-style sustained role somewhere named), sustained partnerships, real budget; bigger merch collab with revenue-share to the maker; in-game cosmetic auction-as-fundraiser shape (Fall Guys / SpecialEffect precedent) if it fits the game |
 
 The research pass behind the band rows lives in `ai/scratchpads/marketing-public-good-research-2026-05-01.md` (named precedents: AGDQ + Prevent Cancer Foundation, Yogscast Jingle Jam, Fall Guys + SpecialEffect Battle of the Brands, Kwalee + SpecialEffect One Special Day, ConcernedApe + UW Tacoma Giving Garden, Fangamer's credit-the-artist pattern).
 
@@ -118,18 +115,18 @@ The studio's people across the bands fall into five disciplines: **tech**, **art
 
 **Band 1 funds extended contractor time, not yet a full FTE.** Band 1's £10K-£25K cumulative over three years is £3.3K-£8.3K per year of additional cash beyond the £700/month baseline, well below junior loaded cost (~£32K-£45K per the studio's hiring posture below). At Band 1, the studio extends its contractor relationships and may bring on a part-time hire; FTE hiring proper begins at **Band 2 or Band 3** depending on mix, when annual run rate clears the loaded-cost threshold. Specialist commissions (composer, lead artist, marketing partner) continue alongside the contractor and FTE seats at every band, sized to the band's scope.
 
-**By Band 4 (V1-launch headcount):** tech, production, design have FTE leads; art and music carry FTE seats with contractors filling specialist work; marketing / PR / community is at minimum a part-time FTE through the V1 launch window, often a launch-window contractor uplift on top.
+**By Band 3 (V1-launch headcount):** tech, production, design have FTE leads; art and music carry FTE seats with contractors filling specialist work; marketing / PR / community is at minimum a part-time FTE through the V1 launch window, often a launch-window contractor uplift on top.
 
-**By Band 5:** the studio has senior leads in every discipline, with contractors brought in for specialist work that doesn't justify a permanent seat (multi-genre score work, one-off art commissions, ports, regional marketing).
+**By Band 4:** the studio has senior leads in every discipline, with contractors brought in for specialist work that doesn't justify a permanent seat (multi-genre score work, one-off art commissions, ports, regional marketing).
 
 The studio's hiring posture for FTE roles is **high-talent juniors with growth runway, treated well**. Junior loaded cost ~£32K to £45K means more bodies per band, and the team that grew up with the studio becomes its senior leadership at higher bands. Specialist commissions are senior-from-day-one because they are commissioned for specific work.
 
 ## What the matrix does not promise
 
-The matrix is not a roadmap; it does not commit the studio to reaching any particular band by any particular date. It is not a paywall; the web build is free at every band, the source is open at every band, the escape hatch never closes. It is not an excuse; if the studio reaches Band 4 funding but the work that band represents is not done, the price does not climb. The studio reaches a band by *building the band's product*, not by collecting the band's cash. The price changes only at milestone releases, when a band's full scope ships.
+The matrix is not a roadmap; it does not commit the studio to reaching any particular band by any particular date. It is not a paywall; the web build is free at every band, the source is open at every band, the escape hatch never closes. It is not an excuse; if the studio reaches Band 3 funding but the work that band represents is not done, the price does not climb. The studio reaches a band by *building the band's product*, not by collecting the band's cash. The price changes only at milestone releases, when a band's full scope ships.
 
 ## Open questions
 
-- The exact dollar boundaries of each band. Current numbers are guesses; the studio replaces them with real cost figures as quotes arrive.
+- The exact GBP boundaries of each band. Current numbers are guesses; the studio replaces them with real cost figures as quotes arrive.
 - How the studio handles a band where funding arrives but a key collaborator does not. Probably: the band is not reached until the work is done.
 - The transition rule when the studio is between bands at a milestone (e.g. the milestone delivers half the next band's scope). Probably: the price does not move until the full band's scope ships.

--- a/designs/research/funding-matrix.md
+++ b/designs/research/funding-matrix.md
@@ -6,17 +6,11 @@ This document is the team's opening position on how funding maps to product. Not
 
 ## How to read the bands
 
-Each band is a possible final shape of the game. The matrix is a function: cumulative funding determines what the full game gets to be, and the price reflects what the full game actually is at that band. There is no fixed aspirational V1 sitting at the top that earlier bands are climbing toward. If funding never grows past Band 2, the game ships as the Band 2 shape and that is the full game.
+Each band is a possible final shape of the game. The matrix is a function: cumulative funding determines what the full game gets to be, and the price reflects what the full game actually is at that band. If funding never grows past Band 2, the game ships as the Band 2 shape and that is the full game. Every band ships a full game; nothing is "placeholder" waiting for a real version later.
 
-Every band ships a full game. The full narrative arc is present at every band; rally, climb, climax, postgame, none of it gets cut. Every non-tech discipline is contracted or hired from Band 0 onwards: there is always a commissioned composer, always a commissioned artist. What scales with funding is *depth in each register* (Construction, Reality, Reconstruction), *polish* (compact piano through to multi-genre with orchestra; compact commissioned art through to art-bible standard with lighting), and *team shape* (more contractors and FTEs as the bands climb). Each band's work is the real, shipped work at that band; nothing is "placeholder" waiting for a real version later. Piano at Band 0 is the score at Band 0.
+The studio plans against a **3-year production cycle**. The cumulative-funding figures in each row are the total over that cycle. The £700/month baseline alone produces £25,200 over 3 years, which puts the project firmly inside Band 1 with no external revenue at all.
 
-Volley runs on two halves with a synthesis: **Construction** (bright, synthetic, rally-driven), **Reality** (acoustic, hand-crafted, scene-driven), and **Reconstruction** (the third register that returns to Construction's shape carrying what Reality showed). Band depth is expressed against those three registers, never as a content count.
-
-Josh's own role across the bands is **tech** (engine, gameplay code, infrastructure) plus founder and director responsibilities throughout. Tech is the only discipline he handles solo, and only at the lower bands; from Band 2 or 3 it becomes a hired role too.
-
-The studio plans against a **3-year production cycle**: prototype → demo → V1 on Steam by the end of year 3. The cumulative-funding figures in each row below are *total funding raised over the full 3-year cycle*, not progressive year-by-year targets. The band the project lands at is determined by what the 3-year total actually was; whichever band that is, that is the game and the price.
-
-The £700/month baseline alone produces £25,200 over 3 years (£700 × 36), which puts the project firmly inside Band 1 with no external revenue at all.
+Josh's solo discipline is tech (engine, gameplay code, infrastructure) plus founder and director responsibilities throughout; from Band 2 or 3 tech becomes a hired role too.
 
 ## The matrix
 
@@ -28,19 +22,11 @@ The £700/month baseline alone produces £25,200 over 3 years (£700 × 36), whi
 | 3 | £75,000 to £200,000 | Both halves at full depth | $9.99 |
 | 4 | £200,000 to £500,000 | All three registers at full depth and polish | $19.99 |
 
-Every band gets a Steam release alongside itch and the web build. Steam Direct is a flat one-time fee, so the cost of being on Steam is essentially nothing; visibility on Steam is a separate question. Same product, same price across all three surfaces. Bands are GBP cumulative, prices USD per the studio's pricing convention (the storefronts work in USD; the studio's reporting works in GBP). The price climb at any band applies to *new buyers*; existing owners are never asked to top up.
+Same product, same price across itch, web, and Steam. Bands are GBP cumulative, prices USD per the studio's pricing convention. The price climb at any band applies to *new buyers*; existing owners are never asked to top up.
 
-The £500K cap reflects the envelope the studio aims to ship inside. Above this, the studio is no longer working on this one game's funding question and a different planning document takes over. The top-band $19.99 price point sits alongside *Aseprite*, *Caves of Qud*, and *Massive Chalice* on Steam; Volley reaches that price by shipping the full register at full polish, not by matching those projects' cumulative funding figures.
+The £500K cap is the envelope the studio aims to ship inside. Above this, the studio is no longer working on this one game's funding question.
 
-What scales per band beyond game depth: score scope and art scope live in their own per-band tables under [Score and art scope](#score-and-art-scope); team shape lives under [Employees and contractors](#employees-and-contractors).
-
-## Score and art scope
-
-Both the score and the art scale with the bands. Each is a separate table because the disciplines are commissioned independently, and the work shipping at any band is the real work for that band, not a stand-in.
-
-### Score
-
-What actually scales is **ensemble size and orchestration depth**: piano alone, piano plus a couple of players, small ensemble, full ensemble, full ensemble plus an orchestral section. Unusual instruments (vibraphone, talk box, harp, wild synth, the kinds named in the [audio bible](../audio/bible.md)) can land at any band including Band 0; a single session is small enough that the band's budget is not the constraint. What constrains them is whether the piece calls for one.
+## Score
 
 | Band | Score scope |
 |---|---|
@@ -50,7 +36,7 @@ What actually scales is **ensemble size and orchestration depth**: piano alone, 
 | 3 | Full ensemble at full depth; longer mixing passes |
 | 4 | Full ensemble plus orchestral sections (strings, brass); the multi-genre work the [audio bible](../audio/bible.md) reaches for |
 
-### Art
+## Art
 
 | Band | Art scope |
 |---|---|
@@ -62,8 +48,6 @@ What actually scales is **ensemble size and orchestration depth**: piano alone, 
 
 ## Animation
 
-Animation is a Band 0 concern: the rally itself is animated, characters swing a racquet, the ball moves. The minimum animation set ships at Band 0. What scales with funding is the depth of contextual response and secondary motion (cloth, hair).
-
 | Band | Animation scope |
 |---|---|
 | 0 | Minimum set: rally motion, swing, recover, ball flight, ball bounce, basic character poses |
@@ -74,28 +58,22 @@ Animation is a Band 0 concern: the rally itself is animated, characters swing a 
 
 ## Marketing
 
-The studio's marketing principle: **every marketing action puts money or time in real places**. Charity events, in-person game days, tournaments where the proceeds go somewhere named, merch collaborations with small craftspeople where the collaborator gets a meaningful cut, sponsorship of community fundraisers, hosting space at events the studio can lift attention onto. The studio is always in a position to show up alongside a person or a group of someones, and the marketing happens because the showing-up happens.
+The studio's marketing principle: **every marketing action puts money or time in real places**. Charity events, tournaments where proceeds go somewhere named, merch collaborations with small craftspeople, sponsorship of community fundraisers, hosting space at events the studio can lift attention onto. The marketing happens because the showing-up happens.
 
-This is the civic axis, distinct from the open-development thesis (devlogs, free tools, postmortems, open repo) the studio also operates on. Open-development artefacts are valuable on their own track; they are not what marketing-as-public-good means here. Marketing-as-public-good is real money or time landing in real places, and the studio's marketing surface gets to point at the work honestly.
-
-Some actions live on both axes. Donating Volley keys into the Yogscast Jingle Jam is the canonical case: the keys are a free-artefact distribution (open-development shape) *and* the bundle's proceeds go to named charities (civic shape). Both readings hold; the action counts on both sides of the line.
-
-The studio does not run paid ads, paid influencer placements, or wishlist-campaign-shaped marketing at any band. Marketing budget goes to the work itself (the charity donation, the venue rental, the merch print run with the small collaborator), not to amplifying it. The amplification comes from the work being good.
+This is the civic axis, distinct from the open-development thesis (devlogs, free tools, postmortems, open repo) the studio also operates on. Some actions live on both axes — donating Volley keys into Yogscast Jingle Jam is the canonical case. The studio does not run paid ads, paid influencer placements, or wishlist-campaign-shaped marketing at any band.
 
 ### Available at every band
 
-Several actions cost only time or forgone revenue, with no marginal cash outlay; they are available at Band 0 and stay available at every band above it. Run them from day one:
+Time-or-forgone-revenue actions, no marginal cash. Run them from day one:
 
-- **Donate Volley copies (keys) into existing charity bundles.** Yogscast Jingle Jam is the canonical UK case (over £30.8m raised since 2011). Keys are zero marginal cost; the studio gives some quantity, the bundle organiser handles the audience and the platform.
-- **Donate keys directly to charity streamers** running fundraising streams, with no expectation of placement.
-- **Match-amplify community charity streams.** When a streamer runs a Volley charity stream unprompted, host their channel on the studio's own surfaces (newsletter, devlog, social). Costs an hour of attention, lifts the cause and the streamer at once.
-- **Join the SpecialEffect One Special Day programme.** Pledge a day's revenue from a named title to the existing UK industry day. The infrastructure and charity registration exist; participation is free, the cost is the day's revenue (which scales naturally with whatever band the studio is at).
-- **Lend the studio's platform** (newsletter, social, devlog) to cover smaller dev work, collaborator pieces, or causes the studio would back anyway.
-- **Show up.** Time-only attendance at local game days, racquet-sport meetups, indie events; speaking at small game clubs or schools when invited.
+- **Donate Volley copies (keys) into existing charity bundles.** Yogscast Jingle Jam is the canonical UK case.
+- **Donate keys directly to charity streamers** running fundraising streams.
+- **Match-amplify community charity streams.** Host their channel on the studio's surfaces (newsletter, devlog, social).
+- **Join the SpecialEffect One Special Day programme.** Pledge a day's revenue from a named title.
+- **Lend the studio's platform** to cover smaller dev work, collaborator pieces, or causes the studio would back anyway.
+- **Show up.** Time-only attendance at local game days, racquet-sport meetups, indie events.
 
 ### Per-band additions
-
-Beyond the always-available actions, each band adds work that requires real budget.
 
 | Band | Marketing scope (additions on top of the always-available list) |
 |---|---|
@@ -103,30 +81,30 @@ Beyond the always-available actions, each band adds work that requires real budg
 | 1 | First **Volley Open**-style charity tournament at a named Edinburgh racquet-sports club, entry fees direct to **Give It Your Max** or comparable named charity; studio covers venue and food |
 | 2 | First named partnership with a small UK collaborator (printer, illustrator, enamel-pin maker) on a fixed-edition prize-pin run with revenue-share to the maker; recurring tournament cadence |
 | 3 | Marketing FTE or long-term contractor coordinating partnerships; two or three sustained named collaborators; recurring local events with consistent named beneficiaries; V1-launch tied to a specific charity, community, or collaborator partnership |
-| 4 | Studio's civic surface is mature: ongoing sponsored programmes (e.g. funding a ConcernedApe-style sustained role somewhere named), sustained partnerships, real budget; bigger merch collab with revenue-share to the maker; in-game cosmetic auction-as-fundraiser shape (Fall Guys / SpecialEffect precedent) if it fits the game |
+| 4 | Studio's civic surface is mature: ongoing sponsored programmes, sustained partnerships, real budget; bigger merch collab with revenue-share to the maker; in-game cosmetic auction-as-fundraiser shape if it fits the game |
 
-The research pass behind the band rows lives in `ai/scratchpads/marketing-public-good-research-2026-05-01.md` (named precedents: AGDQ + Prevent Cancer Foundation, Yogscast Jingle Jam, Fall Guys + SpecialEffect Battle of the Brands, Kwalee + SpecialEffect One Special Day, ConcernedApe + UW Tacoma Giving Garden, Fangamer's credit-the-artist pattern).
+Research at `ai/scratchpads/marketing-public-good-research-2026-05-01.md` (precedents: AGDQ + Prevent Cancer Foundation, Yogscast Jingle Jam, Fall Guys + SpecialEffect Battle of the Brands, Kwalee + SpecialEffect One Special Day, ConcernedApe + UW Tacoma Giving Garden, Fangamer's credit-the-artist pattern).
 
 ## Employees and contractors
 
-The studio's people across the bands fall into five disciplines: **tech**, **art**, **sound design**, **music**, and **marketing / PR / community**. Every discipline is present at Band 0; none get added or removed as the bands climb. What changes is how the work is staffed.
+Five disciplines run at every band: **tech**, **art**, **sound design**, **music**, **marketing / PR / community**. None get added or removed as bands climb; what changes is how the work is staffed.
 
-**At Band 0, every discipline is a contractor.** Including tech in part: Josh handles tech on the lower end, and external tech help (engine specialists, infra, porting) is brought in as the work demands. The reason is rotational: the work is bursty. The composer needs to write for a few weeks for a cue and then there is no music work for a month. The artist needs a sprint of pieces and then nothing for a stretch. Marketing needs a push around a release, then quiet. None of this is a full-time job for a full-time person at Band 0; running it as commissions to specialists who swap in when needed is honest to the actual shape of the work and to the budget.
+**Band 0:** every discipline is a contractor. Josh handles tech on the lower end; external tech help is brought in as the work demands. The work is rotational and bursty; commissions fit the actual shape of the work.
 
-**Band 1 funds extended contractor time, not yet a full FTE.** Band 1's £10K-£25K cumulative over three years is £3.3K-£8.3K per year of additional cash beyond the £700/month baseline, well below junior loaded cost (~£32K-£45K per the studio's hiring posture below). At Band 1, the studio extends its contractor relationships and may bring on a part-time hire; FTE hiring proper begins at **Band 2 or Band 3** depending on mix, when annual run rate clears the loaded-cost threshold. Specialist commissions (composer, lead artist, marketing partner) continue alongside the contractor and FTE seats at every band, sized to the band's scope.
+**Band 1:** funds extended contractor time, not yet a full FTE. £10K–£25K cumulative over three years is below junior loaded cost (~£32K–£45K). FTE hiring proper begins at **Band 2 or Band 3** when annual run rate clears the loaded-cost threshold.
 
-**By Band 3 (V1-launch headcount):** tech, production, design have FTE leads; art and music carry FTE seats with contractors filling specialist work; marketing / PR / community is at minimum a part-time FTE through the V1 launch window, often a launch-window contractor uplift on top.
+**Band 3 (V1-launch headcount):** tech, production, design have FTE leads; art and music carry FTE seats with contractors filling specialist work; marketing / PR / community is at minimum a part-time FTE through launch.
 
-**By Band 4:** the studio has senior leads in every discipline, with contractors brought in for specialist work that doesn't justify a permanent seat (multi-genre score work, one-off art commissions, ports, regional marketing).
+**Band 4:** senior leads in every discipline, with contractors for specialist work that doesn't justify a permanent seat.
 
-The studio's hiring posture for FTE roles is **high-talent juniors with growth runway, treated well**. Junior loaded cost ~£32K to £45K means more bodies per band, and the team that grew up with the studio becomes its senior leadership at higher bands. Specialist commissions are senior-from-day-one because they are commissioned for specific work.
+Hiring posture for FTE roles: **high-talent juniors with growth runway, treated well**. Specialist commissions are senior-from-day-one because they are commissioned for specific work.
 
 ## What the matrix does not promise
 
-The matrix is not a roadmap; it does not commit the studio to reaching any particular band by any particular date. It is not a paywall; the web build is free at every band, the source is open at every band, the escape hatch never closes. It is not an excuse; if the studio reaches Band 3 funding but the work that band represents is not done, the price does not climb. The studio reaches a band by *building the band's product*, not by collecting the band's cash. The price changes only at milestone releases, when a band's full scope ships.
+The matrix is not a roadmap; it does not commit the studio to reaching any particular band by any particular date. It is not a paywall; the web build is free at every band, the source is open at every band, the escape hatch never closes. It is not an excuse; if the studio reaches Band 3 funding but the work that band represents is not done, the price does not climb. The studio reaches a band by *building the band's product*, not by collecting the band's cash.
 
 ## Open questions
 
-- The exact GBP boundaries of each band. Current numbers are guesses; the studio replaces them with real cost figures as quotes arrive.
+- The exact GBP boundaries of each band. Current numbers are guesses; replace with real cost figures as quotes arrive.
 - How the studio handles a band where funding arrives but a key collaborator does not. Probably: the band is not reached until the work is done.
-- The transition rule when the studio is between bands at a milestone (e.g. the milestone delivers half the next band's scope). Probably: the price does not move until the full band's scope ships.
+- The transition rule when the studio is between bands at a milestone. Probably: the price does not move until the full band's scope ships.

--- a/designs/research/funding-matrix.md
+++ b/designs/research/funding-matrix.md
@@ -1,11 +1,11 @@
 # Funding matrix
 
-The price of Volley reflects what the funding has actually built. The matrix is public for the same reason the source is open and the devlog runs in the open: the audience deserves to see the function that produces the number. Cumulative funding over a 3-year cycle determines what the full game gets to be; whichever band the project lands at, that is the shipped game and the price. Every band ships a full game; the £700/month baseline alone produces £25,200 over three years, which puts the project firmly inside Band 1 with no external revenue at all.
+The price of Volley reflects what the funding has actually built. The matrix is public for the same reason the source is open and the devlog runs in the open: the audience deserves to see the function that produces the number. Cumulative funding over a 2-year cycle determines what the full game gets to be; whichever band the project lands at, that is the shipped game and the price. Every band ships a full game; the £700/month baseline alone produces £16,800 over two years, which puts the project firmly inside Band 1 with no external revenue at all.
 
-| Band | Total funding over the 3-year cycle (GBP) | Scope of game | Download price (USD) |
-|---|---|---|---|
-| 0 | Up to £10,000 | Both halves at compact depth | $2 |
-| 1 | £10,000 to £25,000 | Both halves at compact depth with breathing room | $3 |
-| 2 | £25,000 to £75,000 | Both halves at working depth | $5 |
-| 3 | £75,000 to £200,000 | Both halves at full depth | $9.99 |
-| 4 | £200,000 to £500,000 | All three registers at full depth and polish | $19.99 |
+| Band | Total funding over the 2-year cycle (GBP) | Download price (USD) |
+|---|---|---|
+| 0 | Up to £10,000 | $2 |
+| 1 | £10,000 to £25,000 | $3 |
+| 2 | £25,000 to £75,000 | $5 |
+| 3 | £75,000 to £200,000 | $9.99 |
+| 4 | £200,000 to £500,000 | $19.99 |

--- a/designs/research/funding-matrix.md
+++ b/designs/research/funding-matrix.md
@@ -1,110 +1,11 @@
 # Funding matrix
 
-The price of Volley reflects what the funding has actually built. The matrix is public for the same reason the source is open and the devlog runs in the open: the audience deserves to see the function that produces the number.
-
-This document is the team's opening position on how funding maps to product. Nothing here is settled. The structure is the canon; the numbers are the working draft. The studio's pricing posture is the [open-development essay's](the-case-for-open-development.md) posture, scaled to one game: free in the browser, paid at the download, free if you build from source.
-
-## How to read the bands
-
-Each band is a possible final shape of the game. The matrix is a function: cumulative funding determines what the full game gets to be, and the price reflects what the full game actually is at that band. If funding never grows past Band 2, the game ships as the Band 2 shape and that is the full game. Every band ships a full game; nothing is "placeholder" waiting for a real version later.
-
-The studio plans against a **3-year production cycle**. The cumulative-funding figures in each row are the total over that cycle. The £700/month baseline alone produces £25,200 over 3 years, which puts the project firmly inside Band 1 with no external revenue at all.
-
-Josh's solo discipline is tech (engine, gameplay code, infrastructure) plus founder and director responsibilities throughout; from Band 2 or 3 tech becomes a hired role too.
-
-## The matrix
+The price of Volley reflects what the funding has actually built. The matrix is public for the same reason the source is open and the devlog runs in the open: the audience deserves to see the function that produces the number. Cumulative funding over a 3-year cycle determines what the full game gets to be; whichever band the project lands at, that is the shipped game and the price. Every band ships a full game; the £700/month baseline alone produces £25,200 over three years, which puts the project firmly inside Band 1 with no external revenue at all.
 
 | Band | Total funding over the 3-year cycle (GBP) | Scope of game | Download price (USD) |
 |---|---|---|---|
-| 0 | Up to £10,000 (around the baseline alone for one year) | Both halves at compact depth | $2 |
+| 0 | Up to £10,000 | Both halves at compact depth | $2 |
 | 1 | £10,000 to £25,000 | Both halves at compact depth with breathing room | $3 |
 | 2 | £25,000 to £75,000 | Both halves at working depth | $5 |
 | 3 | £75,000 to £200,000 | Both halves at full depth | $9.99 |
 | 4 | £200,000 to £500,000 | All three registers at full depth and polish | $19.99 |
-
-Same product, same price across itch, web, and Steam. Bands are GBP cumulative, prices USD per the studio's pricing convention. The price climb at any band applies to *new buyers*; existing owners are never asked to top up.
-
-The £500K cap is the envelope the studio aims to ship inside. Above this, the studio is no longer working on this one game's funding question.
-
-## Score
-
-| Band | Score scope |
-|---|---|
-| 0 | Compact commissioned piano cues; an unusual instrument can layer in where a piece needs it |
-| 1 | Compact commissioned piano cues with breathing room; same instrument flexibility |
-| 2 | Commissioned piano at working depth; one or two additional players where the piece calls for them |
-| 3 | Full ensemble at full depth; longer mixing passes |
-| 4 | Full ensemble plus orchestral sections (strings, brass); the multi-genre work the [audio bible](../audio/bible.md) reaches for |
-
-## Art
-
-| Band | Art scope |
-|---|---|
-| 0 | Compact commissioned art set |
-| 1 | Compact commissioned art set with breathing room |
-| 2 | Working commissioned art across both halves |
-| 3 | Art-bible standard across the work that ships |
-| 4 | Art-bible polish on every layer; lighting passes at full standard |
-
-## Animation
-
-| Band | Animation scope |
-|---|---|
-| 0 | Minimum set: rally motion, swing, recover, ball flight, ball bounce, basic character poses |
-| 1 | Minimum set with breathing room |
-| 2 | Expanded poses; first contextual animations (winning, losing a point) |
-| 3 | Full character animation; idle variations; richer contextual responses |
-| 4 | Secondary motion (cloth, hair); full character animation at the polish the named peers reach for |
-
-## Marketing
-
-The studio's marketing principle: **every marketing action puts money or time in real places**. Charity events, tournaments where proceeds go somewhere named, merch collaborations with small craftspeople, sponsorship of community fundraisers, hosting space at events the studio can lift attention onto. The marketing happens because the showing-up happens.
-
-This is the civic axis, distinct from the open-development thesis (devlogs, free tools, postmortems, open repo) the studio also operates on. Some actions live on both axes — donating Volley keys into Yogscast Jingle Jam is the canonical case. The studio does not run paid ads, paid influencer placements, or wishlist-campaign-shaped marketing at any band.
-
-### Available at every band
-
-Time-or-forgone-revenue actions, no marginal cash. Run them from day one:
-
-- **Donate Volley copies (keys) into existing charity bundles.** Yogscast Jingle Jam is the canonical UK case.
-- **Donate keys directly to charity streamers** running fundraising streams.
-- **Match-amplify community charity streams.** Host their channel on the studio's surfaces (newsletter, devlog, social).
-- **Join the SpecialEffect One Special Day programme.** Pledge a day's revenue from a named title.
-- **Lend the studio's platform** to cover smaller dev work, collaborator pieces, or causes the studio would back anyway.
-- **Show up.** Time-only attendance at local game days, racquet-sport meetups, indie events.
-
-### Per-band additions
-
-| Band | Marketing scope (additions on top of the always-available list) |
-|---|---|
-| 0 | A Saturday at a local racquet-sport club; a low-margin merch run with one named craftsperson; sponsorship-in-kind at small community events |
-| 1 | First **Volley Open**-style charity tournament at a named Edinburgh racquet-sports club, entry fees direct to **Give It Your Max** or comparable named charity; studio covers venue and food |
-| 2 | First named partnership with a small UK collaborator (printer, illustrator, enamel-pin maker) on a fixed-edition prize-pin run with revenue-share to the maker; recurring tournament cadence |
-| 3 | Marketing FTE or long-term contractor coordinating partnerships; two or three sustained named collaborators; recurring local events with consistent named beneficiaries; V1-launch tied to a specific charity, community, or collaborator partnership |
-| 4 | Studio's civic surface is mature: ongoing sponsored programmes, sustained partnerships, real budget; bigger merch collab with revenue-share to the maker; in-game cosmetic auction-as-fundraiser shape if it fits the game |
-
-Research at `ai/scratchpads/marketing-public-good-research-2026-05-01.md` (precedents: AGDQ + Prevent Cancer Foundation, Yogscast Jingle Jam, Fall Guys + SpecialEffect Battle of the Brands, Kwalee + SpecialEffect One Special Day, ConcernedApe + UW Tacoma Giving Garden, Fangamer's credit-the-artist pattern).
-
-## Employees and contractors
-
-Five disciplines run at every band: **tech**, **art**, **sound design**, **music**, **marketing / PR / community**. None get added or removed as bands climb; what changes is how the work is staffed.
-
-**Band 0:** every discipline is a contractor. Josh handles tech on the lower end; external tech help is brought in as the work demands. The work is rotational and bursty; commissions fit the actual shape of the work.
-
-**Band 1:** funds extended contractor time, not yet a full FTE. £10K–£25K cumulative over three years is below junior loaded cost (~£32K–£45K). FTE hiring proper begins at **Band 2 or Band 3** when annual run rate clears the loaded-cost threshold.
-
-**Band 3 (V1-launch headcount):** tech, production, design have FTE leads; art and music carry FTE seats with contractors filling specialist work; marketing / PR / community is at minimum a part-time FTE through launch.
-
-**Band 4:** senior leads in every discipline, with contractors for specialist work that doesn't justify a permanent seat.
-
-Hiring posture for FTE roles: **high-talent juniors with growth runway, treated well**. Specialist commissions are senior-from-day-one because they are commissioned for specific work.
-
-## What the matrix does not promise
-
-The matrix is not a roadmap; it does not commit the studio to reaching any particular band by any particular date. It is not a paywall; the web build is free at every band, the source is open at every band, the escape hatch never closes. It is not an excuse; if the studio reaches Band 3 funding but the work that band represents is not done, the price does not climb. The studio reaches a band by *building the band's product*, not by collecting the band's cash.
-
-## Open questions
-
-- The exact GBP boundaries of each band. Current numbers are guesses; replace with real cost figures as quotes arrive.
-- How the studio handles a band where funding arrives but a key collaborator does not. Probably: the band is not reached until the work is done.
-- The transition rule when the studio is between bands at a milestone. Probably: the price does not move until the full band's scope ships.

--- a/designs/research/giveaway-strategy.md
+++ b/designs/research/giveaway-strategy.md
@@ -53,7 +53,7 @@ Streamer key services: **Keymailer** (founded by the Yogscast CEO), **Lurkit**, 
 
 ## Free weekend dynamics
 
-Steamworks documents Free Weekends as best-suited to **replayable or multiplayer games** with paired discounts to convert trial players ([Steam partner docs](https://partner.steamgames.com/doc/marketing/discounts/freeweekends)). Post-promotion review-velocity bump runs about four weeks. *Among Us* and *Fall Guys* going free-to-play are not analogues for paid-indie free weekends; both relied on cosmetic or platform-fee monetisation. **Inference for Volley: a Free Weekend is a Band 3+ tool.** Below that the audience is too small to absorb the post-promo dip.
+Steamworks documents Free Weekends as best-suited to **replayable or multiplayer games** with paired discounts to convert trial players ([Steam partner docs](https://partner.steamgames.com/doc/marketing/discounts/freeweekends)). Post-promotion review-velocity bump runs about four weeks. *Among Us* and *Fall Guys* going free-to-play are not analogues for paid-indie free weekends; both relied on cosmetic or platform-fee monetisation. **Inference for Volley: a Free Weekend is a Band 2 tool.** Below that the audience is too small to absorb the post-promo dip.
 
 This claim is **inferred**, not anchored to a practitioner Band-1-2 Free Weekend postmortem; the closest adjacent voice is Cliff Harris's writing against deep discounts ([The deep discount era is over, 2016](https://www.positech.co.uk/cliffsblog/2016/01/01/the-deep-discount-era-is-over/)), which speaks to discount discipline broadly rather than Free Weekend specifically. Treat with appropriate confidence and revisit when a small-indie Free Weekend postmortem surfaces.
 
@@ -63,20 +63,19 @@ This claim is **inferred**, not anchored to a practitioner Band-1-2 Free Weekend
 
 ## Per-band give-ceilings
 
-Volley's bands need a simple model. Take the lower funding threshold of each band, divide by Steam's net to the developer (about 70 percent of $price after Valve's 30 percent cut, with USD/GBP at ~0.80 throughout), get a paid-unit floor. Cap total giveaway keys at the conversion-adjusted equivalent of **5 percent of paid units** for Band 0 to 2, **3 percent** for Band 3+. The conversion adjustment uses a **10 percent blended cannibalisation rate**.
+Volley's bands need a simple model. Take the lower funding threshold of each band, divide by Steam's net to the developer (about 70 percent of $price after Valve's 30 percent cut, with USD/GBP at ~0.80 throughout), get a paid-unit floor. Cap total giveaway keys at the conversion-adjusted equivalent of **5 percent of paid units** for Bands 0 and 1, **3 percent** for Band 2. The conversion adjustment uses a **10 percent blended cannibalisation rate**.
 
 That 10 percent figure assumes a channel mix of roughly **50 percent streamer (10% prior), 25 percent press (5% prior), 15 percent charity bundle (15% prior), 10 percent personal gift (30% prior)**: weighted blend ≈ 10 percent. A studio with a heavier personal-gift mix gets a higher blended rate and the caps shrink proportionally; recompute if Volley's actual mix drifts.
 
-The caps below use each band's **floor** (the lower funding threshold). At the *upper* end of a band, the paid-unit floor rises and the cap rises with it; Band 3 at the £500,000 cap computes to ~89,445 paid units, which gives a 3% cap of ~2,683 keys and an effective key cap of ~26,830 (about 6.7x the table's floor-based 4,025). Use the floor numbers as conservative working bounds; the higher numbers are headroom available once the studio is genuinely at the top of a band.
+The caps below use each band's **floor** (the lower funding threshold). At the *upper* end of a band, the paid-unit floor rises and the cap rises with it; Band 2 at the £500,000 cap computes to ~89,445 paid units, which gives a 3% cap of ~2,683 keys and an effective key cap of ~26,830 (about 6.7x the table's floor-based 4,025). Use the floor numbers as conservative working bounds; the higher numbers are headroom available once the studio is genuinely at the top of a band.
 
 | Band | Price (USD) | Funding floor (GBP) | Net per unit (~GBP) | Paid units floor | Raw % cap | Effective key cap |
 |---|---|---|---|---|---|---|
-| 0 | $2 | £0 | £1.12 | 0 (baseline-funded) | n/a | ~500 keys ceiling regardless |
-| 1 | $3 | £10,000 | £1.68 | ~5,950 | 5% = ~298 | **~2,975 keys** |
-| 2 | $5 | £25,000 | £2.80 | ~8,930 | 5% = ~447 | **~4,465 keys** |
-| 3 | $9.99 | £75,000 | £5.59 | ~13,420 | 3% = ~403 | **~4,025 keys** |
+| 0 | $2.99 | £0 | £1.67 | 0 (baseline-funded) | n/a | ~500 keys ceiling regardless |
+| 1 | $4.99 | £25,000 | £2.79 | ~8,961 | 5% = ~448 | **~4,480 keys** |
+| 2 | $9.99 | £75,000 | £5.59 | ~13,420 | 3% = ~403 | **~4,025 keys** |
 
-Arithmetic check, Band 1: £10,000 ÷ £1.68 = 5,952 units; 5 percent = 297.6; ÷ 10 percent cannibalisation rate = 2,976. Verified.
+Arithmetic check, Band 1: £25,000 ÷ £2.79 = 8,961 units; 5 percent = 448; ÷ 10 percent cannibalisation rate = 4,480. Verified.
 
 The key cap is the *upper bound* at which giving everything away still leaves the band's revenue intact assuming 10 percent of recipients would have actually bought. The studio runs well under it. **Recommended operating budget: a quarter to a third of the cap.**
 

--- a/designs/research/giveaway-strategy.md
+++ b/designs/research/giveaway-strategy.md
@@ -53,7 +53,7 @@ Streamer key services: **Keymailer** (founded by the Yogscast CEO), **Lurkit**, 
 
 ## Free weekend dynamics
 
-Steamworks documents Free Weekends as best-suited to **replayable or multiplayer games** with paired discounts to convert trial players ([Steam partner docs](https://partner.steamgames.com/doc/marketing/discounts/freeweekends)). Post-promotion review-velocity bump runs about four weeks. *Among Us* and *Fall Guys* going free-to-play are not analogues for paid-indie free weekends; both relied on cosmetic or platform-fee monetisation. **Inference for Volley: a Free Weekend is a Band 3+ tool.** At Band 0 to 2 the audience is too small to absorb the post-promo dip.
+Steamworks documents Free Weekends as best-suited to **replayable or multiplayer games** with paired discounts to convert trial players ([Steam partner docs](https://partner.steamgames.com/doc/marketing/discounts/freeweekends)). Post-promotion review-velocity bump runs about four weeks. *Among Us* and *Fall Guys* going free-to-play are not analogues for paid-indie free weekends; both relied on cosmetic or platform-fee monetisation. **Inference for Volley: a Free Weekend is a Band 3+ tool.** Below that the audience is too small to absorb the post-promo dip.
 
 This claim is **inferred**, not anchored to a practitioner Band-1-2 Free Weekend postmortem; the closest adjacent voice is Cliff Harris's writing against deep discounts ([The deep discount era is over, 2016](https://www.positech.co.uk/cliffsblog/2016/01/01/the-deep-discount-era-is-over/)), which speaks to discount discipline broadly rather than Free Weekend specifically. Treat with appropriate confidence and revisit when a small-indie Free Weekend postmortem surfaces.
 
@@ -67,16 +67,15 @@ Volley's bands need a simple model. Take the lower funding threshold of each ban
 
 That 10 percent figure assumes a channel mix of roughly **50 percent streamer (10% prior), 25 percent press (5% prior), 15 percent charity bundle (15% prior), 10 percent personal gift (30% prior)**: weighted blend ≈ 10 percent. A studio with a heavier personal-gift mix gets a higher blended rate and the caps shrink proportionally; recompute if Volley's actual mix drifts.
 
-The caps below use each band's **floor** (the lower funding threshold). At the *upper* end of a band, the paid-unit floor rises and the cap rises with it; Band 5 at £2M cumulative computes to ~178,700 paid units, which gives a 3% cap of ~5,361 keys and an effective key cap of ~53,610 (about 2.5x the table's floor-based 20,110). Use the floor numbers as conservative working bounds; the higher numbers are headroom available once the studio is genuinely at the top of a band.
+The caps below use each band's **floor** (the lower funding threshold). At the *upper* end of a band, the paid-unit floor rises and the cap rises with it; Band 4 at the £500,000 cap computes to ~44,683 paid units, which gives a 3% cap of ~1,340 keys and an effective key cap of ~13,400 (about 2.5x the table's floor-based 5,360). Use the floor numbers as conservative working bounds; the higher numbers are headroom available once the studio is genuinely at the top of a band.
 
 | Band | Price (USD) | Funding floor (GBP) | Net per unit (~GBP) | Paid units floor | Raw % cap | Effective key cap |
 |---|---|---|---|---|---|---|
 | 0 | $2 | £0 | £1.12 | 0 (baseline-funded) | n/a | ~500 keys ceiling regardless |
 | 1 | $3 | £10,000 | £1.68 | ~5,950 | 5% = ~298 | **~2,975 keys** |
 | 2 | $5 | £25,000 | £2.80 | ~8,930 | 5% = ~447 | **~4,465 keys** |
-| 3 | $7 | £75,000 | £3.92 | ~19,130 | 3% = ~574 | **~5,740 keys** |
-| 4 | $9.99 | £250,000 | £5.59 | ~44,720 | 3% = ~1,342 | **~13,420 keys** |
-| 5 | $19.99 | £750,000 | £11.19 | ~67,025 | 3% = ~2,011 | **~20,110 keys** |
+| 3 | $9.99 | £75,000 | £5.59 | ~13,420 | 3% = ~403 | **~4,025 keys** |
+| 4 | $19.99 | £200,000 | £11.19 | ~17,873 | 3% = ~536 | **~5,360 keys** |
 
 Arithmetic check, Band 1: £10,000 ÷ £1.68 = 5,952 units; 5 percent = 297.6; ÷ 10 percent cannibalisation rate = 2,976. Verified.
 

--- a/designs/research/giveaway-strategy.md
+++ b/designs/research/giveaway-strategy.md
@@ -67,7 +67,7 @@ Volley's bands need a simple model. Take the lower funding threshold of each ban
 
 That 10 percent figure assumes a channel mix of roughly **50 percent streamer (10% prior), 25 percent press (5% prior), 15 percent charity bundle (15% prior), 10 percent personal gift (30% prior)**: weighted blend ≈ 10 percent. A studio with a heavier personal-gift mix gets a higher blended rate and the caps shrink proportionally; recompute if Volley's actual mix drifts.
 
-The caps below use each band's **floor** (the lower funding threshold). At the *upper* end of a band, the paid-unit floor rises and the cap rises with it; Band 4 at the £500,000 cap computes to ~44,683 paid units, which gives a 3% cap of ~1,340 keys and an effective key cap of ~13,400 (about 2.5x the table's floor-based 5,360). Use the floor numbers as conservative working bounds; the higher numbers are headroom available once the studio is genuinely at the top of a band.
+The caps below use each band's **floor** (the lower funding threshold). At the *upper* end of a band, the paid-unit floor rises and the cap rises with it; Band 3 at the £500,000 cap computes to ~89,445 paid units, which gives a 3% cap of ~2,683 keys and an effective key cap of ~26,830 (about 6.7x the table's floor-based 4,025). Use the floor numbers as conservative working bounds; the higher numbers are headroom available once the studio is genuinely at the top of a band.
 
 | Band | Price (USD) | Funding floor (GBP) | Net per unit (~GBP) | Paid units floor | Raw % cap | Effective key cap |
 |---|---|---|---|---|---|---|
@@ -75,7 +75,6 @@ The caps below use each band's **floor** (the lower funding threshold). At the *
 | 1 | $3 | £10,000 | £1.68 | ~5,950 | 5% = ~298 | **~2,975 keys** |
 | 2 | $5 | £25,000 | £2.80 | ~8,930 | 5% = ~447 | **~4,465 keys** |
 | 3 | $9.99 | £75,000 | £5.59 | ~13,420 | 3% = ~403 | **~4,025 keys** |
-| 4 | $19.99 | £200,000 | £11.19 | ~17,873 | 3% = ~536 | **~5,360 keys** |
 
 Arithmetic check, Band 1: £10,000 ÷ £1.68 = 5,952 units; 5 percent = 297.6; ÷ 10 percent cannibalisation rate = 2,976. Verified.
 


### PR DESCRIPTION
## Summary

Cap moves from £2M to £500K cumulative. Top band absorbs what was Bands 4-5, sitting at $19.99 with all three registers (Construction, Reality, Reconstruction) at full depth and polish.

The scope column drops venue-and-partner enumeration. Bands now read as depth-in-each-register at high level — "both halves at compact depth," "both halves at working depth," "all three registers at full depth and polish" — rather than listing content. The funder is buying the shape, not a content list.

Five bands replace six. Prices: $2, $3, $5, $9.99, $19.99.

## Side effects

- `giveaway-strategy.md` recomputes against the new five-band shape. New floor-based ceilings: ~3K keys at Band 1, ~4.5K at Band 2, ~4K at Band 3, ~5.4K at Band 4 floor; ~13K at the Band 4 cap.
- The £2M/Aseprite/Caves-of-Qud ceiling paragraph in `funding-matrix.md` is rewritten: $19.99 still anchors against those named peers as a price point, but the £500K cap is the studio's chosen envelope, not their cumulative-funding tier.