### PR TITLE
refactor: retire stored_balls_in_registry flag and flag-off branches

### DIFF
--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -211,16 +211,17 @@ func grab_from_rack(item_key: String, press_position: Variant = null) -> bool:
 	)
 
 	var stored: Ball = null
-	if reconciler != null and reconciler.stored_balls_in_registry:
+	if reconciler != null:
 		stored = reconciler.get_ball_for_key(item_key)
 
 	if stored != null:
-		# Flag-on rack pickup: the STORED Ball IS the drag target. No HeldBody spawn; the ball
+		# Ball-role rack pickup: the STORED Ball IS the drag target. No HeldBody spawn; the ball
 		# stays in _balls_by_key, transitioned to OUT_HELD until release.
 		stored.enter_out_held()
 		_set_court_exclude_rids([stored.get_rid()])
 		_adopt_live_ball_as_held(stored, item_key)
 	elif not _spawn_held_body(item_key, spawn_position, false):
+		# Equipment-role rack pickup still rides HeldBody; the shop spawn path retires it in a future step.
 		return false
 
 	_held_was_on_court = false
@@ -239,19 +240,18 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 	if reconciler != null:
 		existing = reconciler.get_ball_for_key(item_key)
 
-	# Temporary balls bypass the reconciler; keep the legacy HeldBody spawn so the gesture
-	# does not survive into a tracked entity.
-	if is_temporary or existing == null:
-		var spawn_position: Vector2 = (
-			existing.global_position if existing != null else _cursor_position()
-		)
-		if not _spawn_held_body(item_key, spawn_position, is_temporary):
+	# Temporary balls bypass the reconciler; spawn a HeldBody so the gesture does not survive into a tracked entity.
+	if is_temporary:
+		if not _spawn_held_body(item_key, _cursor_position(), is_temporary):
 			return false
-		_held_was_on_court = not is_temporary
+		_held_was_on_court = false
 		_held_origin = &"live"
 		_mouse_button_down = true
 		pickup_started.emit(item_key)
 		return true
+
+	if existing == null:
+		return false
 
 	# Live grab: the existing Ball IS the drag target across the whole gesture. No HeldBody spawn,
 	# no queue_free, no ball_removed; the ball stays in _balls_by_key in OUT_HELD state.

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -13,9 +13,7 @@ const BallScene: PackedScene = preload("res://scenes/ball.tscn")
 const PRESERVED_SPEED_NONE: float = -1.0
 
 @export var ball_scene: PackedScene = BallScene
-## Registry owns STORED balls when true; rack pickup, court_changed deactivate, and initial kit-walk all light up.
-@export var stored_balls_in_registry: bool = true
-## Ball-role rack consulted for STORED slot positions when stored_balls_in_registry is true.
+## Ball-role rack consulted for STORED slot positions during initial kit-walk and deactivate transitions.
 @export var ball_rack: RackDisplay
 
 var _item_manager: Node
@@ -173,10 +171,8 @@ func release_into_rest(item_key: String, position: Vector2, velocity: Vector2) -
 	return ball
 
 
-## Spawns a STORED ball at `spawn_position` and registers it under `item_key`. Step 7 flips the opt-in flag and wires production callers.
+## Spawns a STORED ball at `spawn_position` and registers it under `item_key`.
 func adopt_stored(item_key: String, spawn_position: Vector2) -> Ball:
-	if not stored_balls_in_registry:
-		return null
 	var ball: Ball = ball_scene.instantiate()
 	add_child(ball)
 	ball.enter_stored()
@@ -238,8 +234,6 @@ func _on_court_changed(item_key: String, on_court: bool) -> void:
 			)
 		):
 			return
-		if not stored_balls_in_registry and existing != null:
-			return
 		ensure_ball_for_key(
 			item_key,
 			_spawn_position_for(item_key),
@@ -251,16 +245,10 @@ func _on_court_changed(item_key: String, on_court: bool) -> void:
 	if ball == null:
 		return
 
-	if stored_balls_in_registry:
-		# Membership = existence; deactivate becomes a state change, registry entry survives.
-		ball.enter_stored()
-		if ball_rack != null:
-			ball.global_position = ball_rack.get_slot_position_for(item_key)
-		return
-
-	_balls_by_key.erase(item_key)
-	ball_removed.emit(ball)
-	ball.call_deferred("queue_free")
+	# Membership = existence; deactivate becomes a state change, registry entry survives.
+	ball.enter_stored()
+	if ball_rack != null:
+		ball.global_position = ball_rack.get_slot_position_for(item_key)
 
 
 ## One-shot: skipped once any signal-driven court_changed activity has begun.
@@ -275,7 +263,7 @@ func _reconcile_initial_state() -> void:
 					_item_manager.get_default_ball_launch_velocity(),
 				)
 	# STORED kit items are independent of the court-pending flag; court_changed cannot spawn them.
-	if stored_balls_in_registry and not _stored_kit_reconciled:
+	if not _stored_kit_reconciled:
 		_stored_kit_reconciled = true
 		_reconcile_stored_kit_items()
 

--- a/scripts/items/rack_display.gd
+++ b/scripts/items/rack_display.gd
@@ -104,7 +104,7 @@ func _populate_art_holder(art_holder: Node2D, definition: ItemDefinition) -> voi
 
 
 func _stored_ball_for(item_key: String) -> Ball:
-	if reconciler == null or not reconciler.stored_balls_in_registry:
+	if reconciler == null:
 		return null
 	var ball: Ball = reconciler.get_ball_for_key(item_key)
 	if ball == null:

--- a/tests/integration/test_rack_pickup_live.gd
+++ b/tests/integration/test_rack_pickup_live.gd
@@ -1,4 +1,4 @@
-# Step 7.4: flag-on rack pickups grab the STORED Ball directly; no HeldBody spawn.
+# Rack pickups grab the STORED Ball directly; no HeldBody spawn for ball-role.
 # Canon: designs/01-prototype/tech/02-ball-lifecycle.md.
 extends GutTest
 
@@ -66,13 +66,12 @@ func before_each() -> void:
 
 func _seed_stored_ball() -> Ball:
 	_manager.take("ball_alpha")
-	_reconciler.stored_balls_in_registry = true
 	var ball: Ball = _reconciler.adopt_stored("ball_alpha", Vector2(50, 0))
-	assert_not_null(ball, "precondition: adopt_stored returns a Ball when the flag is on")
+	assert_not_null(ball, "precondition: adopt_stored returns a Ball")
 	return ball
 
 
-func test_flag_on_rack_grab_adopts_stored_ball_no_held_body() -> void:
+func test_rack_grab_adopts_stored_ball_no_held_body() -> void:
 	var stored: Ball = _seed_stored_ball()
 
 	var removed_count: int = 0
@@ -80,22 +79,11 @@ func test_flag_on_rack_grab_adopts_stored_ball_no_held_body() -> void:
 
 	assert_true(_drag.grab_from_rack("ball_alpha", Vector2(50, 0)))
 
-	assert_eq(_drag._held_ball, stored, "flag-on rack grab adopts the STORED Ball as held")
-	assert_null(_drag._held_body, "no HeldBody spawn on flag-on rack grab")
+	assert_eq(_drag._held_ball, stored, "rack grab adopts the STORED Ball as held")
+	assert_null(_drag._held_body, "no HeldBody spawn on ball-role rack grab")
 	assert_eq(stored.play_state, Ball.PlayState.OUT_HELD)
 	assert_eq(removed_count, 0, "rack pickup does not emit ball_removed")
 	assert_eq(_reconciler.get_ball_for_key("ball_alpha"), stored, "ball stays in registry")
-
-
-func test_flag_off_rack_grab_spawns_held_body() -> void:
-	# Legacy rack-pickup path stays correct until step 7.6 retires HeldBody for ball-role.
-	_reconciler.stored_balls_in_registry = false
-	_manager.take("ball_alpha")
-
-	assert_true(_drag.grab_from_rack("ball_alpha", Vector2(50, 0)))
-
-	assert_not_null(_drag._held_body, "flag-off rack grab spawns a HeldBody")
-	assert_null(_drag._held_ball, "no Ball adopted when flag is off")
 
 
 func test_rack_grab_release_over_court_transitions_to_play() -> void:

--- a/tests/unit/items/test_adopt_stored_membership.gd
+++ b/tests/unit/items/test_adopt_stored_membership.gd
@@ -1,5 +1,4 @@
-## Step 4 of the ball-lifecycle refactor: stored-surface opt-in.
-## Verifies BallReconciler.adopt_stored honours the stored_balls_in_registry flag.
+## Verifies BallReconciler.adopt_stored spawns and registers a STORED Ball.
 extends GutTest
 
 const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
@@ -41,18 +40,7 @@ func _on_ball_spawned(item_key: String, ball: Ball) -> void:
 	_last_spawned_ball = ball
 
 
-func test_adopt_stored_is_inert_when_flag_off() -> void:
-	_reconciler.stored_balls_in_registry = false
-	var ball: Ball = _reconciler.adopt_stored("ball_alpha", Vector2(10, 20))
-	assert_null(ball, "adopt_stored returns null when the flag is off")
-	assert_eq(_added_count, 0, "ball_added must not fire when flag is off")
-	assert_eq(_spawned_count, 0, "ball_spawned must not fire when flag is off")
-	assert_null(_reconciler.get_ball_for_key("ball_alpha"), "no registry entry when flag is off")
-
-
-func test_adopt_stored_spawns_and_registers_when_flag_on() -> void:
-	_reconciler.stored_balls_in_registry = true
-
+func test_adopt_stored_spawns_and_registers() -> void:
 	var ball: Ball = _reconciler.adopt_stored("ball_alpha", Vector2(10, 20))
 	assert_not_null(ball, "adopt_stored returns the spawned ball when flag is on")
 	assert_eq(ball.get_parent(), _reconciler, "spawned ball parented to the reconciler")

--- a/tests/unit/items/test_ball_reconciler_court_changed_transitions.gd
+++ b/tests/unit/items/test_ball_reconciler_court_changed_transitions.gd
@@ -1,4 +1,4 @@
-## SH-374 step 7.3: court_changed transitions instead of destroying when stored_balls_in_registry is on.
+## court_changed transitions a registry ball between STORED and PLAY states; the entry survives deactivate.
 extends GutTest
 
 const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
@@ -63,7 +63,6 @@ func _ball_count() -> int:
 
 
 func test_flag_on_on_court_true_transitions_stored_ball_to_play() -> void:
-	_reconciler.stored_balls_in_registry = true
 	_manager.take("ball_alpha")
 	await get_tree().process_frame
 
@@ -85,7 +84,6 @@ func test_flag_on_on_court_true_transitions_stored_ball_to_play() -> void:
 
 
 func test_flag_on_on_court_false_transitions_play_ball_to_stored() -> void:
-	_reconciler.stored_balls_in_registry = true
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	await get_tree().process_frame
@@ -112,7 +110,6 @@ func test_flag_on_on_court_false_transitions_play_ball_to_stored() -> void:
 
 
 func test_flag_on_round_trip_stored_play_stored_keeps_single_instance() -> void:
-	_reconciler.stored_balls_in_registry = true
 	_manager.take("ball_alpha")
 	await get_tree().process_frame
 	var instance_id := _reconciler.get_ball_for_key("ball_alpha").get_instance_id()
@@ -135,7 +132,6 @@ func test_flag_on_round_trip_stored_play_stored_keeps_single_instance() -> void:
 
 
 func test_bring_into_play_reuses_out_rest_ball_via_enter_play() -> void:
-	_reconciler.stored_balls_in_registry = true
 	_manager.take("ball_alpha")
 	await get_tree().process_frame
 	# Start at rest so reuse must transition; release_into_rest lands an OUT_REST Ball under the same key.
@@ -150,18 +146,3 @@ func test_bring_into_play_reuses_out_rest_ball_via_enter_play() -> void:
 		or played.play_state == Ball.PlayState.PLAY_ARC
 	)
 	assert_true(is_play_state, "reuse path runs enter_play, leaving a PLAY state")
-
-
-func test_flag_off_destroy_on_deactivate_path_still_fires() -> void:
-	# Legacy destroy-on-deactivate path stays correct until step 7.6 retires it.
-	_reconciler.stored_balls_in_registry = false
-	_manager.take("ball_alpha")
-	_manager.activate("ball_alpha")
-	assert_eq(_ball_count(), 1, "precondition: one live ball before deactivate")
-
-	_manager.deactivate("ball_alpha")
-	await get_tree().process_frame
-
-	assert_eq(_ball_count(), 0, "flag-off path still destroys on deactivate")
-	assert_null(_reconciler.get_ball_for_key("ball_alpha"))
-	assert_eq(_ball_removed_count, 1, "ball_removed still fires on flag-off destroy")

--- a/tests/unit/items/test_ball_reconciler_stored_population.gd
+++ b/tests/unit/items/test_ball_reconciler_stored_population.gd
@@ -55,18 +55,7 @@ func _ball_count() -> int:
 	return count
 
 
-func test_flag_off_does_not_populate_stored_kit_items() -> void:
-	# Legacy flag-off path stays correct until step 7.6 retires the opt-in branches.
-	_reconciler.stored_balls_in_registry = false
-	# Owned but not on-court; with flag off, no STORED ball spawns.
-	_manager.take("ball_alpha")
-	_manager.take("ball_beta")
-	await get_tree().process_frame
-	assert_eq(_ball_count(), 0, "flag off keeps stored-population dormant")
-
-
-func test_flag_on_populates_stored_balls_for_kit_ball_items() -> void:
-	_reconciler.stored_balls_in_registry = true
+func test_populates_stored_balls_for_kit_ball_items() -> void:
 	_manager.take("ball_alpha")
 	_manager.take("ball_beta")
 	await get_tree().process_frame
@@ -87,7 +76,6 @@ func test_flag_on_populates_stored_balls_for_kit_ball_items() -> void:
 
 
 func test_mixed_kit_and_court_population_uses_both_branches() -> void:
-	_reconciler.stored_balls_in_registry = true
 	_manager.take("ball_alpha")
 	_manager.take("ball_beta")
 	# Drive ball_alpha onto the court; the existing court branch handles it, kit branch handles ball_beta.
@@ -107,7 +95,6 @@ func test_mixed_kit_and_court_population_uses_both_branches() -> void:
 
 
 func test_collect_item_positions_skips_stored_balls() -> void:
-	_reconciler.stored_balls_in_registry = true
 	_manager.take("ball_alpha")
 	_manager.take("ball_beta")
 	_manager.activate("ball_alpha")

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -286,36 +286,16 @@ func _make_rack_with_reconciler(
 	return rack
 
 
-func test_flag_off_rack_sources_art_from_definition() -> void:
-	var ball := _make_item("ball_alpha", &"ball")
-	var manager: Node = _make_manager_with([ball])
-	manager._progression.friendship_point_balance = 1000
-	var reconciler: BallReconciler = _make_reconciler(manager)
-	reconciler.stored_balls_in_registry = false
-	var rack: Node2D = _make_rack_with_reconciler(&"ball", manager, reconciler)
-	manager.take(ball.key)
-
-	var slot: Node2D = _find_slot(rack, ball.key)
-	assert_not_null(slot, "slot was rendered")
-	var art_holder: Node2D = slot.get_node("ArtHolder")
-	assert_eq(
-		art_holder.get_meta(&"source", ""),
-		&"definition",
-		"with the flag off the rack sources art from the ItemDefinition",
-	)
-
-
-func test_flag_on_with_stored_ball_rack_sources_art_from_ball() -> void:
+func test_rack_with_stored_ball_sources_art_from_ball() -> void:
 	var ball_item := _make_item("ball_alpha", &"ball")
 	var manager: Node = _make_manager_with([ball_item])
 	manager._progression.friendship_point_balance = 1000
 	var reconciler: BallReconciler = _make_reconciler(manager)
-	reconciler.stored_balls_in_registry = true
 	var rack: Node2D = _make_rack_with_reconciler(&"ball", manager, reconciler)
 	manager.take(ball_item.key)
 	# adopt_stored registers a STORED Ball under the key; rack picks it up via ball_spawned.
 	var stored: Ball = reconciler.adopt_stored(ball_item.key, Vector2.ZERO)
-	assert_not_null(stored, "adopt_stored returns a Ball when the flag is on")
+	assert_not_null(stored, "adopt_stored returns a Ball")
 
 	var slot: Node2D = _find_slot(rack, ball_item.key)
 	assert_not_null(slot, "slot was rendered")
@@ -323,7 +303,7 @@ func test_flag_on_with_stored_ball_rack_sources_art_from_ball() -> void:
 	assert_eq(
 		art_holder.get_meta(&"source", ""),
 		&"ball",
-		"with the flag on and a STORED ball registered the rack reads art from the Ball",
+		"the rack reads art from the STORED Ball when one is registered",
 	)
 	# Ball renders its own ItemArtHolder at the slot position; rack must not duplicate art.
 	assert_eq(


### PR DESCRIPTION
Final step (7.6) of the ball-lifecycle refactor stack. The flag flipped on in 7.5, so the flag-off branches are now dead code: drop the `@export var stored_balls_in_registry`, the flag-off destroy-on-deactivate path in `BallReconciler._on_court_changed`, the inert-when-off guard in `adopt_stored`, and the rack/drag-controller flag reads. The temporary-ball branch in `grab_live_ball` tightens to `is_temporary` only — permanent ball-role items always have a registry entry now, so the `existing == null` co-condition retires too.

`HeldBody` stays alive for equipment-role rack pickup and the shop's loose-body spawn; nothing in this PR touches that surface.

Stacked on `refactor/flip-stored-in-registry` (Zaphod's 7.5); merges to that base, not main. Draft until the stack lands.