### PR TITLE
refactor: route ball-role shop purchases into the BallReconciler registry

### DIFF
--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -297,16 +297,26 @@ func spawn_purchased_at(
 		target.accept(item_key, world_position, gesture_velocity)
 		return true
 	if target is VenueDropTarget:
-		# Ball-role venue releases lift the entity into the registry as OUT_REST; equipment keeps the
-		# legacy HeldBody loose path until step 7 unifies it.
 		if _is_ball_role(item_key):
 			_release_to_rest(item_key, world_position, gesture_velocity, false)
 		else:
 			_release_loose_body_at(item_key, world_position, gesture_velocity)
 		return true
-	# Rack/shop targets accept by activating; the ball reconciler handles the live spawn.
+	if target is RackDropTarget and _is_ball_role(item_key):
+		# Ball-role rack landing adopts a STORED Ball at the slot; rack accept's deactivate branch
+		# is a no-op for a just-purchased, not-on-court item.
+		_adopt_purchased_into_rack(item_key)
+		return true
 	target.accept(item_key, world_position, gesture_velocity)
 	return true
+
+
+func _adopt_purchased_into_rack(item_key: String) -> void:
+	if reconciler == null or rack == null:
+		return
+	if reconciler.get_ball_for_key(item_key) != null:
+		return
+	reconciler.adopt_stored(item_key, rack.get_slot_position_for(item_key))
 
 
 ## Step 5: ball-role venue-floor releases funnel here. Equipment retains the HeldBody path until step 7.

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -203,35 +203,68 @@ func _drag_controller() -> Node:
 	return tree.get_first_node_in_group(&"drag_controller")
 
 
-## Drops a HeldBody that falls under gravity; the body's settled position decides purchase vs refund.
+## Drops a falling body for the inside-shop or fallthrough case; ball-role lands as a registry Ball
+## in OUT_REST, equipment keeps the HeldBody loose path.
 func _drop_falling_body(release_position: Vector2) -> void:
 	if item_definition == null:
 		return
+	var controller: Node = _drag_controller()
+	var clamped_position: Vector2 = _clamp_release_into_venue(release_position, controller)
+	if _is_ball_role():
+		_drop_ball_role(clamped_position, controller)
+		return
+	_drop_equipment_body(clamped_position, controller)
+
+
+func _is_ball_role() -> bool:
+	return item_definition != null and item_definition.role == &"ball"
+
+
+func _clamp_release_into_venue(release_position: Vector2, controller: Node) -> Vector2:
+	if controller == null or not ("venue_bounds" in controller):
+		return release_position
+	var bounds: Rect2 = controller.venue_bounds
+	if bounds.size == Vector2.ZERO:
+		return release_position
+	return DropTarget.clamp_to_rect(release_position, bounds)
+
+
+func _drop_equipment_body(clamped_position: Vector2, controller: Node) -> void:
 	var body: HeldBody = HeldBody.make_for(item_definition, item_definition.key)
 	if body == null:
 		return
-	var controller: Node = _drag_controller()
-	# Host under the controller's venue-scoped node so the body survives shop-scene teardown mid-flight.
 	var host: Node = _scene_host()
-	var clamped_position: Vector2 = release_position
-	if controller != null:
-		if controller.has_method("get_loose_body_host"):
-			var resolved: Node = controller.get_loose_body_host()
-			if resolved != null:
-				host = resolved
-		# Clamp into the venue so a body cannot fall into off-screen void.
-		if "venue_bounds" in controller:
-			var bounds: Rect2 = controller.venue_bounds
-			if bounds.size != Vector2.ZERO:
-				clamped_position = DropTarget.clamp_to_rect(release_position, bounds)
+	if controller != null and controller.has_method("get_loose_body_host"):
+		var resolved: Node = controller.get_loose_body_host()
+		if resolved != null:
+			host = resolved
 	body.global_position = clamped_position
 	host.add_child(body)
 	body.go_loose(_release_velocity())
-	# Subscribe controller for re-grab so the dropped body acts like any other loose body.
 	if controller != null and controller.has_method("track_loose_body"):
 		controller.track_loose_body(body)
-	# Defer the settle watch so the body has a frame to acquire its first velocity sample.
 	_watch_for_settle(body)
+
+
+## Spawns the Ball directly in OUT_REST via the reconciler; if it settles inside-shop the Ball is
+## torn down for refund, otherwise the purchase commits and the Ball stays in the registry.
+func _drop_ball_role(clamped_position: Vector2, controller: Node) -> void:
+	var reconciler: Node = _resolve_reconciler(controller)
+	if reconciler == null:
+		# No reconciler reachable (test isolation, broken venue): bail without leaking a HeldBody.
+		return
+	var ball: Ball = reconciler.release_into_rest(
+		item_definition.key, clamped_position, _release_velocity()
+	)
+	if ball == null:
+		return
+	_watch_for_settle(ball)
+
+
+func _resolve_reconciler(controller: Node) -> Node:
+	if controller != null and "reconciler" in controller and controller.reconciler != null:
+		return controller.reconciler
+	return null
 
 
 func _scene_host() -> Node:
@@ -241,7 +274,7 @@ func _scene_host() -> Node:
 	return get_tree().root
 
 
-func _watch_for_settle(body: HeldBody) -> void:
+func _watch_for_settle(body: RigidBody2D) -> void:
 	# Poll until the body's velocity falls below a settle threshold or it is freed.
 	# Use load() so the class-name cache (which can be async-stale) doesn't mismatch path-based lookups.
 	var drop: Node = load("res://scripts/shop/shop_item_drop.gd").new()
@@ -251,12 +284,16 @@ func _watch_for_settle(body: HeldBody) -> void:
 
 
 ## Called by ShopItemDrop with the body's resting position once velocity has settled.
-func notify_body_settled(body: HeldBody, settled_position: Vector2) -> void:
+func notify_body_settled(body: RigidBody2D, settled_position: Vector2) -> void:
 	if item_definition == null:
 		if is_instance_valid(body):
 			body.queue_free()
 		return
 	if not is_instance_valid(body):
+		return
+
+	if body is Ball:
+		_notify_ball_settled(body, settled_position)
 		return
 
 	if _is_position_inside_shop(settled_position):
@@ -278,6 +315,36 @@ func notify_body_settled(body: HeldBody, settled_position: Vector2) -> void:
 	if controller != null and controller.has_method("register_loose_body"):
 		controller.register_loose_body(body)
 	drop_completed.emit(item_definition.key, settled_position, true)
+
+
+## Ball-role settle: registry-resident Ball is either kept (purchase commits) or released (refund).
+func _notify_ball_settled(ball: Ball, settled_position: Vector2) -> void:
+	var controller: Node = _drag_controller()
+	var reconciler: Node = _resolve_reconciler(controller)
+
+	if _is_position_inside_shop(settled_position):
+		_release_ball_from_registry(reconciler, ball)
+		visible = true
+		return
+
+	if not is_owned():
+		if not _complete_purchase():
+			_release_ball_from_registry(reconciler, ball)
+			visible = true
+			return
+
+	visible = false
+	# Mark as loose-in-venue so the rack filter hides the slot while the Ball rests on the venue floor.
+	if _item_manager != null and _item_manager.has_method("mark_loose_in_venue"):
+		_item_manager.mark_loose_in_venue(item_definition.key)
+	drop_completed.emit(item_definition.key, settled_position, true)
+
+
+func _release_ball_from_registry(reconciler: Node, ball: Ball) -> void:
+	if reconciler != null and reconciler.has_method("release_ball"):
+		reconciler.release_ball(item_definition.key)
+	if is_instance_valid(ball):
+		ball.queue_free()
 
 
 func _release_velocity() -> Vector2:

--- a/scripts/shop/shop_item_drop.gd
+++ b/scripts/shop/shop_item_drop.gd
@@ -1,17 +1,18 @@
 class_name ShopItemDrop
 extends Node
 
-## A drop in progress: rides the falling HeldBody, settles on rest, notifies the originating ShopItem.
+## A drop in progress: rides the falling body, settles on rest, notifies the originating ShopItem.
+## Body is RigidBody2D (HeldBody for equipment, Ball for ball-role).
 
 @export var tuning: ShopDragTuning
 
-var _body: HeldBody
+var _body: RigidBody2D
 var _shop_item: Object
 var _slow_frames: int = 0
 var _elapsed: float = 0.0
 
 
-func configure(body: HeldBody, shop_item: Object) -> void:
+func configure(body: RigidBody2D, shop_item: Object) -> void:
 	_body = body
 	_shop_item = shop_item
 

--- a/tests/integration/test_shop_drag_drop.gd
+++ b/tests/integration/test_shop_drag_drop.gd
@@ -269,8 +269,9 @@ func test_shop_to_court_release_spawns_ball_at_release_position() -> void:
 	assert_eq(ball.global_position, court_release, "live ball lands at the released cursor point")
 
 
-func test_shop_release_outside_court_falls_through_to_rack_default() -> void:
-	# Outside the venue rejects every target; rack regrows via the court_changed path.
+func test_shop_release_outside_court_spawns_ball_in_registry_via_falling_body() -> void:
+	# Outside the venue rejects every drop target; the ball-role fallthrough drops a Ball directly
+	# into the registry (OUT_REST) via release_into_rest instead of the retired HeldBody loose path.
 	_item_manager.items.assign([TrainingBall] as Array[ItemDefinition])
 	_shop.queue_free()
 	await get_tree().process_frame
@@ -296,10 +297,10 @@ func test_shop_release_outside_court_falls_through_to_rack_default() -> void:
 	item.start_drag()
 	item.attempt_release(Vector2(99999, 99999))
 
-	assert_eq(_item_manager.get_level("training_ball"), 1, "purchase still committed")
-	assert_null(
+	# Purchase commits inside notify_body_settled, not at release; only the registry Ball must exist now.
+	assert_not_null(
 		reconciler.get_ball_for_key("training_ball"),
-		"far-outside release falls through to the rack-default path, not court spawn",
+		"ball-role fallthrough lands a registry Ball, not a HeldBody",
 	)
 
 

--- a/tests/integration/test_shop_purchase_lands_ball_in_registry.gd
+++ b/tests/integration/test_shop_purchase_lands_ball_in_registry.gd
@@ -1,0 +1,156 @@
+## Step 7.7: shop purchases route ball-role items into the BallReconciler registry directly.
+## Three destinations are exercised: rack -> STORED, court -> PLAY, venue floor -> OUT_REST.
+## Equipment-role purchases keep their existing HeldBody loose-body path (regression).
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _rack: RackDisplay
+var _rack_drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+
+
+func _make_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _make_area(position: Vector2, size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_def: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var equipment_def: ItemDefinition = ItemFactory.create(
+		"gear_alpha", &"paddle_speed", &"add", 10.0
+	)
+	# Default ItemFactory.create leaves role unset; explicit empty (not ball) routes to the loose-body path.
+	equipment_def.role = &""
+	# HeldBody.make_for refuses items with no at_rest_shape; equipment needs one for the loose-body lane.
+	var gear_shape := CircleShape2D.new()
+	gear_shape.radius = 7.2
+	equipment_def.at_rest_shape = gear_shape
+	var typed_items: Array[ItemDefinition] = [ball_def, equipment_def]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_rack = _make_rack(_manager)
+	# Rack drop area at -1000,0 with a 300x200 footprint; comfortably away from court/venue.
+	_rack_drop_target = _make_area(Vector2(-1000, 0), Vector2(300, 200))
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	_reconciler.ball_rack = _rack
+	add_child_autofree(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _rack_drop_target, _reconciler)
+	_drag.court_bounds = Rect2(Vector2(-100, -100), Vector2(200, 200))
+	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	add_child_autofree(_drag)
+	await get_tree().process_frame
+
+
+func _free_any_initial_balls() -> void:
+	# _reconcile_stored_kit_items adopts kit balls on first frame; clear them so each AC starts
+	# from a known empty registry.
+	for key in _manager.get_kit_items(&"ball"):
+		var ball: Ball = _reconciler.get_ball_for_key(key)
+		if ball != null:
+			_reconciler.release_ball(key)
+			ball.queue_free()
+	await get_tree().process_frame
+
+
+# --- Ball-role purchase destinations ----------------------------------------------------------
+
+
+func test_ball_role_purchase_over_rack_lands_in_registry_as_stored() -> void:
+	await _free_any_initial_balls()
+	# Position lands inside the rack drop area (centered on -1000,0).
+	var release_at: Vector2 = Vector2(-1000, 0)
+	var spawned: bool = _drag.spawn_purchased_at("ball_alpha", release_at, Vector2.ZERO)
+	assert_true(spawned, "rack drop target accepts ball-role purchase")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "purchase over rack adopts a STORED Ball into the registry")
+	assert_eq(
+		ball.play_state, Ball.PlayState.STORED, "rack-landed purchase enters STORED, not PLAY"
+	)
+
+
+func test_ball_role_purchase_over_court_lands_in_registry_as_play() -> void:
+	await _free_any_initial_balls()
+	# Centre of the court rect: -100,-100 size 200x200 -> centre at 0,0.
+	var release_at: Vector2 = Vector2(0, 0)
+	var spawned: bool = _drag.spawn_purchased_at("ball_alpha", release_at, Vector2(120, 0))
+	assert_true(spawned, "court drop target accepts ball-role purchase")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "purchase over court spawns a registry Ball")
+	var in_play: bool = (
+		ball.play_state == Ball.PlayState.PLAY_NORMAL or ball.play_state == Ball.PlayState.PLAY_ARC
+	)
+	assert_true(in_play, "court-landed purchase enters PLAY (NORMAL or ARC)")
+
+
+func test_ball_role_purchase_over_venue_floor_lands_in_registry_as_out_rest() -> void:
+	await _free_any_initial_balls()
+	# Inside venue but outside court and outside the rack drop area: clearly venue-floor.
+	var release_at: Vector2 = Vector2(800, 500)
+	var spawned: bool = _drag.spawn_purchased_at("ball_alpha", release_at, Vector2(50, 0))
+	assert_true(spawned, "venue drop target accepts ball-role purchase")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "purchase over venue floor lifts a registry Ball")
+	assert_eq(
+		ball.play_state,
+		Ball.PlayState.OUT_REST,
+		"venue-landed purchase enters OUT_REST, not PLAY or STORED",
+	)
+
+
+# --- Equipment-role regression ---------------------------------------------------------------
+
+
+func test_equipment_role_purchase_over_venue_still_spawns_held_body() -> void:
+	# Equipment retains the legacy HeldBody loose-body lane until a separate equipment-role rework.
+	await _free_any_initial_balls()
+	var release_at: Vector2 = Vector2(800, 500)
+	var spawned: bool = _drag.spawn_purchased_at("gear_alpha", release_at, Vector2.ZERO)
+	assert_true(spawned, "venue drop target accepts equipment-role purchase")
+	# Find a HeldBody under the reconciler's loose-body host (parent of the loose lane).
+	var host: Node = _drag.get_loose_body_host()
+	var found: HeldBody = null
+	for child in host.get_children():
+		if child is HeldBody and (child as HeldBody).item_key == "gear_alpha":
+			found = child
+			break
+	assert_not_null(found, "equipment-role venue purchase still spawns a HeldBody loose body")
+	assert_null(
+		_reconciler.get_ball_for_key("gear_alpha"),
+		"equipment never enters the BallReconciler registry",
+	)


### PR DESCRIPTION
Sub-step 7.7 of the ball-lifecycle refactor. Shop's `spawn_purchased_at` gains a ball-role rack-target branch that adopts a STORED Ball at the slot, and `_drop_falling_body` for ball-role spawns the Ball directly via `release_into_rest` so the falling visual IS the registry entity. Equipment-role keeps the legacy `HeldBody` loose-body lane.

Locks in the lifecycle invariant for shop spawns: one Ball instance per ball-role item, regardless of where the purchase lands.

Draft until 7.7's sibling work in the SH-366 stack settles.