### PR TITLE
fix(items): SH-366 battle follow-ups on ball drag and reconciler

### DIFF
--- a/scripts/items/ball_drag_controller.gd
+++ b/scripts/items/ball_drag_controller.gd
@@ -53,8 +53,7 @@ var _grab_target_scale: Vector2 = Vector2.ONE
 var _cursor_state: int = CursorStateScript.State.DEFAULT
 ## Negative means expansion-ring polling has not started timing yet.
 var _expansion_started_at: float = -1.0
-## True after a real player mouse-up while no drop target accepted; the gesture stays alive
-## following the cursor until the player drags to a valid drop position. Never auto-cancels.
+## True after a real player mouse-up while no drop target accepted; the gesture stays alive following the cursor.
 var _release_pending: bool = false
 
 var _drop_targets: Array[DropTarget] = []
@@ -255,6 +254,8 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 
 	# Live grab: the existing Ball IS the drag target across the whole gesture. No HeldBody spawn,
 	# no queue_free, no ball_removed; the ball stays in _balls_by_key in OUT_HELD state.
+	# Capture on-court state before the overlay clear so OUT_REST origins skip the deactivate branch on cancel.
+	var was_on_court: bool = _item_manager != null and _item_manager.is_on_court(item_key)
 	# OUT_REST pickup also routes through here; clear the loose-in-venue overlay so a release-over-rack
 	# (or any non-venue target) restores the slot exactly like a live-grab originating from the court.
 	if _item_manager != null:
@@ -263,7 +264,7 @@ func grab_live_ball(item_key: String, is_temporary: bool = false) -> bool:
 	# Self-overlap exclusion: the held ball's own body would otherwise reject the release projection.
 	_set_court_exclude_rids([existing.get_rid()])
 	_adopt_live_ball_as_held(existing, item_key)
-	_held_was_on_court = true
+	_held_was_on_court = was_on_court
 	_held_origin = &"live"
 	_mouse_button_down = true
 	pickup_started.emit(item_key)
@@ -298,7 +299,7 @@ func spawn_purchased_at(
 		return true
 	if target is VenueDropTarget:
 		if _is_ball_role(item_key):
-			_release_to_rest(item_key, world_position, gesture_velocity, false)
+			_release_to_rest(item_key, world_position, gesture_velocity)
 		else:
 			_release_loose_body_at(item_key, world_position, gesture_velocity)
 		return true
@@ -319,19 +320,14 @@ func _adopt_purchased_into_rack(item_key: String) -> void:
 	reconciler.adopt_stored(item_key, rack.get_slot_position_for(item_key))
 
 
-## Step 5: ball-role venue-floor releases funnel here. Equipment retains the HeldBody path until step 7.
-## Reconciler creates or transitions the Ball into OUT_REST; the rack hides via on-court (live grab)
-## or loose-in-venue (rack origin), so the player never sees both a slot and a venue body.
-func _release_to_rest(
-	item_key: String, world_position: Vector2, gesture_velocity: Vector2, was_live: bool
-) -> void:
+## Funnels ball-role venue-floor releases into the reconciler with the loose-in-venue overlay set.
+func _release_to_rest(item_key: String, world_position: Vector2, gesture_velocity: Vector2) -> void:
 	if reconciler == null:
 		return
 	reconciler.release_into_rest(item_key, world_position, gesture_velocity)
-	# Rack-origin paths arrive with the item not on-court; flip the overlay so the rack filter hides
-	# the slot. Live grabs keep their on-court flag — touching it would tear the Ball down via the
-	# reconciler's court_changed handler.
-	if not was_live and _item_manager != null:
+	# Loose-in-venue overlay makes is_on_court return false regardless of placement, so save/reload
+	# skips the spurious court-spawn at the saved venue-floor position.
+	if _item_manager != null:
 		_item_manager.mark_loose_in_venue(item_key)
 
 
@@ -353,8 +349,7 @@ func _release_held_body_as_loose(release_position: Vector2) -> void:
 	_held_body = null
 
 
-## Equipment still rides the HeldBody path; step 7 unifies the surfaces. Spawns a loose body at the
-## release point, wires re-grab + loose-in-venue overlay through register_loose_body.
+## Spawns a loose HeldBody at the release point and wires re-grab + loose-in-venue overlay.
 func _release_loose_body_at(
 	item_key: String, world_position: Vector2, gesture_velocity: Vector2
 ) -> void:
@@ -427,7 +422,7 @@ func attempt_release(release_position: Vector2) -> bool:
 			# Temporary balls never join the registry; fall through to finalise (which frees the HeldBody).
 			pass
 		elif _is_ball_role(item_key):
-			_release_to_rest(item_key, clamped_position, _compute_release_velocity(), has_live_ball)
+			_release_to_rest(item_key, clamped_position, _compute_release_velocity())
 		else:
 			# Equipment keeps the HeldBody loose path; rehome the existing held body rather than spawning a new one.
 			_release_held_body_as_loose(clamped_position)
@@ -474,18 +469,13 @@ func _release_live_ball_to_court(release_position: Vector2, velocity: Vector2) -
 		_item_manager.activate(_held_key)
 
 
-## Step 5 seam: venue-floor releases no longer spawn loose HeldBodies, but Shop's `_drop_falling_body`
-## still does (retires at step 7). The five helpers below — track_loose_body, register_loose_body,
-## get_loose_body_host, _on_loose_body_grabbed, _adopt_loose_body_as_held, _on_loose_body_freed — keep
-## that path alive. Removing them would crash purchased-item drops.
+## Keeps the loose-body helper path alive for Shop's `_drop_falling_body`; venue-floor releases bypass it.
 func track_loose_body(body: HeldBody) -> void:
 	if not body.grabbed.is_connected(_on_loose_body_grabbed):
 		body.grabbed.connect(_on_loose_body_grabbed)
 
 
-## Folds the three loose-body bookkeeping ops (re-grab wiring + ItemManager promotion + slot-restore on free) so callers
-## only stand a fresh body up once. Subsystems that birth their own bodies (Shop drop, venue release) call this rather
-## than re-implementing the trio.
+## Folds re-grab wiring, ItemManager loose-in-venue promotion, and slot-restore-on-free into one call.
 func register_loose_body(body: HeldBody) -> void:
 	if body == null:
 		return
@@ -626,8 +616,7 @@ func _update_expansion_state(world_position: Vector2) -> void:
 		_cancel_to_source()
 
 
-## Live-ball cancels deactivate the on-court placement so the rack regrows the at-rest token.
-## STORED-origin cancels transition the held Ball back to STORED at its rack slot.
+## Routes a timed-out gesture back to its origin: on-court deactivate, OUT_REST unfreeze, or STORED restore.
 func _cancel_to_source() -> void:
 	var item_key: String = _held_key
 	var was_on_court: bool = _held_was_on_court
@@ -640,17 +629,22 @@ func _cancel_to_source() -> void:
 	if origin == &"live" and was_on_court:
 		if _item_manager != null and _item_manager.is_on_court(item_key):
 			_item_manager.deactivate(item_key)
+	elif origin == &"live" and _held_ball != null:
+		# OUT_REST origin: deactivate is a no-op so unfreeze back to OUT_REST at the cancel point.
+		_held_ball.enter_out_rest()
 	elif origin == &"rack" and _held_ball != null:
 		_restore_held_ball_to_stored(item_key)
 
 	_finalise_gesture(item_key, release_position, false)
 
 
-## Returns a STORED-origin held Ball to its rack slot in STORED state. Rack accept is a no-op for
-## items not on court, so flag-on rack-origin grabs reach this from cancel and release-over-rack.
+## Returns a held Ball to its rack slot in STORED state; safety net when rack accept's deactivate is a no-op.
 func _restore_held_ball_to_stored(item_key: String) -> void:
 	if _held_ball == null:
 		return
+	# Live OUT_REST → rack-drop carries a loose-in-venue overlay that would otherwise hide the restored slot.
+	if _item_manager != null:
+		_item_manager.clear_loose_in_venue(item_key)
 	_held_ball.enter_stored()
 	if rack != null:
 		_held_ball.global_position = rack.get_slot_position_for(item_key)

--- a/scripts/items/ball_reconciler.gd
+++ b/scripts/items/ball_reconciler.gd
@@ -146,6 +146,7 @@ func ensure_ball_for_key(
 
 	var ball: Ball = ball_scene.instantiate()
 	add_child(ball)
+	ball.item_key = item_key
 	ball.global_position = spawn_position
 	ball.linear_velocity = initial_velocity
 	_apply_item_art(ball, item_key)
@@ -162,6 +163,7 @@ func release_into_rest(item_key: String, position: Vector2, velocity: Vector2) -
 	if ball == null:
 		ball = ball_scene.instantiate()
 		add_child(ball)
+		ball.item_key = item_key
 		_apply_item_art(ball, item_key)
 		_balls_by_key[item_key] = ball
 		ball_spawned.emit(item_key, ball)
@@ -177,6 +179,7 @@ func release_into_rest(item_key: String, position: Vector2, velocity: Vector2) -
 func adopt_stored(item_key: String, spawn_position: Vector2) -> Ball:
 	var ball: Ball = ball_scene.instantiate()
 	add_child(ball)
+	ball.item_key = item_key
 	ball.enter_stored()
 	ball.global_position = spawn_position
 	_apply_item_art(ball, item_key)

--- a/tests/unit/items/test_sh366_battle_followups.gd
+++ b/tests/unit/items/test_sh366_battle_followups.gd
@@ -1,0 +1,173 @@
+## SH-366 Battle follow-ups: OUT_REST cancel, court→venue ItemManager sync, item_key on spawn, loose-clear on restore.
+extends GutTest
+
+const BallDragControllerScript: GDScript = preload("res://scripts/items/ball_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+var _manager: Node
+var _rack: RackDisplay
+var _drop_target: Area2D
+var _reconciler: BallReconciler
+var _drag: BallDragController
+
+
+func _make_rack(manager: Node) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+	for index in 4:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _make_drop_target(area_position: Vector2, area_size: Vector2) -> Area2D:
+	var area := Area2D.new()
+	area.global_position = area_position
+	var collision := CollisionShape2D.new()
+	var rectangle := RectangleShape2D.new()
+	rectangle.size = area_size
+	collision.shape = rectangle
+	area.add_child(collision)
+	add_child_autofree(area)
+	return area
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
+	var typed_items: Array[ItemDefinition] = [ball_alpha]
+	_manager.items.assign(typed_items)
+	_manager._progression.friendship_point_balance = 10000
+
+	_rack = _make_rack(_manager)
+	_drop_target = _make_drop_target(Vector2(-1000, 0), Vector2(300, 200))
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	add_child_autofree(_reconciler)
+
+	_drag = BallDragControllerScript.new()
+	_drag.configure(_manager, _rack, _drop_target, _reconciler)
+	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
+	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
+	add_child_autofree(_drag)
+
+
+# --- Finding 1: OUT_REST live-grab cancel unfreezes back to OUT_REST instead of stuck OUT_HELD --
+
+
+func test_out_rest_live_grab_cancel_returns_to_out_rest() -> void:
+	_manager.take("ball_alpha")
+	# Drive the ball into OUT_REST at a venue-floor position via the documented release path.
+	_manager.activate("ball_alpha")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(ball, "precondition: live ball exists on court")
+	_drag.grab_live_ball("ball_alpha", false)
+	await get_tree().process_frame
+	# Release inside venue but outside court → ball ends in OUT_REST and ItemManager flips loose-in-venue.
+	assert_true(_drag.attempt_release(Vector2(1500, 50)))
+	assert_eq(ball.play_state, Ball.PlayState.OUT_REST)
+	assert_true(_manager.is_loose_in_venue("ball_alpha"))
+
+	# Grab the OUT_REST ball.
+	assert_true(_drag.grab_live_ball("ball_alpha", false))
+	assert_eq(ball.play_state, Ball.PlayState.OUT_HELD)
+	# OUT_REST origin: the ball was not on court at grab time.
+	assert_false(_drag._held_was_on_court, "OUT_REST grab must not flag was_on_court")
+
+	# Trigger cancel-to-source via the expansion timeout.
+	_drag._gesture_below_threshold = false
+	_drag._mouse_button_down = false
+	_drag._expansion_started_at = (
+		float(Time.get_ticks_msec()) / 1000.0 - _drag.expansion_ring_hold_s * 2.0 - 0.1
+	)
+	_drag._update_expansion_state(Vector2(99999, 99999))
+
+	assert_false(_drag.is_dragging(), "cancel completes the gesture")
+	assert_eq(
+		ball.play_state,
+		Ball.PlayState.OUT_REST,
+		"OUT_REST origin restores to OUT_REST, not stuck OUT_HELD"
+	)
+	assert_false(ball.freeze, "OUT_REST unfreezes so gravity integrates")
+
+
+# --- Finding 3: live-court → venue release marks loose-in-venue so save reload skips court-spawn --
+
+
+func test_live_court_to_venue_release_marks_loose_in_venue() -> void:
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	assert_true(_manager.is_on_court("ball_alpha"), "precondition: ball is on court")
+
+	_drag.grab_live_ball("ball_alpha", false)
+	await get_tree().process_frame
+
+	# Release inside venue but outside court bounds.
+	assert_true(_drag.attempt_release(Vector2(1500, 50)))
+
+	assert_true(
+		_manager.is_loose_in_venue("ball_alpha"),
+		"live court→venue release flips the loose-in-venue overlay",
+	)
+	assert_false(
+		_manager.is_on_court("ball_alpha"),
+		"is_on_court returns false once loose-in-venue overlay is set",
+	)
+	assert_eq(
+		_manager.get_court_items().size(),
+		0,
+		"get_court_items skips the venue-floor ball so save reload does not respawn at the floor",
+	)
+
+
+# --- Finding 4: reconciler-spawned balls carry item_key for downstream lookups --
+
+
+func test_release_into_rest_sets_ball_item_key() -> void:
+	var ball: Ball = _reconciler.release_into_rest("ball_alpha", Vector2(100, 50), Vector2.ZERO)
+	assert_eq(ball.item_key, "ball_alpha")
+
+
+func test_adopt_stored_sets_ball_item_key() -> void:
+	var ball: Ball = _reconciler.adopt_stored("ball_alpha", Vector2(40, 0))
+	assert_eq(ball.item_key, "ball_alpha")
+
+
+func test_ensure_ball_for_key_sets_ball_item_key() -> void:
+	var ball: Ball = _reconciler.ensure_ball_for_key("ball_alpha", Vector2(0, 0), Vector2.ZERO)
+	assert_eq(ball.item_key, "ball_alpha")
+
+
+# --- Finding 5: restoring a held ball to STORED clears loose-in-venue overlay --
+
+
+func test_restore_held_ball_to_stored_clears_loose_in_venue() -> void:
+	_manager.take("ball_alpha")
+	_manager.activate("ball_alpha")
+	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	_drag.grab_live_ball("ball_alpha", false)
+	await get_tree().process_frame
+	# Drop on the venue floor to set loose-in-venue.
+	assert_true(_drag.attempt_release(Vector2(1500, 50)))
+	assert_true(_manager.is_loose_in_venue("ball_alpha"))
+
+	# Re-grab the OUT_REST ball, then restore to STORED via the rack-release safety net.
+	_drag.grab_live_ball("ball_alpha", false)
+	_drag._restore_held_ball_to_stored("ball_alpha")
+
+	assert_false(
+		_manager.is_loose_in_venue("ball_alpha"),
+		"restore-to-stored must clear the overlay so the rack slot reveals",
+	)
+	assert_eq(ball.play_state, Ball.PlayState.STORED)


### PR DESCRIPTION
Addresses the five Battle findings on PR #608:

1. OUT_REST live-grab cancel now unfreezes back to OUT_REST instead of leaving the ball stuck in OUT_HELD. `_held_was_on_court` is captured from `is_on_court` before the loose-in-venue clear.
2. Multi-line `##` docstrings in `ball_drag_controller.gd` collapsed to single lines.
3. Live court→venue release marks loose-in-venue unconditionally; the `was_live` gate is dropped (parameter retired). Save reload no longer respawns the ball at the venue-floor position via the spurious court-spawn path.
4. Reconciler `ensure_ball_for_key`, `release_into_rest`, and `adopt_stored` set `ball.item_key` on every fresh Ball.
5. `_restore_held_ball_to_stored` clears the loose-in-venue overlay so rack-drops of OUT_REST grabs reveal the slot.

Folds into #608 alongside Riebeck's work.