### PR TITLE
chore: track sh366 battle-followups test uid

### DIFF
--- a/tests/unit/items/test_sh366_battle_followups.gd.uid
+++ b/tests/unit/items/test_sh366_battle_followups.gd.uid
@@ -1,0 +1,1 @@
+uid://qdavpk0gf0ki


### PR DESCRIPTION
Tracks the `.uid` sidecar for `tests/unit/items/test_sh366_battle_followups.gd`, which was missed when the test landed in #608. Caught during Banana Tank debrief cleanup. One-line addition; no behaviour change.