### PR TITLE
docs: tech doc for paddle-bounce direction

### DIFF
--- a/designs/01-prototype/tech/03-paddle-bounce.md
+++ b/designs/01-prototype/tech/03-paddle-bounce.md
@@ -1,0 +1,73 @@
+# Paddle Bounce
+
+Implementation spec for the post-bounce direction computed when the ball strikes a paddle. Court-bound mechanics live in [`01-court-control.md`](01-court-control.md); ball state transitions live in [`02-ball-lifecycle.md`](02-ball-lifecycle.md).
+
+## Player goal
+
+The paddle is a tool the player aims with. Where the ball touches the paddle decides where the ball goes. Moving the paddle while striking imparts motion the player can feel. Centre hits don't read as the ball ignoring the paddle, and edge hits don't read as the ball getting stuck against the back wall.
+
+## Genre convention
+
+The reference games and tutorials surveyed (Pong 1972's 8-segment lookup, Breakout / Arkanoid family, MDN Phaser Breakout, CS50 Breakout, StudyPlan SDL2, MonoGame Breakernoid, Lethal League, Windjammers, Wii / Switch Sports tennis) all discard the incoming angle on paddle contact and compute the post-bounce direction from contact offset, player input at contact, or both. Pure mirror reflection is described in the source material as "boring" and "the most simplistic Pong", the design Alcorn explicitly moved away from in 1972. Background reading with citations: [`designs/research/paddle-bounce.md`](../../research/paddle-bounce.md).
+
+So Volley's bounce replaces the incoming angle. That's the natural shape; preserving the incoming angle is the unnatural one.
+
+## Geometry
+
+Paddles are vertical bodies on the left and right of the court. A bounce produces:
+
+- A **horizontal sign** away from the struck paddle (the ball heads back across the court).
+- A **vertical component** signed by how far above or below paddle centre the contact landed, optionally biased by paddle motion.
+
+The ball's speed magnitude is preserved through the bounce; only direction changes.
+
+## Components of the post-bounce direction
+
+The direction is built from three contributions:
+
+### 1. Contact offset
+
+Normalise the contact point against paddle half-height: `offset_norm = clamp((ball.y - paddle.y) / paddle.half_height, -1, +1)`. This is the primary aim signal. The mapping from `offset_norm` to the vertical component of the new direction is governed by `paddle_return_angle_max_degrees`, the steepest angle off horizontal an extreme edge hit can produce. Centre hit (`offset_norm = 0`) returns flat across the court; edge hit (`offset_norm = ±1`) returns at the configured max.
+
+### 2. Paddle velocity at contact (english)
+
+The paddle's vertical velocity at the moment of contact biases the return. A paddle moving upward into the ball adds upward bias; a paddle moving downward adds downward bias. The strength is the `paddle_english_coefficient` tunable: zero means contact offset is the only aim signal, higher values let a moving paddle pull or push the ball off the offset-only line. This is the signal that makes the paddle read as an active tool rather than a passive zone-strip.
+
+Crucially, english does not sum into offset. When the paddle is moving, the final angle is forced into the english's hemisphere: `(|offset_angle| + |offset_english|) * sign(english)`. A downward-moving paddle striking the top edge bounces downward, never upward. The motivation is that a player swinging the paddle expects the bounce to follow the swing; an additive sum would let a strong offset cancel a swing the player can see and feel.
+
+### 3. Minimum and maximum angle clamp
+
+After combining offset and english, clamp the vertical component so the post-bounce direction never lands within a narrow band of pure horizontal or pure vertical. Pure horizontal at centre reads as "the ball ignored me." Pure vertical at the extreme edge reads as "I'm stuck bouncing off the back wall." A small floor on both ends (default 3° off horizontal, 87° off horizontal) keeps every bounce visibly directional without making the math non-monotonic in offset. On a true-zero angle (centre hit, paddle stationary) the incoming y-sign breaks the tie so the ball continues in the direction it was already travelling.
+
+## Resulting math (sketch)
+
+```
+horizontal_sign = sign(ball.vx_at_contact)      # already points away from struck paddle
+offset_norm     = clamp((ball.y - paddle.y) / paddle.half_height, -1, +1)
+offset_angle    = offset_norm * deg_to_rad(paddle_return_angle_max_degrees)
+english_angle   = paddle.velocity.y * paddle_english_coefficient
+incoming_y_sign = sign(ball.vy_at_contact)
+target_angle    = blend_english_into_offset(offset_angle, english_angle)
+target_angle    = clamp_off_horizontal_and_vertical(target_angle, incoming_y_sign)
+direction       = Vector2(horizontal_sign * cos(target_angle), sin(target_angle))
+ball.linear_velocity = direction * ball.speed
+```
+
+`blend_english_into_offset` returns `offset_angle` when english is zero, otherwise `(|offset_angle| + |english_angle|) * sign(english_angle)`. `clamp_off_horizontal_and_vertical` enforces the min/max magnitude and uses `incoming_y_sign` as the tie-breaker on zero.
+
+## Tunables
+
+All four live on `PaddleConfig` and resolve through `Stats.resolve`, so items can modify them:
+
+- `paddle_return_angle_max_degrees`: maximum angle off horizontal an extreme edge hit produces.
+- `paddle_english_coefficient`: multiplier on paddle vertical velocity when computing the english bias (radians per pixel/sec).
+- `paddle_bounce_min_angle_degrees`: dead-zone floor; default 3°.
+- `paddle_bounce_max_angle_degrees`: dead-zone ceiling; default 87°.
+
+Default min/max read as safety guards rather than gameplay levers, but they go through the same resolve path as the others; an item could legitimately push them.
+
+## Out of scope
+
+- Spin / curve in flight. The bounce computes a new direction at the contact frame; the ball travels in a straight line afterwards as today.
+- Different bounce behaviour per ball type or per paddle role. Player paddle, partner paddle, and AI paddle all use the same bounce.
+- Swing-timing or held-input direction selection (Wii / Lethal League pattern). The Volley paddle is positional, not swing-based.

--- a/designs/01-prototype/tech/03-paddle-bounce.md
+++ b/designs/01-prototype/tech/03-paddle-bounce.md
@@ -8,9 +8,7 @@ The paddle is a tool the player aims with. Where the ball touches the paddle dec
 
 ## Genre convention
 
-The reference games and tutorials surveyed (Pong 1972's 8-segment lookup, Breakout / Arkanoid family, MDN Phaser Breakout, CS50 Breakout, StudyPlan SDL2, MonoGame Breakernoid, Lethal League, Windjammers, Wii / Switch Sports tennis) all discard the incoming angle on paddle contact and compute the post-bounce direction from contact offset, player input at contact, or both. Pure mirror reflection is described in the source material as "boring" and "the most simplistic Pong", the design Alcorn explicitly moved away from in 1972. Background reading with citations: [`designs/research/paddle-bounce.md`](../../research/paddle-bounce.md).
-
-So Volley's bounce replaces the incoming angle. That's the natural shape; preserving the incoming angle is the unnatural one.
+Volley's bounce replaces the incoming angle rather than reflecting it. That's the natural shape for the genre; preserving the incoming angle is the unnatural one. See [`designs/research/paddle-bounce.md`](../../research/paddle-bounce.md) for the survey and citations.
 
 ## Geometry
 

--- a/designs/research/INDEX.md
+++ b/designs/research/INDEX.md
@@ -16,6 +16,7 @@ Background research that informs Volley!'s direction. Each doc stands alone; tog
 | [Visual Positioning](visual-positioning.md) | Where Volley! sits visually among idle, desktop, and sport games. Reasoning behind the hand-drawn, live-scene direction. |
 | [Early Clone Games](early-clone-games.md) | Why Breakout's clone lineage outlasted Pong's, and what cloning shaped in the early industry. |
 | [Open Development Plan](open-development-plan.md) | Earlier internal plan that seeded the essay. |
+| [Paddle Bounce](paddle-bounce.md) | How paddle-and-ball games actually compute return angle. Background for `01-prototype/tech/03-paddle-bounce.md`. |
 
 ## Working folders
 

--- a/designs/research/paddle-bounce.md
+++ b/designs/research/paddle-bounce.md
@@ -1,0 +1,65 @@
+# Paddle Bounce: How the Genre Computes Return Angle
+
+How paddle-and-ball games actually compute the post-bounce direction. Background reading for `01-prototype/tech/03-paddle-bounce.md`.
+
+## Summary
+
+The dominant pattern in paddle-and-ball games is to **replace** the incoming angle, not reflect it. The post-bounce direction is computed from where the ball touched the paddle (and in modern racket games, from player input at contact). Incoming angle is discarded. Pure angle-of-incidence reflection is described in the source material as "the most simplistic Pong" and was the design Atari moved away from in 1972 because it played as "too boring."
+
+## Classic Pong (1972, Atari)
+
+Allan Alcorn divided the paddle into eight segments. Centre segments returned the ball at 90° to the paddle; outer segments at smaller angles. There was no continuous function and no preservation of incoming angle: the segment alone picked the output direction. Sources call this "completely arbitrary" but functional, designed to add strategic depth without floating-point math the hardware did not have [^pong-wiki] [^cornell-pong] [^bespoke-pong].
+
+## Breakout / Arkanoid family
+
+Every reference describes the same pattern: compute hit offset (`ball.x − paddle.x`), normalise to roughly `[-1, +1]`, use that as the new x-component, set y-component to a fixed positive value, normalise, multiply by speed. Incoming angle is discarded. Some variants additionally mix in paddle velocity for "english" [^breakernoid] [^smiling-cat] [^gamedev-breakout].
+
+## Modern paddle / racket games
+
+Three patterns surveyed, all of which discard pure angle-of-incidence reflection:
+
+- **Wii Sports / Switch Sports tennis**: direction is a function of swing timing, not paddle geometry. Early swing on forehand goes cross-court, late swing goes down-the-line. Wrist angle reads spin [^wii-tennis-sw] [^wii-tennis-wiki].
+- **Lethal League / Lethal League Blaze**: "neutral swing" releases the ball at one of three player-selected angles (Up / Neutral / Down) at the moment the swing animation ends. Incoming angle fully replaced [^lethal-league].
+- **Windjammers**: holding a direction at contact angles the disc diagonally; per-character "attack angles" the disc differently [^script-routine].
+
+Every modern racket-feel game gives the player intent at the contact moment, and that intent picks the new direction.
+
+## Canonical tutorial pattern
+
+All most-referenced 2D-physics tutorials replace the incoming direction with a hard-coded y-sign:
+
+- **MDN / Phaser Breakout**: `ball.body.velocity.x = -5 * (paddle.x - ball.x)` [^mdn-phaser].
+- **CS50 Breakout (Lua/LÖVE)**: `ball.dx = ±50 + ±8 * |paddle.center - ball.x|`. Additive with a non-zero floor, gated by paddle movement direction [^cs50-breakout].
+- **StudyPlan SDL2 Breakout**: offset normalised to `[-1, +1]` becomes x, y forced to a positive constant [^studyplan-sdl2].
+- **MonoGame Breakernoid**: same shape, with clamping to avoid near-vertical bounces [^breakernoid].
+
+Common refinements in the tutorials: clamp away from horizontal-near-vertical, mix paddle velocity for english, renormalise to constant ball speed after the math.
+
+## On the semantic question
+
+No Steve Swink or Game Maker's Toolkit piece lands cleanly on "preserve incoming angle vs replace it" for racket games, but the surrounding material is consistent:
+
+- Pure angle-of-incidence reflection is treated as a baseline to improve on, not a target feel [^gamedev-pong].
+- The shipped 1972 Pong intentionally departed from pure reflection because Alcorn felt the game was "too boring" without the 8-segment table [^pong-wiki].
+- Tutorials explicitly justify offset-overwrite as "where the ball hits the paddle has a strong effect on direction... this is what gives players control" [^breakernoid] [^studyplan-sdl2].
+- Real tennis physics: perpendicular-to-racket velocity is roughly preserved, but the parallel-to-racket component reverses, and string friction plus spin make the bounce deviate significantly from incidence. Even the realistic reference does not behave like a mirror [^tennis-physics].
+
+The genre convention, taught in every tutorial and shipped in every reference game found, is that contact offset or player input at contact picks the post-bounce direction and incoming angle is largely or wholly discarded.
+
+## Sources
+
+[^pong-wiki]: [Pong, Wikipedia](https://en.wikipedia.org/wiki/Pong). Retrieved 2026-05-13.
+[^cornell-pong]: [Atari's Pong Reimagined, Cornell ECE4760](https://ece4760.github.io/Projects/Fall2023/dms489_kw462/FinalProjectAtarisPongReimagined.html). Retrieved 2026-05-13.
+[^bespoke-pong]: [Pong, Bespoke Arcades](https://bespoke-arcades.co.uk/blogs/blog/pong-1972). Retrieved 2026-05-13.
+[^breakernoid]: [Building Breakernoid in MonoGame, InformIT](https://www.informit.com/articles/article.aspx?p=2180417&seqNum=2). Retrieved 2026-05-13.
+[^smiling-cat]: [Physics for a Block Breaker Game, Smiling Cat](https://www.smilingcatentertainment.com/physics-for-a-block-breaker-game/). Retrieved 2026-05-13.
+[^gamedev-breakout]: [Breakout-bounce thread, GameDev.net](https://www.gamedev.net/forums/topic/108709-help-plz-breakoutarkanoid-clone-bouncing-ball-giving-it-angles-etc/). Retrieved 2026-05-13.
+[^wii-tennis-sw]: [Wii Sports Tennis, StrategyWiki](https://strategywiki.org/wiki/Wii_Sports/Tennis). Retrieved 2026-05-13.
+[^wii-tennis-wiki]: [Tennis, Wii Sports Wiki](https://wiisports.fandom.com/wiki/Tennis_(sport)). Retrieved 2026-05-13.
+[^lethal-league]: [Gameplay/Mechanics, Lethal League Wiki](https://lethal-league.fandom.com/wiki/Gameplay/Mechanics). Retrieved 2026-05-13.
+[^script-routine]: [Sports Game Triple Play: Pong → Windjammers → Lethal League, Script Routine](https://scriptroutine.com/2020/12/05/sports-game-triple-play-evolving-pongs-design-into-windjammers-and-lethal-league/). Retrieved 2026-05-13.
+[^mdn-phaser]: [Randomizing gameplay, MDN Phaser Breakout tutorial](https://developer.mozilla.org/en-US/docs/Games/Tutorials/2D_breakout_game_Phaser/Randomizing_gameplay). Retrieved 2026-05-13.
+[^cs50-breakout]: [Breakout notes, CS50G](https://cs50.harvard.edu/games/notes/2/). Retrieved 2026-05-13.
+[^studyplan-sdl2]: [Breakout Paddle Physics, StudyPlan SDL2](https://www.studyplan.dev/sdl2/sdl2-breakout-paddle-physics). Retrieved 2026-05-13.
+[^gamedev-pong]: [Best PONG bounce method, GameDev.net](https://www.gamedev.net/forums/topic/169021-best-pong-bounce-method/). Retrieved 2026-05-13.
+[^tennis-physics]: [Physics of Tennis, Tennis Without Talent](https://www.tenniswithouttalent.com/Physics.html). Retrieved 2026-05-13.


### PR DESCRIPTION
Documents the post-bounce direction math that landed in SH-316. Lives at `designs/01-prototype/tech/03-paddle-bounce.md` with the research notes that informed the genre-convention call at `designs/research/paddle-bounce.md`.

Covers the three contributions (contact offset, paddle english, min/max clamp), the english-blend rule that forces moving-paddle hits into the swing's hemisphere rather than summing into offset, and the four `PaddleConfig` tunables that drive it. The math sketch matches `effect_processor._apply_paddle_offset_return` line-for-line so a reader can navigate between doc and code.

Replaces the closed #657, which described an older simple-sum english model and pointed at `BaseStatsConfig` for tunables that have since moved to `PaddleConfig`.