### PR TITLE
chore: tune paddle_return_angle_max_degrees to 50

### DIFF
--- a/resources/ball/states/out_rest.tres
+++ b/resources/ball/states/out_rest.tres
@@ -1,12 +1,9 @@
-[gd_resource type="Resource" script_class="BallStateConfig" load_steps=3 format=3 uid="uid://bballstateoutrs"]
+[gd_resource type="Resource" script_class="BallStateConfig" format=3 uid="uid://d2dmpxm2br441"]
 
-[ext_resource type="Script" path="res://scripts/entities/ball/ball_state_config.gd" id="1"]
-[ext_resource type="PhysicsMaterial" uid="uid://b0volleyrestmt" path="res://resources/ball/rest.tres" id="2"]
+[ext_resource type="Script" uid="uid://crmt1lslcq7mq" path="res://scripts/entities/ball/ball_state_config.gd" id="1"]
+[ext_resource type="PhysicsMaterial" uid="uid://bwkjqj6ywrpad" path="res://resources/ball/rest.tres" id="2"]
 
 [resource]
 script = ExtResource("1")
-freeze = false
-collision_layer = 1
-collision_mask = 1
 gravity_scale = 1.0
 physics_material_override = ExtResource("2")

--- a/resources/ball/states/play_active.tres
+++ b/resources/ball/states/play_active.tres
@@ -1,12 +1,8 @@
-[gd_resource type="Resource" script_class="BallStateConfig" load_steps=3 format=3 uid="uid://bballstateplnrm"]
+[gd_resource type="Resource" script_class="BallStateConfig" format=3 uid="uid://d2dmpxm2cix4u"]
 
-[ext_resource type="Script" path="res://scripts/entities/ball/ball_state_config.gd" id="1"]
+[ext_resource type="Script" uid="uid://crmt1lslcq7mq" path="res://scripts/entities/ball/ball_state_config.gd" id="1"]
 [ext_resource type="PhysicsMaterial" uid="uid://bldc0c7o5o2o4" path="res://resources/ball/play.tres" id="2"]
 
 [resource]
 script = ExtResource("1")
-freeze = false
-collision_layer = 1
-collision_mask = 1
-gravity_scale = 0.0
 physics_material_override = ExtResource("2")

--- a/resources/ball/states/stored.tres
+++ b/resources/ball/states/stored.tres
@@ -1,11 +1,9 @@
-[gd_resource type="Resource" script_class="BallStateConfig" load_steps=2 format=3 uid="uid://bballstatestor0"]
+[gd_resource type="Resource" script_class="BallStateConfig" format=3 uid="uid://d2dmpxm2fqy48"]
 
-[ext_resource type="Script" path="res://scripts/entities/ball/ball_state_config.gd" id="1"]
+[ext_resource type="Script" uid="uid://crmt1lslcq7mq" path="res://scripts/entities/ball/ball_state_config.gd" id="1"]
 
 [resource]
 script = ExtResource("1")
 freeze = true
 collision_layer = 0
 collision_mask = 0
-gravity_scale = 0.0
-physics_material_override = null

--- a/resources/paddle_stats.tres
+++ b/resources/paddle_stats.tres
@@ -4,3 +4,4 @@
 
 [resource]
 script = ExtResource("1_paddlecfg")
+paddle_return_angle_max_degrees = 50.0

--- a/resources/paddle_stats.tres
+++ b/resources/paddle_stats.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="PaddleConfig" format=3 uid="uid://b8paddl3stats1"]
+[gd_resource type="Resource" script_class="PaddleConfig" format=3 uid="uid://b0ckcnhi7txw1"]
 
 [ext_resource type="Script" uid="uid://svj0ppajmpw" path="res://scripts/core/paddle_config.gd" id="1_paddlecfg"]
 

--- a/tests/unit/ball/test_paddle_offset_return_angle.gd
+++ b/tests/unit/ball/test_paddle_offset_return_angle.gd
@@ -41,14 +41,17 @@ func _build_with_stats(degrees: float, english: float) -> void:
 func _build_with_stats_and_min_angle(
 	degrees: float, english: float, min_angle_bonus: float
 ) -> void:
-	# Builds items whose `always` triggers contribute the requested stat values like real items would.
+	# Items add a DELTA from the live base so the test lands at the requested absolute value,
+	# independent of the production paddle_stats.tres tuning.
+	var max_degrees_delta: float = degrees - GameRules.paddle.paddle_return_angle_max_degrees
+	var english_delta: float = english - GameRules.paddle.paddle_english_coefficient
 	_manager = ItemFactory.create_manager(
-		self, "max_angle_kit", &"paddle_return_angle_max_degrees", &"add", degrees
+		self, "max_angle_kit", &"paddle_return_angle_max_degrees", &"add", max_degrees_delta
 	)
 
-	if english != 0.0:
+	if english_delta != 0.0:
 		var english_item := ItemFactory.create(
-			"english_kit", &"paddle_english_coefficient", &"add", english
+			"english_kit", &"paddle_english_coefficient", &"add", english_delta
 		)
 		_manager.items.append(english_item)
 
@@ -60,7 +63,7 @@ func _build_with_stats_and_min_angle(
 	_manager.economy.friendship_point_balance = 100000
 	_manager.purchase("max_angle_kit")
 
-	if english != 0.0:
+	if english_delta != 0.0:
 		_manager.purchase("english_kit")
 
 	if min_angle_bonus != 0.0:


### PR DESCRIPTION
The paddle-offset return-angle feature shipped in #651 with `paddle_stats.tres` authored at zero, so `effect_processor._apply_paddle_offset_return` short-circuited and no bounce angle was produced. Ride for SH-403 surfaced this; live tracing confirmed the math is correct once the value is non-zero.

50° reads as a meaningful edge-hit angle (centre stays flat, extremes steepen) without sitting near the 87° safety ceiling. English coefficient stays at the default 0.0 until Josh decides what swing feel he wants.

Closes SH-403 once the ride accepts the in-game feel.