### PR TITLE
ci: trim wall time per PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,54 @@ env:
   GITLEAKS_VERSION: "8.28.0"
 
 jobs:
-  lint:
-    name: Lint
+  gdformat:
+    name: gdformat
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install Python tools
+        run: |
+          pip install --user -r requirements-dev.txt
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: gdformat
+        run: find scripts tests -name '*.gd' | xargs gdformat --check
+
+  gdlint:
+    name: gdlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install Python tools
+        run: |
+          pip install --user -r requirements-dev.txt
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: gdlint
+        run: find scripts tests -name '*.gd' | xargs gdlint
+
+  text-checks:
+    name: text-checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -51,14 +97,23 @@ jobs:
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v${{ env.GITLEAKS_VERSION }}/gitleaks_${{ env.GITLEAKS_VERSION }}_linux_x64.tar.gz \
             | tar -xz -C ~/.local/bin gitleaks
 
-      - name: gdformat
-        run: find scripts tests -name '*.gd' | xargs gdformat --check
-
-      - name: gdlint
-        run: find scripts tests -name '*.gd' | xargs gdlint
-
       - name: codespell
         run: codespell
 
       - name: gitleaks
         run: gitleaks detect --redact --verbose --no-banner
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: [gdformat, gdlint, text-checks]
+    if: always()
+    steps:
+      - name: Umbrella gate
+        run: |
+          if [ "${{ needs.gdformat.result }}" != "success" ] \
+            || [ "${{ needs.gdlint.result }}" != "success" ] \
+            || [ "${{ needs.text-checks.result }}" != "success" ]; then
+            echo "::error::One or more lint jobs failed"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,14 +47,14 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .godot
-          key: godot-import-${{ env.GODOT_VERSION }}-${{ hashFiles('project.godot', '**/*.tscn', '**/*.tres', '**/*.gd', '**/*.uid', 'assets/**', 'art/**', 'resources/**') }}
+          key: godot-import-${{ env.GODOT_VERSION }}-${{ hashFiles('project.godot', 'addons/**', '**/*.import') }}
 
       - name: Import Project
-        # First pass populates the UID cache from .import files; second pass uses it
-        # so subsequent loads do not fall back to text paths and emit UID warnings.
-        run: |
-          godot --headless --path . --import
-          godot --headless --path . --import
+        # Single pass. Cold-cache UID warnings and their paired
+        # "Failed loading resource" errors are filtered in the Leak gate step
+        # (see ai/scratchpads/godot-ci-uid-cache.md). Godot's incremental
+        # importer handles per-file changes once the .godot cache is warm.
+        run: godot --headless --path . --import
 
       - name: Run Tests
         env:


### PR DESCRIPTION
Drops the second `godot --import` pass in Tests (single pass; cold-cache UID warnings and their paired `Failed loading resource` errors stay filtered by the existing leak gate per `ai/scratchpads/godot-ci-uid-cache.md`). Narrows the `.godot` import cache key to `project.godot`, `addons/**`, and `**/*.import` so impl PRs reuse the warm cache and Godot's incremental importer handles per-file changes. Splits `gdformat` and `gdlint` into parallel jobs in Lint, with a `Lint` umbrella job that depends on all three sub-jobs so the required-check name in branch protection (still pinned to `Lint`) stays valid; no merge-gate coordination needed. Closes #676.