### PR TITLE
fix(ci): fix sync-wiki YAML and add actionlint pre-merge gate

### DIFF
--- a/.github/scripts/title_case.py
+++ b/.github/scripts/title_case.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Title Case a hyphen-separated name with a small-word filter.
+# "title-is-this" -> "Title-is-This"; "01-prototype" -> "01-Prototype".
+# First and last segments always capped (when the leading char is a lowercase
+# letter); middle small words stay lowercase.
+import sys
+
+SMALL = {"a","an","the","and","or","but","of","in","on","to","by","at","for",
+         "with","is","as","if","vs","from","into"}
+
+parts = sys.argv[1].split("-")
+out = []
+for i, p in enumerate(parts):
+    if not p:
+        out.append(p)
+        continue
+    if i in (0, len(parts) - 1) or p.lower() not in SMALL:
+        if p[0].isalpha() and p[0].islower():
+            out.append(p[0].upper() + p[1:])
+        else:
+            out.append(p)
+    else:
+        out.append(p.lower())
+print("-".join(out))

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,11 +31,11 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-          cache-dependency-path: requirements-dev.txt
+          cache-dependency-path: requirements-lint.txt
 
       - name: Install Python tools
         run: |
-          pip install --user -r requirements-dev.txt
+          pip install --user -r requirements-lint.txt
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Cache gitleaks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   GITLEAKS_VERSION: "8.28.0"
+  ACTIONLINT_VERSION: "1.7.12"
 
 jobs:
   lint:
@@ -51,6 +52,20 @@ jobs:
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v${{ env.GITLEAKS_VERSION }}/gitleaks_${{ env.GITLEAKS_VERSION }}_linux_x64.tar.gz \
             | tar -xz -C ~/.local/bin gitleaks
 
+      - name: Cache actionlint
+        id: cache-actionlint
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.local/bin/actionlint
+          key: actionlint-${{ env.ACTIONLINT_VERSION }}
+
+      - name: Install actionlint
+        if: steps.cache-actionlint.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/bin
+          curl -sSfL https://github.com/rhysd/actionlint/releases/download/v${{ env.ACTIONLINT_VERSION }}/actionlint_${{ env.ACTIONLINT_VERSION }}_linux_amd64.tar.gz \
+            | tar -xz -C ~/.local/bin actionlint
+
       - name: gdformat
         run: find scripts tests -name '*.gd' | xargs gdformat --check
 
@@ -62,3 +77,6 @@ jobs:
 
       - name: gitleaks
         run: gitleaks detect --redact --verbose --no-banner
+
+      - name: actionlint
+        run: actionlint -color

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,10 +67,10 @@ jobs:
             | tar -xz -C ~/.local/bin actionlint
 
       - name: gdformat
-        run: find scripts tests -name '*.gd' | xargs gdformat --check
+        run: find scripts tests -name '*.gd' -print0 | xargs -0 gdformat --check
 
       - name: gdlint
-        run: find scripts tests -name '*.gd' | xargs gdlint
+        run: find scripts tests -name '*.gd' -print0 | xargs -0 gdlint
 
       - name: codespell
         run: codespell

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'designs/**/*.md'
       - '.github/workflows/sync-wiki.yml'
+      - '.github/scripts/title_case.py'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -92,29 +92,12 @@ jobs:
             ' "$src" > "$dest"
           }
 
-          # Title Case a hyphen-separated name with a small-word filter.
-          # "title-is-this" -> "Title-is-This"; "01-prototype" -> "01-Prototype";
-          # "narrative-discipline" -> "Narrative-Discipline".
-          # First and last words always capped (when the leading char is a lowercase
-          # letter); middle small words ("a", "an", "the", "and", "or", "but", "of",
-          # "in", "on", "to", "by", "at", "for", "with", "is", "as", "if", "vs",
-          # "from", "into") stay lowercase.
+          # Title-case helper extracted to .github/scripts/title_case.py because
+          # a multi-line python heredoc inside `run: |` breaks the YAML block
+          # scalar indent (python top-level needs column 0; YAML block scalar
+          # needs indent >= run-block).
           title_case() {
-            python3 -c '
-import sys
-small = {"a","an","the","and","or","but","of","in","on","to","by","at","for","with","is","as","if","vs","from","into"}
-parts = sys.argv[1].split("-")
-out = []
-for i, p in enumerate(parts):
-    if not p:
-        out.append(p)
-        continue
-    if i in (0, len(parts)-1) or p.lower() not in small:
-        out.append(p[0].upper() + p[1:] if p[0].isalpha() and p[0].islower() else p)
-    else:
-        out.append(p.lower())
-print("-".join(out))
-' "$1"
+            python3 "${GITHUB_WORKSPACE}/.github/scripts/title_case.py" "$1"
           }
 
           for src in designs/**/*.md; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,10 +104,10 @@ jobs:
       - name: Coverage Report
         if: always()
         run: |
-          echo '## Run Tests Summary' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          grep -A 100 'Coverage' test_output.txt | sed 's/\x1b\[[0-9;]*m//g' >> $GITHUB_STEP_SUMMARY || echo 'No coverage output found' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '## Run Tests Summary' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          grep -A 100 'Coverage' test_output.txt | sed 's/\x1b\[[0-9;]*m//g' >> "$GITHUB_STEP_SUMMARY" || echo 'No coverage output found' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Coverage
         if: always()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
-gdtoolkit==4.*
-codespell
+-r requirements-lint.txt
 pip-audit==2.*

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,2 @@
+gdtoolkit==4.*
+codespell


### PR DESCRIPTION
Two related fixes for the same failure mode (YAML drift in `.github/workflows/*.yml`):

1. **sync-wiki.yml YAML fix.** The inline python heredoc in SH-330 (#552, 4467734) landed at column 0, terminating the YAML block scalar mid-script. GitHub rejected the workflow with `Invalid workflow file: .github/workflows/sync-wiki.yml#L104` on every push since 2026-04-29; production wiki sync stopped silently the same day. Pulled `title_case` into `.github/scripts/title_case.py` so the source stays runnable as python and the YAML parses. Behaviour parity confirmed on three inputs (`narrative-discipline`, `01-prototype`, `title-is-this`).

2. **actionlint pre-merge gate.** Added `actionlint` v1.7.12 to `lint.yml`. Startup-failure shape (the bug above) is the most silent class of CI failure: no email, no workflow_run event, no check posted on the triggering commit. Pre-merge actionlint catches it (and undefined env vars, unpinned actions, shell-syntax inside run blocks) at the door. Cached binary, same pattern as gitleaks.

Status: not yet battled.