### PR TITLE
docs: code-style + test-budget + conventional-commits + ticket example

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,9 @@ version-resolver:
   default: patch
 
 categories:
+  - title: "Breaking Changes"
+    labels:
+      - "breaking"
   - title: "Features"
     labels:
       - "feature"
@@ -46,6 +49,12 @@ autolabeler:
       - "/^fix(\\(.+\\))?:/i"
       - "/^fix(\\(.+\\))?!:/i"
       - "/^SH-\\d+ fix(\\(.+\\))?:/i"
+  # Conventional Commits ! suffix: any type with a bang lands the breaking label
+  # so the release-drafter groups it under Breaking Changes at the top.
+  - label: "breaking"
+    title:
+      - "/^[a-z]+(\\(.+\\))?!:/i"
+      - "/^SH-\\d+ [a-z]+(\\(.+\\))?!:/i"
 
 change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
 change-title-escapes: '\<*_&'
@@ -59,5 +68,13 @@ template: |
   ## What changed
 
   $CHANGES
+
+  ## Contributors
+
+  Thanks to everyone whose work shipped in this release:
+
+  <!-- CONTRIBUTORS_LIST -->
+  $CONTRIBUTORS
+  <!-- /CONTRIBUTORS_LIST -->
 
   **Full changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -49,12 +49,13 @@ autolabeler:
       - "/^fix(\\(.+\\))?:/i"
       - "/^fix(\\(.+\\))?!:/i"
       - "/^SH-\\d+ fix(\\(.+\\))?:/i"
-  # Conventional Commits ! suffix: any type with a bang lands the breaking label
-  # so the release-drafter groups it under Breaking Changes at the top.
+  # Conventional Commits ! suffix on a known type: lands the breaking label so
+  # release-drafter groups it under Breaking Changes at the top. Explicit type
+  # list avoids labelling `Merge!:` / `WIP!:` style titles as breaking.
   - label: "breaking"
     title:
-      - "/^[a-z]+(\\(.+\\))?!:/i"
-      - "/^SH-\\d+ [a-z]+(\\(.+\\))?!:/i"
+      - "/^(feat|fix|refactor|perf|chore|build|ci|docs|style|test|revert)(\\(.+\\))?!:/i"
+      - "/^SH-\\d+ (feat|fix|refactor|perf|chore|build|ci|docs|style|test|revert)(\\(.+\\))?!:/i"
 
 change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
 change-title-escapes: '\<*_&'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,15 +29,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bullet the contributors block and credit Claude
+      - name: Bullet the contributors block
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_ID: ${{ steps.draft.outputs.id }}
           RELEASE_BODY: ${{ steps.draft.outputs.body }}
         # The drafter renders $CONTRIBUTORS as `@a, @b, @c` between marker
-        # comments. Convert to one bullet per author (bots included), append
-        # Claude as a fixed credit for swarm-authored commits, and PATCH the
-        # release body so the published notes carry the reshaped section.
+        # comments. Convert to one bullet per author (bots included) and
+        # PATCH the release body so the published notes carry the reshaped
+        # section.
         run: |
           python3 <<'PY' > new_body.md
           import os, re
@@ -48,8 +48,6 @@ jobs:
           )
           def reshape(match):
               names = [n.strip() for n in match.group(2).split(",") if n.strip()]
-              if "Claude" not in names:
-                  names.append("Claude")
               bullets = "\n".join(f"- {n}" for n in names)
               return f"{match.group(1)}{bullets}{match.group(3)}"
           print(pattern.sub(reshape, body), end="")

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,6 +24,35 @@ jobs:
       pull-requests: read
     steps:
       - name: Draft release notes
+        id: draft
         uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bullet the contributors block and credit Claude
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.draft.outputs.id }}
+          RELEASE_BODY: ${{ steps.draft.outputs.body }}
+        # The drafter renders $CONTRIBUTORS as `@a, @b, @c` between marker
+        # comments. Convert to one bullet per author (bots included), append
+        # Claude as a fixed credit for swarm-authored commits, and PATCH the
+        # release body so the published notes carry the reshaped section.
+        run: |
+          python3 <<'PY' > new_body.md
+          import os, re
+          body = os.environ["RELEASE_BODY"]
+          pattern = re.compile(
+              r"(<!-- CONTRIBUTORS_LIST -->\n)(.*?)(\n<!-- /CONTRIBUTORS_LIST -->)",
+              re.DOTALL,
+          )
+          def reshape(match):
+              names = [n.strip() for n in match.group(2).split(",") if n.strip()]
+              if "Claude" not in names:
+                  names.append("Claude")
+              bullets = "\n".join(f"- {n}" for n in names)
+              return f"{match.group(1)}{bullets}{match.group(3)}"
+          print(pattern.sub(reshape, body), end="")
+          PY
+          gh api -X PATCH "/repos/${{ github.repository }}/releases/${RELEASE_ID}" \
+            -f body="$(cat new_body.md)" >/dev/null

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,0 +1,92 @@
+# Code Style
+
+GDScript conventions used in Volley!. The lint pipeline (`gdformat`, `gdlint`) catches most of the mechanical stuff; this file covers the project-specific decisions that lint does not enforce.
+
+## Blank line before every `if`
+
+Always leave a blank line above an `if` statement. It separates the predicate from whatever set it up, and keeps the control flow readable in dense bodies.
+
+```gdscript
+var remaining := target - current
+
+if remaining <= step:
+    return
+```
+
+Not:
+
+```gdscript
+var remaining := target - current
+if remaining <= step:
+    return
+```
+
+## `@export` over `@onready` for child node references
+
+Wire child node references through `@export var name: NodeType` (or `@export var name: NodePath`) instead of `@onready var name = $Path`. Exports survive scene renames, fail loud when the wire breaks, and document the dependency in the inspector.
+
+```gdscript
+@export var hit_sound: AudioStreamPlayer
+@export var collision: CollisionShape2D
+```
+
+Reserve `@onready` for things genuinely owned by the script (a Timer the script creates, a value computed at ready time).
+
+## Full words; no abbreviations
+
+In file names, variable names, function names, and comments, write the word out. `paddle_velocity` over `pdl_vel`. `current_state` over `cur_st`. The reader does not gain anything from a guess; the writer does not lose anything by typing the extra letters.
+
+Exceptions are unambiguous, project-wide abbreviations that have stuck: `id`, `url`, `ui`, `ms`. If you are about to invent a new one, write the word out instead.
+
+## Descriptive variable names; no single letters
+
+Single-letter names (`b`, `t`, `n`) and one-word reductions (`tmp`, `val`) hide intent. Name the thing for what it represents in the system: `spawned_ball`, `elapsed_seconds`, `remaining_descent`.
+
+Loop counters in a five-line block where the iteration variable is obvious (`for i in range(...)`) are fine; longer or nested loops earn a real name.
+
+## Comments: one line, WHY only
+
+If a comment is needed at all, it is one line and it says *why* the code looks the way it does. The reader can already see *what* it does from the code. Multi-line block comments and narrative explanations belong in design docs, not in code.
+
+```gdscript
+# Read placement state directly so a mid-drag overlay does not skew capacity.
+var equipped_count := _count_equipped_from_state()
+```
+
+Not:
+
+```gdscript
+# This function counts equipped items by iterating the item_placements
+# dictionary and checking each placement against the EQUIPPED enum value.
+# It returns the count as an integer.
+var equipped_count := _count_equipped_from_state()
+```
+
+If removing the comment would not confuse a future reader, do not write it.
+
+## Tunables live in data, not code
+
+Numbers, thresholds, durations, speeds. If a value might want tuning without a code edit, promote it to `@export var`. If three or more related tunables move together (e.g. a movement profile: acceleration, top speed, decel), cluster them into a `Resource` subclass with its own `.tres` file.
+
+```gdscript
+@export var walk_speed: float = 200.0
+```
+
+For clusters:
+
+```gdscript
+class_name TimeoutConfig
+extends Resource
+
+@export var descent_speed: float = 1200.0
+@export var walk_duration_seconds: float = 0.6
+@export var equip_pose_offset_x: float = -192.0
+```
+
+The script holds defaults; the `.tres` overrides for live tuning. Designers and contributors can author values without editing source.
+
+## `Resource` subclass over loose `@export` vars when clustered
+
+When you find yourself adding the third `@export` to a node and the values clearly belong together (a movement profile, a visual style block, an item definition), promote to a `Resource` subclass and store the values in a `.tres`. Loose exports scale poorly: they bind the data to the node, they cannot be shared across instances, and they bury the cluster in the inspector.
+
+The diagnostic: count the degrees of freedom. If most of the resource's fields are exercised by the live use cases, it earns its `Resource`. If only one or two fields ever vary, the cluster is premature; keep them as loose exports.

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,10 +1,12 @@
 # Code Style
 
-GDScript conventions used in Volley!. The lint pipeline (`gdformat`, `gdlint`) catches most of the mechanical stuff; this file covers the project-specific decisions that lint does not enforce.
+Welcome. This is the short list of GDScript conventions we follow in Volley!. `gdformat` and `gdlint` handle most of the mechanical stuff for you; this file is for the project-specific calls those tools cannot make.
+
+None of this is meant to slow you down. The patterns here exist because they have repeatedly made the code easier to read, easier to refactor, and easier to onboard new contributors onto. If one does not fit your situation, open the PR and we will work it out.
 
 ## Blank line before every `if`
 
-Always leave a blank line above an `if` statement. It separates the predicate from whatever set it up, and keeps the control flow readable in dense bodies.
+Leave a blank line above an `if` statement. It gives the predicate room to breathe and keeps dense bodies readable.
 
 ```gdscript
 var remaining := target - current
@@ -13,7 +15,7 @@ if remaining <= step:
     return
 ```
 
-Not:
+rather than:
 
 ```gdscript
 var remaining := target - current
@@ -21,39 +23,39 @@ if remaining <= step:
     return
 ```
 
-## `@export` over `@onready` for child node references
+## `@export` over `@onready` for child nodes
 
-Wire child node references through `@export var name: NodeType` (or `@export var name: NodePath`) instead of `@onready var name = $Path`. Exports survive scene renames, fail loud when the wire breaks, and document the dependency in the inspector.
+Wire child node references through `@export var name: NodeType` (or `@export var name: NodePath`) rather than `@onready var name = $Path`. Exports survive scene renames, fail loudly when the wire breaks, and show the dependency in the inspector, all of which save time the next time someone reorganises a scene.
 
 ```gdscript
 @export var hit_sound: AudioStreamPlayer
 @export var collision: CollisionShape2D
 ```
 
-Reserve `@onready` for things genuinely owned by the script (a Timer the script creates, a value computed at ready time).
+`@onready` still has its place: things the script genuinely owns, like a Timer it creates, or a value computed once at ready time.
 
-## Full words; no abbreviations
+## Full words
 
-In file names, variable names, function names, and comments, write the word out. `paddle_velocity` over `pdl_vel`. `current_state` over `cur_st`. The reader does not gain anything from a guess; the writer does not lose anything by typing the extra letters.
+In file names, variable names, function names, and comments, write the word out. `paddle_velocity` reads better than `pdl_vel`; `current_state` reads better than `cur_st`. The few extra letters are easier to write than the guesswork is to read.
 
-Exceptions are unambiguous, project-wide abbreviations that have stuck: `id`, `url`, `ui`, `ms`. If you are about to invent a new one, write the word out instead.
+A handful of project-wide abbreviations have stuck (`id`, `url`, `ui`, `ms`) and are fine. If you are about to invent a new one, spell it out instead.
 
-## Descriptive variable names; no single letters
+## Descriptive variable names
 
-Single-letter names (`b`, `t`, `n`) and one-word reductions (`tmp`, `val`) hide intent. Name the thing for what it represents in the system: `spawned_ball`, `elapsed_seconds`, `remaining_descent`.
+Name variables for what they represent in the system. `spawned_ball`, `elapsed_seconds`, `remaining_descent` will tell a reader what they are looking at; `b`, `t`, `n` will not.
 
-Loop counters in a five-line block where the iteration variable is obvious (`for i in range(...)`) are fine; longer or nested loops earn a real name.
+Loop counters in a five-line block where the iteration variable is obvious (`for i in range(...)`) are fine as is. Longer or nested loops earn a real name.
 
 ## Comments: one line, WHY only
 
-If a comment is needed at all, it is one line and it says *why* the code looks the way it does. The reader can already see *what* it does from the code. Multi-line block comments and narrative explanations belong in design docs, not in code.
+If a comment is needed at all, it is one line and it explains *why* the code looks the way it does. The reader can already see *what* it does from the code itself. Multi-line block comments and narrative explanations are wonderful in design docs; in code they tend to rot.
 
 ```gdscript
 # Read placement state directly so a mid-drag overlay does not skew capacity.
 var equipped_count := _count_equipped_from_state()
 ```
 
-Not:
+rather than:
 
 ```gdscript
 # This function counts equipped items by iterating the item_placements
@@ -62,11 +64,11 @@ Not:
 var equipped_count := _count_equipped_from_state()
 ```
 
-If removing the comment would not confuse a future reader, do not write it.
+A quick test: if removing the comment would not confuse a future reader, you do not need it.
 
-## Tunables live in data, not code
+## Tunables live in data
 
-Numbers, thresholds, durations, speeds. If a value might want tuning without a code edit, promote it to `@export var`. If three or more related tunables move together (e.g. a movement profile: acceleration, top speed, decel), cluster them into a `Resource` subclass with its own `.tres` file.
+Numbers, thresholds, durations, speeds. If a value might want tuning without a code edit, promote it to an `@export var`. When three or more related tunables move together (a movement profile: acceleration, top speed, decel, for instance), cluster them into a `Resource` subclass with its own `.tres` file so they can be edited from the inspector, shared across instances, and saved separately.
 
 ```gdscript
 @export var walk_speed: float = 200.0
@@ -83,10 +85,10 @@ extends Resource
 @export var equip_pose_offset_x: float = -192.0
 ```
 
-The script holds defaults; the `.tres` overrides for live tuning. Designers and contributors can author values without editing source.
+The script holds the defaults; the `.tres` holds whatever values are in play. Designers and contributors can tune values without touching the source.
 
-## `Resource` subclass over loose `@export` vars when clustered
+## `Resource` subclass when a cluster forms
 
-When you find yourself adding the third `@export` to a node and the values clearly belong together (a movement profile, a visual style block, an item definition), promote to a `Resource` subclass and store the values in a `.tres`. Loose exports scale poorly: they bind the data to the node, they cannot be shared across instances, and they bury the cluster in the inspector.
+You will notice when you are reaching for the third related `@export` on a node that the values clearly belong together: a movement profile, a visual style block, an item definition. That is the moment to promote them to a `Resource` subclass and store the values in a `.tres`. Loose exports work for one or two values; once a cluster forms, they tend to scatter what should travel together.
 
-The diagnostic: count the degrees of freedom. If most of the resource's fields are exercised by the live use cases, it earns its `Resource`. If only one or two fields ever vary, the cluster is premature; keep them as loose exports.
+A useful diagnostic: count the degrees of freedom. If most of the resource's fields are exercised by the live use cases, it earns its `Resource`. If only one or two ever vary, the cluster is premature, and keeping them as loose exports is the kinder call.

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -32,7 +32,9 @@ Wire child node references through `@export var name: NodeType` (or `@export var
 @export var collision: CollisionShape2D
 ```
 
-The project has no `@onready` in production code today, and you should not need to add one. If you find a case where `@export` genuinely cannot cover the dependency, flag it in the PR thread and we will sort it out together.
+`@onready` exists in GDScript for a real reason: deferring evaluation of an arbitrary expression until the node enters the tree, not just caching child references. Something like `@onready var damage = base_damage * difficulty_multiplier` waits for dependencies to populate. That use case is what `@onready` was designed for, and `@export` cannot replace it.
+
+The project has no `@onready` in production code today, including the deferred-computation case, so you should not need to add one. If you find a case where `@export` genuinely cannot cover the dependency, flag it in the PR thread and we will sort it out together.
 
 ## Full words
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -2,7 +2,7 @@
 
 Welcome. This is the short list of GDScript conventions we follow in Volley!. `gdformat` and `gdlint` handle most of the mechanical stuff for you; this file is for the project-specific calls those tools cannot make.
 
-None of this is meant to slow you down. The patterns here exist because they have repeatedly made the code easier to read, easier to refactor, and easier to onboard new contributors onto. If one does not fit your situation, open the PR and we will work it out.
+These patterns exist because they have repeatedly made the code easier to read, easier to refactor, and easier to onboard new contributors onto. If one feels wrong for your situation, open the PR and we will work it out.
 
 ## Blank line before every `if`
 
@@ -32,7 +32,7 @@ Wire child node references through `@export var name: NodeType` (or `@export var
 @export var collision: CollisionShape2D
 ```
 
-`@onready` exists in GDScript for a real reason: deferring evaluation of an arbitrary expression until the node enters the tree, not just caching child references. Something like `@onready var damage = base_damage * difficulty_multiplier` waits for dependencies to populate. That use case is what `@onready` was designed for, and `@export` cannot replace it.
+`@onready` exists in GDScript for deferring evaluation of an arbitrary expression until the node enters the tree, beyond simply caching child references. Something like `@onready var damage = base_damage * difficulty_multiplier` waits for dependencies to populate. That use case is what `@onready` was designed for, and `@export` cannot replace it.
 
 The project has no `@onready` in production code today, including the deferred-computation case, so you should not need to add one. If you find a case where `@export` genuinely cannot cover the dependency, flag it in the PR thread and we will sort it out together.
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -23,7 +23,7 @@ if remaining <= step:
     return
 ```
 
-## `@export` over `@onready` for child nodes
+## `@export` for child nodes, not `@onready`
 
 Wire child node references through `@export var name: NodeType` (or `@export var name: NodePath`) rather than `@onready var name = $Path`. Exports survive scene renames, fail loudly when the wire breaks, and show the dependency in the inspector, all of which save time the next time someone reorganises a scene.
 
@@ -32,7 +32,7 @@ Wire child node references through `@export var name: NodeType` (or `@export var
 @export var collision: CollisionShape2D
 ```
 
-`@onready` still has its place: things the script genuinely owns, like a Timer it creates, or a value computed once at ready time.
+The project has no `@onready` in production code today, and you should not need to add one. If you find a case where `@export` genuinely cannot cover the dependency, flag it in the PR thread and we will sort it out together.
 
 ## Full words
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,21 +67,19 @@ The GitHub issue thread is the right place. Decisions live there, future contrib
 
 ## Commit messages
 
-We use [Conventional Commits](https://www.conventionalcommits.org). The first line is `<type>: <subject>`, present tense, lowercase. Types in regular use: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `perf`.
+We follow [Conventional Commits](https://www.conventionalcommits.org) so the history reads cleanly and the changelog can write itself. The first line is `<type>: <subject>`, in the present tense and lowercase. The types you will reach for most are `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, and `perf`.
 
 ```
 feat: ascend back to the lane via physics after walking on
 ```
 
-For breaking changes (save format wipe, public API rename, workflow input shift), suffix the type with `!`:
+When a change breaks compatibility (a save format wipe, a public API rename, a workflow input shift, anything a downstream reader needs to act on), add `!` after the type. The bang is what our autolabeller picks up, and what surfaces in the squash-merge commit and the changelog so the people who care can find it.
 
 ```
 feat!: drop floor_y from TimeoutConfig; descent grounds on physics
 ```
 
-The `!` is the autolabel signal that the change is breaking; readers see it in the squash-merge commit and in the changelog.
-
-Keep the subject under ~70 characters. If a body is needed, write it as one or two sentences explaining the why.
+Aim for a subject under about seventy characters. If there is more to say, a short body of one or two sentences explaining the why goes a long way; reviewers love the context.
 
 ## Sign your commits (DCO)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,24 @@ Full list of labels in [`designs/process/labels.md`](designs/process/labels.md).
 
 The GitHub issue thread is the right place. Decisions live there, future contributors can find them, and maintainers read everything. No question is too small.
 
+## Commit messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org). The first line is `<type>: <subject>`, present tense, lowercase. Types in regular use: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `perf`.
+
+```
+feat: ascend back to the lane via physics after walking on
+```
+
+For breaking changes (save format wipe, public API rename, workflow input shift), suffix the type with `!`:
+
+```
+feat!: drop floor_y from TimeoutConfig; descent grounds on physics
+```
+
+The `!` is the autolabel signal that the change is breaking; readers see it in the squash-merge commit and in the changelog.
+
+Keep the subject under ~70 characters. If a body is needed, write it as one or two sentences explaining the why.
+
 ## Sign your commits (DCO)
 
 We use the [Developer Certificate of Origin](https://developercertificate.org) instead of a Contributor License Agreement. It is a lightweight way of saying "I wrote this, or I have the right to submit it under the project's license." Every commit needs a `Signed-off-by:` line, added automatically with:

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -241,6 +241,25 @@ So that [downstream decision that depends on the answer]
 - [ ] No regression in related systems
 ```
 
+### Worked example
+
+Filled-in user story so the shape reads in context. Title under 50 characters; body under twelve lines; acceptance criteria are player-observable, not implementation-shaped.
+
+> **Title:** Equip flow with kit cap
+>
+> As the player,
+> I want to drag gear onto the character during the timeout window.
+> So that I can shape my kit between rallies.
+>
+> **Acceptance Criteria:**
+>
+> - [ ] During the equip window, dragging a gear item onto the character equips it.
+> - [ ] When the kit is full, the character refuses the drop and the item bounces back to where the drag started.
+> - [ ] Dragging an equipped item back to the rack unequips it and frees its slot.
+> - [ ] Outside the equip window, the character does not accept or react to dropped gear.
+
+The acceptance criteria name what the player sees, not the classes, signals, or fields that implement them. A reviewer (or a contributor verifying their own work) can run the game and check each line by playing.
+
 ---
 
 ## Writing for open-source contributors

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -243,7 +243,7 @@ So that [downstream decision that depends on the answer]
 
 ### Worked example
 
-Filled-in user story so the shape reads in context. Title under 50 characters; body under twelve lines; acceptance criteria are player-observable, not implementation-shaped.
+A template is easier to follow with a filled-in version next to it, so here is the user-story shape applied to a real ticket. Title under fifty characters, body under twelve lines, and acceptance criteria written so anyone with a build of the game can check each line by playing.
 
 > **Title:** Equip flow with kit cap
 >
@@ -258,7 +258,7 @@ Filled-in user story so the shape reads in context. Title under 50 characters; b
 > - [ ] Dragging an equipped item back to the rack unequips it and frees its slot.
 > - [ ] Outside the equip window, the character does not accept or react to dropped gear.
 
-The acceptance criteria name what the player sees, not the classes, signals, or fields that implement them. A reviewer (or a contributor verifying their own work) can run the game and check each line by playing.
+Notice that the criteria name what the player sees, not the classes, signals, or fields underneath. That is the part that matters: a contributor verifying their own work, or a reviewer signing off, can answer each line by playing rather than by reading source. It also means the ticket survives a refactor; if the implementation changes but the player experience does not, the AC is still met.
 
 ---
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -139,8 +139,6 @@ The full GUT suite is fast, and we like it that way. The fast feedback loop is o
 
 The usual culprit is waiting for real frames. Swap `await get_tree().physics_frame` loops for deterministic stepping: call the controller's `_physics_process(virtual_delta)` directly with a chosen delta, advance tweens with `tween.custom_step(...)`, step the physics server with `PhysicsServer2D.step`. The production code is unchanged; the test just stops paying the wall-clock cost of waiting for real frames.
 
-When a change moves the suite, report the exact wall times. Specific numbers are more useful than approximations, and giving both the before and after lets the reviewer (and the next person diagnosing a regression) see the shape of the change.
-
 ## CI
 
 Tests run on every push to non-main branches via `.github/workflows/test.yml`. The `logs/` directory must be created before running GUT (`mkdir -p logs`) to prevent a crash from GUT's file logger.

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -135,19 +135,18 @@ The physics dispatch path (`body_entered` -> `_on_body_entered` -> duck-typed me
 
 ## Test budget
 
-The full GUT suite is fast and we keep it that way. A new test case should not push the per-case average up. Concretely: at the time of writing the suite runs in roughly two seconds across ~700 tests, so each case averages about three milliseconds. If your new case takes noticeably longer than the existing average, the fixture is doing too much real-time work; switch to deterministic stepping (`controller._physics_process(virtual_delta)`, `tween.custom_step(...)`, manual `PhysicsServer2D.step`) instead of awaiting real frames.
+The full GUT suite is fast, and we like it that way. The fast feedback loop is one of the reasons working on this codebase feels light, and it only stays fast if every new case respects that. The rule of thumb: a new case should not push the per-case average up. The suite currently runs in roughly two seconds across about seven hundred tests, so each case averages somewhere around three milliseconds.
 
-Report exact wall times when a change moves the suite. Quote `11.6s` not `~12s`, and give before and after when you have both numbers.
+If your case is taking noticeably longer than that, the fixture is almost always doing too much real-time work. Swap `await get_tree().physics_frame` loops for deterministic stepping: call the controller's `_physics_process(virtual_delta)` directly with a chosen delta, advance tweens with `tween.custom_step(...)`, step the physics server with `PhysicsServer2D.step`. The production code is unchanged; the test just stops paying the wall-clock cost of waiting for real frames.
+
+When a change moves the suite, report the exact wall times. `11.6s` reads better than `~12s`, and giving both the before and after numbers lets the reviewer (and the next person diagnosing a regression) see the shape of the change.
 
 ## CI
 
 Tests run on every push to non-main branches via `.github/workflows/test.yml`. The `logs/` directory must be created before running GUT (`mkdir -p logs`) to prevent a crash from GUT's file logger.
 
-CI fails the build on any of the following in GUT output:
+CI is strict about output noise. The build fails on any `WARNING`, `ERROR`, `SCRIPT ERROR`, `USER WARNING`, or `USER ERROR` line in the GUT output, and on any orphan count (per-test `N Orphans` where `N > 0`) or exit-time `ObjectDB instances leaked at exit`. We are strict because leaks compound: a few orphans per test become impossible to triage later, and warnings hide real regressions in the noise.
 
-- A `WARNING`, `ERROR`, `SCRIPT ERROR`, `USER WARNING`, or `USER ERROR` line.
-- An orphan count (per-test `N Orphans` where `N > 0`) or exit-time `ObjectDB instances leaked at exit`.
+If your change introduces a leak, fix it before pushing rather than carrying it forward. The two surfaces, per-test orphans and exit-time leaks, are independent, so it is worth checking both; grepping one will not catch the other.
 
-Fix new leaks inline; do not carry them forward. The two surfaces (per-test orphans and exit-time leaks) are independent; grepping one does not catch the other, so check both.
-
-The one known WARNING class that CI filters is Godot's cold-cache UID lookup, which fires on first-run `--import` even when the project is valid. The filter in the workflow's `Leak gate` step matches the warning pattern and the paired `Failed loading resource` ERROR. Tracked upstream as [godot#101677](https://github.com/godotengine/godot/issues/101677), [godot#115205](https://github.com/godotengine/godot/issues/115205), [godot#109636](https://github.com/godotengine/godot/issues/109636), and [godot#100228](https://github.com/godotengine/godot/issues/100228). The workaround is to declare autoloads with `res://` paths, not `uid://` paths, so the import order does not depend on the cache.
+There is one warning class we deliberately filter: Godot's cold-cache UID lookup, which fires on a first-run `--import` even when the project is valid. The filter lives in the workflow's `Leak gate` step and matches the warning pattern plus the paired `Failed loading resource` ERROR that follows it. The upstream Godot issues that track this are [#101677](https://github.com/godotengine/godot/issues/101677), [#115205](https://github.com/godotengine/godot/issues/115205), [#109636](https://github.com/godotengine/godot/issues/109636), and [#100228](https://github.com/godotengine/godot/issues/100228). The workaround in the project is to declare autoloads with `res://` paths rather than `uid://` paths so the import order does not depend on the cache; if you are adding a new autoload, follow that pattern and you will not trip the filter.

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -133,6 +133,21 @@ Every integration test that exercises a player-facing AC drives the real input h
 
 The physics dispatch path (`body_entered` -> `_on_body_entered` -> duck-typed method call) is not covered by automated tests. It requires real physics collisions and is intentionally left as a manual QA item; it's two lines that rarely change.
 
+## Test budget
+
+The full GUT suite is fast and we keep it that way. A new test case should not push the per-case average up. Concretely: at the time of writing the suite runs in roughly two seconds across ~700 tests, so each case averages about three milliseconds. If your new case takes noticeably longer than the existing average, the fixture is doing too much real-time work; switch to deterministic stepping (`controller._physics_process(virtual_delta)`, `tween.custom_step(...)`, manual `PhysicsServer2D.step`) instead of awaiting real frames.
+
+Report exact wall times when a change moves the suite. Quote `11.6s` not `~12s`, and give before and after when you have both numbers.
+
 ## CI
 
 Tests run on every push to non-main branches via `.github/workflows/test.yml`. The `logs/` directory must be created before running GUT (`mkdir -p logs`) to prevent a crash from GUT's file logger.
+
+CI fails the build on any of the following in GUT output:
+
+- A `WARNING`, `ERROR`, `SCRIPT ERROR`, `USER WARNING`, or `USER ERROR` line.
+- An orphan count (per-test `N Orphans` where `N > 0`) or exit-time `ObjectDB instances leaked at exit`.
+
+Fix new leaks inline; do not carry them forward. The two surfaces (per-test orphans and exit-time leaks) are independent; grepping one does not catch the other, so check both.
+
+The one known WARNING class that CI filters is Godot's cold-cache UID lookup, which fires on first-run `--import` even when the project is valid. The filter in the workflow's `Leak gate` step matches the warning pattern and the paired `Failed loading resource` ERROR. Tracked upstream as [godot#101677](https://github.com/godotengine/godot/issues/101677), [godot#115205](https://github.com/godotengine/godot/issues/115205), [godot#109636](https://github.com/godotengine/godot/issues/109636), and [godot#100228](https://github.com/godotengine/godot/issues/100228). The workaround is to declare autoloads with `res://` paths, not `uid://` paths, so the import order does not depend on the cache.

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -135,11 +135,11 @@ The physics dispatch path (`body_entered` -> `_on_body_entered` -> duck-typed me
 
 ## Test budget
 
-The full GUT suite is fast, and we like it that way. The fast feedback loop is one of the reasons working on this codebase feels light, and it only stays fast if every new case respects that. The rule of thumb: a new case should not push the per-case average up. The suite currently runs in roughly two seconds across about seven hundred tests, so each case averages somewhere around three milliseconds.
+The full GUT suite is fast, and we like it that way. The fast feedback loop is one of the reasons working on this codebase feels light, and it only stays fast if every new case respects that. The rule of thumb: a new case should not push the per-case average up. Run the suite, note the wall time, add your case, run it again; if the average per test got slower, the fixture is doing too much real-time work.
 
-If your case is taking noticeably longer than that, the fixture is almost always doing too much real-time work. Swap `await get_tree().physics_frame` loops for deterministic stepping: call the controller's `_physics_process(virtual_delta)` directly with a chosen delta, advance tweens with `tween.custom_step(...)`, step the physics server with `PhysicsServer2D.step`. The production code is unchanged; the test just stops paying the wall-clock cost of waiting for real frames.
+The usual culprit is waiting for real frames. Swap `await get_tree().physics_frame` loops for deterministic stepping: call the controller's `_physics_process(virtual_delta)` directly with a chosen delta, advance tweens with `tween.custom_step(...)`, step the physics server with `PhysicsServer2D.step`. The production code is unchanged; the test just stops paying the wall-clock cost of waiting for real frames.
 
-When a change moves the suite, report the exact wall times. `11.6s` reads better than `~12s`, and giving both the before and after numbers lets the reviewer (and the next person diagnosing a regression) see the shape of the change.
+When a change moves the suite, report the exact wall times. Specific numbers are more useful than approximations, and giving both the before and after lets the reviewer (and the next person diagnosing a regression) see the shape of the change.
 
 ## CI
 


### PR DESCRIPTION
Propagating four internal rules to the contributor-facing docs:

- **New CODE_STYLE.md** at repo root covers the GDScript conventions lint does not enforce: blank line before `if`, `@export` over `@onready`, full words and descriptive names, one-line WHY-only comments, data-driven tunables, and `Resource` over loose `@export` when a cluster forms.
- **tests/TESTING.md** gains a *Test budget* section (no individual case grows the suite past its average) and a *CI* section listing the warning / orphan classes that fail the build, plus the cold-cache UID filter with upstream Godot issue links (#101677, #115205, #109636, #100228).
- **CONTRIBUTING.md** gains a *Commit messages* section naming the conventional shape and the breaking-change `!` suffix with a worked example.
- **designs/process/ticket-writing.md** gains a filled-in user-story example so the shape reads in context after the templates.