### PR TITLE
chore: name 2D physics layers (world=1, items=2)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -85,6 +85,8 @@ camera_right={
 [physics]
 
 3d/physics_engine="Jolt Physics"
+2d/layer_names/layer_1="world"
+2d/layer_names/layer_2="items"
 
 [rendering]
 


### PR DESCRIPTION
Names the two physics layers in `project.godot` so the inspector shows intent (`world`, `items`) instead of bare numbers. No behaviour change; the integer math is identical. The follow-up spike covers the bigger move (a constants module so `.gd` callsites stop referencing magic numbers); that one is a separate decision.

Small unblock for the audit-on-layer-change discipline; sharpened in memory after the SH-405 ball-layer ripple.