### PR TITLE
fix(ci): strip zaphod-requested when a verdict lands

### DIFF
--- a/.github/workflows/reviewer-re-run.yml
+++ b/.github/workflows/reviewer-re-run.yml
@@ -1,12 +1,15 @@
 name: Reviewer Re-run
 
-# Label lifecycle for the zaphod-* verdicts. Two reconcilers live here:
+# Label lifecycle for the zaphod-* verdicts. Three reconcilers live here:
 #
 #   - strip-zaphod-on-push: new commit strips all three zaphod-* labels
 #     (requested, approved, blocked); the request and any verdict must be
 #     re-earned against the new HEAD. Re-dispatch is manual, by the
 #     organiser (main Claude thread), never CI; PR-triggered workflows
 #     do not run Claude because outside PRs are a prompt-injection surface.
+#   - verdict-strips-request: when zaphod-approved or zaphod-blocked lands,
+#     zaphod-requested has been answered and gets stripped. The request was
+#     "please review"; the verdict closes that request either way.
 #   - blocked-supersedes-approved (SH-166): when two specialists race and
 #     one lands blocked after the other landed approved, the blocker wins.
 #     approved is removed so the merged state reflects the combined verdict.
@@ -57,6 +60,43 @@ jobs:
                 } else {
                   throw error;
                 }
+              }
+            }
+
+  verdict-strips-request:
+    # zaphod-requested is a "please review" signal from Josh; once a verdict
+    # lands (approved or blocked), the request is answered. Stripping it
+    # avoids the next PR-state summary mis-reading a stale request as "still
+    # waiting" when reviewers have already verdict'd.
+    name: Verdict strips request label
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      (github.event.label.name == 'zaphod-approved' ||
+       github.event.label.name == 'zaphod-blocked')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Remove zaphod-requested if present
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'zaphod-requested',
+              });
+              core.info('Removed zaphod-requested; verdict closes the request.');
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('zaphod-requested not present; nothing to strip.');
+              } else {
+                throw error;
               }
             }
 


### PR DESCRIPTION
A `zaphod-approved` or `zaphod-blocked` label is the answer to a `zaphod-requested` ask. Once the verdict is in, the request is closed; leaving the request label on the PR makes downstream summaries mis-read state as "still waiting" when reviewers have already verdict'd. This adds a small workflow job that strips `zaphod-requested` whenever a verdict label lands, symmetric to the existing `blocked-supersedes-approved` race resolver.

Sits in `.github/workflows/reviewer-re-run.yml` alongside the other two zaphod-* reconcilers. Comment block at the top updated to name all three.