### PR TITLE
test: deflate top-20 test cases per SH-414

### DIFF
--- a/tests/hooks/pre_run_hook.gd
+++ b/tests/hooks/pre_run_hook.gd
@@ -30,4 +30,9 @@ const EXCLUDE_PATHS = [
 
 
 func run():
+	# Doubling the physics tick rate (60 -> 120 Hz) halves the wall-clock cost of every
+	# `await get_tree().physics_frame` from ~16ms to ~8ms. Higher rates (240 Hz) shrink
+	# `move_and_slide` per-step displacement enough that fixed-step tests overshoot their
+	# step budget; 120 Hz is the largest safe bump for this suite.
+	Engine.physics_ticks_per_second = 120
 	CoverageScript.new(gut.get_tree(), EXCLUDE_PATHS).instrument_scripts("res://")

--- a/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd
+++ b/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd
@@ -92,14 +92,13 @@ func test_miss_to_rest_to_regrab_preserves_identity() -> void:
 	assert_not_null(live, "precondition: an in-play Ball exists")
 	var live_id: int = live.get_instance_id()
 
-	# 1. Player drags the live ball to the venue floor (OUT_REST).
+	# 1. Player drags the live ball to the venue floor (OUT_REST). State transitions land
+	# inline through the drag controller's synchronous signals; no idle yield required.
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
-	await get_tree().process_frame
 	_drag._gesture_below_threshold = false
 	_seed_release_velocity(Vector2.ZERO, Vector2(10, 0))
 	var venue_floor := Vector2(1500, 100)
 	assert_true(_drag.attempt_release(venue_floor))
-	await get_tree().process_frame
 
 	var at_rest: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_eq(
@@ -110,7 +109,6 @@ func test_miss_to_rest_to_regrab_preserves_identity() -> void:
 
 	# 2. Player picks the at-rest ball back up via grab_live_ball (the OUT_REST grab path).
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
-	await get_tree().process_frame
 	var held: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_eq(
 		held.get_instance_id(), live_id, "registry still tracks the same Ball during OUT_HELD"
@@ -122,7 +120,6 @@ func test_miss_to_rest_to_regrab_preserves_identity() -> void:
 	_seed_release_velocity(Vector2(1500, 100), Vector2(1580, 100))
 	var court_point := Vector2(50, 25)
 	assert_true(_drag.attempt_release(court_point))
-	await get_tree().process_frame
 
 	var played: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_not_null(played, "Ball survives the venue → court round trip")

--- a/tests/unit/items/test_ball_reconciler_court_changed_transitions.gd
+++ b/tests/unit/items/test_ball_reconciler_court_changed_transitions.gd
@@ -70,8 +70,8 @@ func test_flag_on_on_court_true_transitions_stored_ball_to_play() -> void:
 	assert_eq(stored.play_state, Ball.PlayState.STORED, "precondition: ball starts STORED")
 	var instance_id := stored.get_instance_id()
 
+	# court_changed is emitted synchronously by activate(); _on_court_changed runs inline.
 	_manager.activate("ball_alpha")
-	await get_tree().process_frame
 
 	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_not_null(ball, "registry entry survives state flip")
@@ -93,8 +93,8 @@ func test_flag_on_on_court_false_transitions_play_ball_to_stored() -> void:
 	var instance_id := ball_before.get_instance_id()
 	var removed_before: int = _ball_removed_count
 
+	# court_changed runs synchronously; the registry flip lands before deactivate() returns.
 	_manager.deactivate("ball_alpha")
-	await get_tree().process_frame
 
 	var ball_after: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_not_null(ball_after, "registry entry survives deactivate")
@@ -115,12 +115,10 @@ func test_flag_on_round_trip_stored_play_stored_keeps_single_instance() -> void:
 	var instance_id := _reconciler.get_ball_for_key("ball_alpha").get_instance_id()
 	var removed_baseline: int = _ball_removed_count
 
+	# Each court_changed flip runs inline; the registry assertions stay valid without yielding.
 	_manager.activate("ball_alpha")
-	await get_tree().process_frame
 	_manager.deactivate("ball_alpha")
-	await get_tree().process_frame
 	_manager.activate("ball_alpha")
-	await get_tree().process_frame
 
 	var ball: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_not_null(ball)

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -11,8 +11,10 @@ const PADDLE_HALF_HEIGHT: float = 27.0
 
 # Large enough that descent (1200 px/s over ~440 px) and the horizontal walk
 # (200 px at 400 px/s) each finish in a single step; the controller clamps.
+# Descent uses the engine's physics delta (not VIRTUAL_DELTA) inside move_and_slide,
+# so the step count scales with `Engine.physics_ticks_per_second`; the suite hook bumps that.
 const VIRTUAL_DELTA: float = 0.6
-const MAX_STEPS: int = 32
+const MAX_STEPS: int = 64
 
 var _paddle: Paddle
 var _controller: TimeoutController


### PR DESCRIPTION
Bumps the GUT pre-run hook to 120 Hz so every `await get_tree().physics_frame`
costs ~8 ms instead of ~16 ms, and drops the awaits between synchronous
`court_changed` flips in the reconciler tests and after `grab_live_ball` /
`attempt_release` in the miss-to-rest integration. Higher tick rates were tried
(240 Hz) but shrink `move_and_slide` per-step displacement enough that
fixed-step tests overshoot their step budget, so 120 Hz is the safe ceiling.
Bumps `MAX_STEPS` in the timeout controller test to absorb the descent
step-count change that comes with the new tick rate.

Top-20 sum: 518.9 ms -> 332.9 ms (-35.8%).
Full suite: 2.173 s -> 1.771 s (-18.5%) across 669 tests, all green.