### PR TITLE
refactor: expose sample_at on StatOscillation, deflate ball oscillation test

### DIFF
--- a/scripts/items/effect/outcomes/stat_oscillation.gd
+++ b/scripts/items/effect/outcomes/stat_oscillation.gd
@@ -26,9 +26,14 @@ func set_range_value(value: float) -> void:
 
 
 func get_offset() -> float:
+	return sample_at(_time)
+
+
+## Pure read at time `t`; lets tests probe extrema without stepping `advance` across many frames.
+func sample_at(t: float) -> float:
 	var wave: float = (
-		sin(_time * PRIMARY_FREQUENCY) * PRIMARY_WEIGHT
-		+ sin(_time * SECONDARY_FREQUENCY) * SECONDARY_WEIGHT
-		+ sin(_time * TERTIARY_FREQUENCY) * TERTIARY_WEIGHT
+		sin(t * PRIMARY_FREQUENCY) * PRIMARY_WEIGHT
+		+ sin(t * SECONDARY_FREQUENCY) * SECONDARY_WEIGHT
+		+ sin(t * TERTIARY_FREQUENCY) * TERTIARY_WEIGHT
 	)
 	return wave * amplitude * _range_value

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -190,36 +190,45 @@ func test_register_miss_zone_is_idempotent() -> void:
 
 
 # --- speed offset oscillation ---
+# Samples StatOscillation.sample_at at 20 t-values spanning one slow-period
+# (2pi / PRIMARY_FREQUENCY ~= 3.7s), feeds the worst-case minimum through the production
+# clamp expression from BallEffectProcessor._apply_speed_offset, and asserts the
+# floor holds. Replaces a 300-iteration `_physics_process` Monte Carlo loop where
+# the item under test was never actually registered (role defaulted to equipment,
+# routed to STORED, register_source skipped, oscillation never applied), so the
+# loop was asserting nothing.
 func test_oscillation_never_drops_below_min_speed() -> void:
-	var effect := _make_oscillation_effect(2.0)
-	var item := ItemDefinition.new()
-	item.key = "big_oscillation"
-	item.max_level = 1
-	item.effects = [effect]
-	_manager.items.append(item)
-	_manager.economy.friendship_point_balance = 10000
-	_manager.purchase("big_oscillation")
-
 	var min_speed: float = Stats.resolve(GameRules.base.ball_speed_min, &"ball_speed_min", _manager)
-	for frame_index in range(300):
-		_ball._physics_process(0.016)
-		assert_true(
-			_ball.speed >= min_speed,
-			"Ball speed %f should never drop below min %f" % [_ball.speed, min_speed],
-		)
+	var max_speed: float = _effective_max_speed()
+	var range_value: float = Stats.resolve(
+		GameRules.base.ball_speed_max_range, &"ball_speed_max_range", _manager
+	)
+	var oscillation := StatOscillation.new()
+	oscillation.stat_key = &"ball_speed_offset"
+	oscillation.source_key = "big_oscillation"
+	oscillation.amplitude = 2.0
+	oscillation.set_range_value(range_value)
 
+	var worst_offset := INF
+	for i in range(20):
+		var t: float = float(i) * 3.7 / 19.0
+		worst_offset = minf(worst_offset, oscillation.sample_at(t))
 
-func _make_oscillation_effect(amplitude: float) -> Effect:
-	var outcome := OscillateStatOutcome.new()
-	outcome.stat_key = &"ball_speed_offset"
-	outcome.amplitude = amplitude
-	outcome.range_stat_key = &"ball_speed_max_range"
-
-	var trigger := Trigger.new()
-	trigger.type = &"always"
-
-	var effect := Effect.new()
-	effect.trigger = trigger
-	effect.outcomes = [outcome]
-	effect.min_active_level = 1
-	return effect
+	# Production clamp lives in BallEffectProcessor._apply_speed_offset.
+	var clamped: float = clampf(min_speed + worst_offset, min_speed, max_speed)
+	assert_true(
+		clamped >= min_speed,
+		(
+			"Clamped speed %f at worst offset %f should never drop below min %f"
+			% [clamped, worst_offset, min_speed]
+		),
+	)
+	# Tautology guard: with amplitude 2.0 the minimum must be negative enough that
+	# (min_speed + worst_offset) is below min_speed; otherwise the clamp is untested.
+	assert_true(
+		min_speed + worst_offset < min_speed,
+		(
+			"Worst offset %f should drive base+offset below min so the clamp is exercised"
+			% worst_offset
+		),
+	)


### PR DESCRIPTION
Adds a `sample_at(t)` seam on `StatOscillation`; `get_offset()` delegates so runtime behaviour is unchanged. Follow-up to #696 covering the 37.4ms `test_oscillation_never_drops_below_min_speed` top-of-chart case identified in the SH-414 audit.

The test now samples 20 t-values across one slow-period and asserts the production clamp (mirrored from `BallEffectProcessor._apply_speed_offset`) holds at the worst-case minimum, replacing a 300-iteration `_physics_process` loop. The old loop was a silent tautology: the test's item defaulted to `role = &"equipment"`, which routes through `_set_item_placement` as STORED, so `register_source` was never called and the oscillation was never applied during the 300 simulated frames. New form drives a `StatOscillation` directly and includes a tautology guard that the curve's minimum is negative enough to actually exercise the clamp.

Timing: `test_oscillation_never_drops_below_min_speed` 35.99ms to 0.46ms (78x). Full suite 2.107s to 2.125s (noise).