### PR TITLE
test: revert tick-rate bump, keep async drops

### DIFF
--- a/tests/hooks/pre_run_hook.gd
+++ b/tests/hooks/pre_run_hook.gd
@@ -30,9 +30,4 @@ const EXCLUDE_PATHS = [
 
 
 func run():
-	# Doubling the physics tick rate (60 -> 120 Hz) halves the wall-clock cost of every
-	# `await get_tree().physics_frame` from ~16ms to ~8ms. Higher rates (240 Hz) shrink
-	# `move_and_slide` per-step displacement enough that fixed-step tests overshoot their
-	# step budget; 120 Hz is the largest safe bump for this suite.
-	Engine.physics_ticks_per_second = 120
 	CoverageScript.new(gut.get_tree(), EXCLUDE_PATHS).instrument_scripts("res://")

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -11,10 +11,8 @@ const PADDLE_HALF_HEIGHT: float = 27.0
 
 # Large enough that descent (1200 px/s over ~440 px) and the horizontal walk
 # (200 px at 400 px/s) each finish in a single step; the controller clamps.
-# Descent uses the engine's physics delta (not VIRTUAL_DELTA) inside move_and_slide,
-# so the step count scales with `Engine.physics_ticks_per_second`; the suite hook bumps that.
 const VIRTUAL_DELTA: float = 0.6
-const MAX_STEPS: int = 64
+const MAX_STEPS: int = 32
 
 var _paddle: Paddle
 var _controller: TimeoutController


### PR DESCRIPTION
Unwinds Bex's global `Engine.physics_ticks_per_second = 120` from PR #696's pre-run hook (and the compensating MAX_STEPS 32 to 64 in test_timeout_controller). Running tests at twice the production tick rate creates silent divergence for any future code that frame-counts or reads engine delta. The MAX_STEPS bump was the first symptom: a test had to be doctored to compensate for the global, and a fragility ceiling at 240 Hz (Bex tried it, it broke airborne timeout tests on shrinking move_and_slide displacement) said the approach does not scale.

The async drops Bex made in `test_ball_reconciler_court_changed_transitions` and `test_miss_to_rest_to_regrab_preserves_identity` stay. Both reviewer specialists (Eli, test-coverage; Dax, devils-advocate) confirmed the targeted signal chains emit synchronously, so the drops are dead-yield removal, not silent weakening.

Per-case sweeps with direct `_process(delta)` / `_physics_process(delta)` calls (the researcher's #1 free win for SH-414) replace the global. Suite at 60 Hz / 32 MAX_STEPS: 2.085s across 669 tests.