### PR TITLE
fix: require explicit role on ItemDefinition

### DIFF
--- a/resources/items/ankle_weights.tres
+++ b/resources/items/ankle_weights.tres
@@ -30,6 +30,7 @@ max_active_level = null
 script = ExtResource("1_item")
 key = "ankle_weights"
 type = &"kit"
+role = &"equipment"
 display_name = "Ankle Weights"
 art = ExtResource("6_art")
 descriptions = Array[String](["Heavy steps", "Didn't notice the difference until I took them off", "Still wearing them"])

--- a/resources/items/cadence.tres
+++ b/resources/items/cadence.tres
@@ -48,6 +48,7 @@ max_active_level = null
 script = ExtResource("1_item")
 key = "cadence"
 type = &"kit"
+role = &"equipment"
 display_name = "Cadence"
 art = ExtResource("7_art")
 descriptions = Array[String](["Sounds wrong", "Don't stop. Won't stop", "Was anyone listening?"])

--- a/resources/items/court_lines.tres
+++ b/resources/items/court_lines.tres
@@ -30,6 +30,7 @@ max_active_level = null
 script = ExtResource("1_item")
 key = "court_lines"
 type = &"kit"
+role = &"equipment"
 display_name = "Court Lines"
 art = ExtResource("6_art")
 descriptions = Array[String](["Wider than it looks", "The ceiling keeps moving", "Drew them everywhere"])

--- a/resources/items/grip_tape.tres
+++ b/resources/items/grip_tape.tres
@@ -31,6 +31,7 @@ max_active_level = null
 script = ExtResource("1_item")
 key = "grip_tape"
 type = &"kit"
+role = &"equipment"
 display_name = "Grip Tape"
 art = ExtResource("6_art")
 descriptions = Array[String](["Covers more than you think", "Hard to miss now", "Held it together"])

--- a/resources/items/spare.tres
+++ b/resources/items/spare.tres
@@ -30,6 +30,7 @@ max_active_level = null
 script = ExtResource("1_item")
 key = "spare"
 type = &"court"
+role = &"equipment"
 display_name = "Spare"
 art = ExtResource("1_por0g")
 descriptions = Array[String](["There's always one left over", "Wasn't supposed to need it", "Nobody noticed it was missing"])

--- a/resources/items/wrist_brace.tres
+++ b/resources/items/wrist_brace.tres
@@ -46,6 +46,7 @@ max_active_level = null
 script = ExtResource("1_item")
 key = "wrist_brace"
 type = &"kit"
+role = &"equipment"
 display_name = "Wrist Brace"
 art = ExtResource("1_srhju")
 descriptions = Array[String](["Can't bend it", "Doesn't give", "Locked for good"])

--- a/scripts/items/item_definition.gd
+++ b/scripts/items/item_definition.gd
@@ -4,7 +4,8 @@ extends Resource
 @export var key: String
 @export var type: StringName = &""
 ## &"equipment" lives on the player; &"ball" lives on the court.
-@export var role: StringName = &"equipment"
+## Required; missing role fails the placement assertion (SH-414 oscillator-seam regression).
+@export var role: StringName = &""
 @export var display_name: String
 @export var art: PackedScene
 @export var descriptions: Array[String]

--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -337,6 +337,7 @@ func _set_item_placement(item_key: String, placement: int) -> void:
 	if previous == placement:
 		return
 	var item := _get_item(item_key)
+	assert(item.role != StringName(), "ItemDefinition.role must be set: " + item.key)
 	if placement == PlacementScript.STORED:
 		state.item_placements.erase(item_key)
 		_effect_manager.unregister_source(item)

--- a/tests/stubs/item_factory.gd
+++ b/tests/stubs/item_factory.gd
@@ -39,6 +39,7 @@ static func create(
 
 	var item := ItemDefinition.new()
 	item.key = item_key
+	item.role = &"equipment"
 	item.base_cost = 100
 	item.cost_scaling = 2.0
 	item.max_level = 3

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -194,6 +194,7 @@ func test_oscillation_never_drops_below_min_speed() -> void:
 	var effect := _make_oscillation_effect(2.0)
 	var item := ItemDefinition.new()
 	item.key = "big_oscillation"
+	item.role = &"equipment"
 	item.max_level = 1
 	item.effects = [effect]
 	_manager.items.append(item)


### PR DESCRIPTION
The equipment-leaning default on `ItemDefinition.role` was a silent trap. Items built via `ItemDefinition.new()` without setting `role` defaulted to `&"equipment"`, which routes through `_set_item_placement` as STORED and skips `register_source`. Cal's oscillator-seam work in #697 traced one tautological test back to this default; the test had been silently asserting nothing for its whole life.

Drops the default to `&""` (unset), asserts the field is set at the routing chokepoint in `_set_item_placement`, and stamps `role = &"equipment"` onto the six `.tres` files that were relying on the silent default (grip_tape, ankle_weights, wrist_brace, cadence, court_lines, spare). Ball-role items already carried explicit `role = &"ball"`.

Two test seams that built items inline picked up `role = &"equipment"` to match the behaviour the test was asserting; `tests/stubs/item_factory.gd` now stamps every factory-built item, and `tests/unit/ball/test_ball.gd::test_oscillation_never_drops_below_min_speed` carries an explicit role until #697 lands and replaces the body wholesale.

Suite stays green at 669 passing. Top-20 sum unchanged at 0.522s; total moved 1.601s to 1.651s (noise).