### PR TITLE
docs(skills): consolidate debrief flow into gru/debrief.md

### DIFF
--- a/ai/skills/gru/debrief.md
+++ b/ai/skills/gru/debrief.md
@@ -1,0 +1,79 @@
+---
+name: debrief
+description: How to wrap a mission, swarm, ride, or session. Read on "debrief", "mission complete", "retro", "wrap-up", "done with X". Six-step flow that ends with a project status update on Linear, not inline prose.
+---
+
+# Debrief
+
+A debrief is the closing pulse on a chunk of work. It is not a self-flattering orchestrator summary, and it does not live in conversation prose. The discipline below consolidates five memory rules that fired round after round in past sessions.
+
+## Six-step flow
+
+Read top-to-bottom before producing any debrief text.
+
+```
+[ ] 1. git status + git branch --show-current. Name what's dirty or "clean".
+[ ] 2. Dispatch three agents in parallel, briefed not to read each other's drafts:
+       - cold-read agent: surveys open / closed PRs, Linear state, commits
+       - devils-advocate: stress-tests what shipped, names blind spots
+       - CI miner: scrapes commit history and diffs for patterns
+[ ] 3. Fold the three drafts. Never write the orchestrator's draft yourself;
+       the orchestrator is in the seat that biased the work and lacks distance.
+[ ] 4. Post via mcp__linear__save_status_update(type: "project", project: <id>)
+       on the relevant project. NEVER as save_comment on issues, even when
+       issues lack a parent. Cross-cutting work goes on Swarm Hardening.
+[ ] 5. Action items section: every follow-up routed Filed / Memory-only / Parked.
+       No unstructured prose. If nothing, say "No follow-up issues required."
+[ ] 6. Flags section: list every flag added during the mission, or "none added"
+       explicitly. Flags that lived 10 commits and got deleted still get named.
+```
+
+## What goes in each section
+
+- **Headline.** What the mission shipped, in one sentence. State-assertion-shaped: "Equip flow with kit cap now ships through the rack-equip pose".
+- **What shipped.** Concrete PRs / issues / merged work, with links. The cold-read agent compiles this.
+- **What got blocked / descoped / wasted time.** The devils-advocate's reading. The orchestrator's draft underweights this every time.
+- **Patterns from the CI / commit history.** The miner's reading. Flag misnomers (per `feedback_flags_surface_or_skip`), redundant rounds, late-landed reviewer findings.
+- **Action items.** Each item gets one routing:
+  - **Filed**: issue ID + URL inline. Confirm with Josh first unless the finding is from a Gru Sister (Margo / Edith) on a Ride or Carnival (per `feedback_auto_issue_verified_sister_findings`).
+  - **Memory-only**: named with the memory file that captures the rule, no issue needed.
+  - **Parked**: explicit defer with a reason and who reopens.
+- **Flags.** Per `feedback_flags_surface_or_skip`. List every flag, even retired ones. "None added" is the default and gets stated.
+- **Lessons worth carrying forward.** Narrative; what to do differently next time.
+
+## Surface choice
+
+| Mission scope | Project to post on |
+|---|---|
+| Single ticket / feature mission | The mission's project (e.g. Equip Loop) |
+| Cycle-scope or cross-cutting | Swarm Hardening (agent-infra) |
+| Ride / Carnival output | The mission's project (player-facing) plus issues filed on Swarm Hardening for non-player findings |
+
+The milestone description stays the short brief statement it opened with. The debrief lives as a long-form status update; it is not the milestone description.
+
+## Agent briefs (for step 2)
+
+Each agent's brief explicitly:
+
+- Names "no em dashes" per `feedback_no_em_dashes`. The rule does not propagate unless stated; debrief text lands verbatim on Linear.
+- Tells the agent not to read any existing debrief draft. Independence is the load-bearing property.
+- Names the agent's specific lens (cold-read, devils-advocate, miner). One per agent; do not blur them.
+- Asks for plain prose findings, not a finished debrief draft.
+
+## Failure modes the rules exist to kill
+
+- **Self-flattering orchestrator draft.** Emphasises codenames dispatched and rules added; underweights what got blocked and what wasted time.
+- **Wrong surface.** Per-issue `save_comment` instead of project `save_status_update`. The pulse is project-scope.
+- **Silent dirt.** Tree was dirty when "mission complete" was posted; Godot drive-by re-imports or stash residue.
+- **Action items as unstructured prose.** "Service-account work is its own future issue when prioritised" is how an item vanishes.
+- **Flags glossed over.** A flag that lived ten commits and got retired before merge is still a flag worth naming.
+
+## Memory rules consolidated here
+
+- `feedback_git_status_before_debrief`
+- `feedback_debrief_source_linear_and_devils`
+- `feedback_swarm_retro`
+- `feedback_debrief_action_items`
+- `feedback_flags_surface_or_skip`
+
+Each of those memories is the load-bearing source. This skill is the assembly point so the orchestrator hits all five at once rather than one-at-a-time.

--- a/ai/skills/gru/debrief.md
+++ b/ai/skills/gru/debrief.md
@@ -1,79 +1,29 @@
 ---
 name: debrief
-description: How to wrap a mission, swarm, ride, or session. Read on "debrief", "mission complete", "retro", "wrap-up", "done with X". Six-step flow that ends with a project status update on Linear, not inline prose.
+description: How to wrap a mission, swarm, ride, or session. Read on "debrief", "mission complete", "retro", "wrap-up", "done with X". Six-step checklist; each step points at the memory file that owns the rule body.
 ---
 
 # Debrief
 
-A debrief is the closing pulse on a chunk of work. It is not a self-flattering orchestrator summary, and it does not live in conversation prose. The discipline below consolidates five memory rules that fired round after round in past sessions.
+A debrief is the closing pulse on a chunk of work. The discipline lives across five memory files; this skill is the assembly point so the orchestrator hits all five at once instead of one-at-a-time. Each step below names the action; the load-bearing detail lives in the linked memory.
 
-## Six-step flow
-
-Read top-to-bottom before producing any debrief text.
+## Checklist
 
 ```
-[ ] 1. git status + git branch --show-current. Name what's dirty or "clean".
-[ ] 2. Dispatch three agents in parallel, briefed not to read each other's drafts:
-       - cold-read agent: surveys open / closed PRs, Linear state, commits
-       - devils-advocate: stress-tests what shipped, names blind spots
-       - CI miner: scrapes commit history and diffs for patterns
-[ ] 3. Fold the three drafts. Never write the orchestrator's draft yourself;
-       the orchestrator is in the seat that biased the work and lacks distance.
-[ ] 4. Post via mcp__linear__save_status_update(type: "project", project: <id>)
-       on the relevant project. NEVER as save_comment on issues, even when
-       issues lack a parent. Cross-cutting work goes on Swarm Hardening.
-[ ] 5. Action items section: every follow-up routed Filed / Memory-only / Parked.
-       No unstructured prose. If nothing, say "No follow-up issues required."
-[ ] 6. Flags section: list every flag added during the mission, or "none added"
-       explicitly. Flags that lived 10 commits and got deleted still get named.
+[ ] 1. git status + git branch --show-current; name dirty or clean.
+       feedback_git_status_before_debrief
+[ ] 2. Dispatch three independent agents in parallel (cold-read, devils-advocate, CI miner).
+       feedback_debrief_source_linear_and_devils
+[ ] 3. Fold drafts. The orchestrator does not write the draft itself.
+       feedback_debrief_source_linear_and_devils
+[ ] 4. Post via mcp__linear__save_status_update on the relevant project.
+       feedback_debrief_source_linear_and_devils, feedback_swarm_retro
+[ ] 5. Route every action item Filed / Memory-only / Parked.
+       feedback_debrief_action_items
+[ ] 6. List every flag added during the mission, or state "none".
+       feedback_flags_surface_or_skip
 ```
 
-## What goes in each section
+## Triggers
 
-- **Headline.** What the mission shipped, in one sentence. State-assertion-shaped: "Equip flow with kit cap now ships through the rack-equip pose".
-- **What shipped.** Concrete PRs / issues / merged work, with links. The cold-read agent compiles this.
-- **What got blocked / descoped / wasted time.** The devils-advocate's reading. The orchestrator's draft underweights this every time.
-- **Patterns from the CI / commit history.** The miner's reading. Flag misnomers (per `feedback_flags_surface_or_skip`), redundant rounds, late-landed reviewer findings.
-- **Action items.** Each item gets one routing:
-  - **Filed**: issue ID + URL inline. Confirm with Josh first unless the finding is from a Gru Sister (Margo / Edith) on a Ride or Carnival (per `feedback_auto_issue_verified_sister_findings`).
-  - **Memory-only**: named with the memory file that captures the rule, no issue needed.
-  - **Parked**: explicit defer with a reason and who reopens.
-- **Flags.** Per `feedback_flags_surface_or_skip`. List every flag, even retired ones. "None added" is the default and gets stated.
-- **Lessons worth carrying forward.** Narrative; what to do differently next time.
-
-## Surface choice
-
-| Mission scope | Project to post on |
-|---|---|
-| Single ticket / feature mission | The mission's project (e.g. Equip Loop) |
-| Cycle-scope or cross-cutting | Swarm Hardening (agent-infra) |
-| Ride / Carnival output | The mission's project (player-facing) plus issues filed on Swarm Hardening for non-player findings |
-
-The milestone description stays the short brief statement it opened with. The debrief lives as a long-form status update; it is not the milestone description.
-
-## Agent briefs (for step 2)
-
-Each agent's brief explicitly:
-
-- Names "no em dashes" per `feedback_no_em_dashes`. The rule does not propagate unless stated; debrief text lands verbatim on Linear.
-- Tells the agent not to read any existing debrief draft. Independence is the load-bearing property.
-- Names the agent's specific lens (cold-read, devils-advocate, miner). One per agent; do not blur them.
-- Asks for plain prose findings, not a finished debrief draft.
-
-## Failure modes the rules exist to kill
-
-- **Self-flattering orchestrator draft.** Emphasises codenames dispatched and rules added; underweights what got blocked and what wasted time.
-- **Wrong surface.** Per-issue `save_comment` instead of project `save_status_update`. The pulse is project-scope.
-- **Silent dirt.** Tree was dirty when "mission complete" was posted; Godot drive-by re-imports or stash residue.
-- **Action items as unstructured prose.** "Service-account work is its own future issue when prioritised" is how an item vanishes.
-- **Flags glossed over.** A flag that lived ten commits and got retired before merge is still a flag worth naming.
-
-## Memory rules consolidated here
-
-- `feedback_git_status_before_debrief`
-- `feedback_debrief_source_linear_and_devils`
-- `feedback_swarm_retro`
-- `feedback_debrief_action_items`
-- `feedback_flags_surface_or_skip`
-
-Each of those memories is the load-bearing source. This skill is the assembly point so the orchestrator hits all five at once rather than one-at-a-time.
+Read this skill when the user prompt or task notification names any of: `debrief`, `mission complete`, `mission close`, `wrap up`, `retro`, `done with X`. The UserPromptSubmit hook at `~/.claude/hooks/debrief-flow-signal.sh` injects a reminder when the trigger phrase appears.

--- a/ai/skills/gru/dispatch.md
+++ b/ai/skills/gru/dispatch.md
@@ -223,6 +223,10 @@ On every challenge sweep, check `gh pr view <n> --json state,mergedAt,mergeable,
 
 There is no bot applying `zaphod-conflicts`; Gru owns it.
 
+## Mission close
+
+When the mission's work is done (PRs merged, issue Closed, swarm dispersed), read `ai/skills/gru/debrief.md` and run the six-step flow. The skill consolidates `git status` first, three independent agents in parallel, fold their drafts, post via `save_status_update` on the relevant project, route every action item, list every flag. Do not write the orchestrator's inline summary; that draft is biased and the rule exists because the orchestrator-draft failure mode keeps recurring.
+
 ## Cleanup
 
 Worktrees come down after each stage (push, ready-for-merge, abandon). Recreate on revision; sibling to main worktree, not under `/tmp`.

--- a/ai/skills/gru/dispatch.md
+++ b/ai/skills/gru/dispatch.md
@@ -225,7 +225,7 @@ There is no bot applying `zaphod-conflicts`; Gru owns it.
 
 ## Mission close
 
-When the mission's work is done (PRs merged, issue Closed, swarm dispersed), read `ai/skills/gru/debrief.md` and run the six-step flow. The skill consolidates `git status` first, three independent agents in parallel, fold their drafts, post via `save_status_update` on the relevant project, route every action item, list every flag. Do not write the orchestrator's inline summary; that draft is biased and the rule exists because the orchestrator-draft failure mode keeps recurring.
+When the mission's work is done, read `ai/skills/gru/debrief.md`.
 
 ## Cleanup
 


### PR DESCRIPTION
Five memory rules governed the debrief flow but kept firing one-at-a-time. Today during the SH-414 wrap I posted an inline orchestrator summary, missing the project status update + three-agent-dispatch the rules require.

The skill assembles the six-step flow (git status first, three independent agents in parallel, fold drafts, post via save_status_update on the relevant project, route every action item, list every flag). dispatch.md gains a mission-close pointer so the trigger sits inside the orchestrator's seven-step model. A UserPromptSubmit hook in settings.json (not in this PR) detects 'debrief' / 'mission complete' / 'wrap up' / 'retro' and injects the same pointer.

The five source memory rules stay where they are; the skill is the assembly point, not a replacement.