### PR TITLE
docs: dandori is the impl plan, after filing

### DIFF
--- a/ai/skills/gru/dandori.md
+++ b/ai/skills/gru/dandori.md
@@ -1,40 +1,33 @@
 ---
 name: dandori
-description: Mission-planning interrogation for Gru. Walk the eight steps in order before filing a project, milestone, or dispatching minions.
+description: The mission's implementation plan. Walk after the milestone, Ride, and attached issues are filed; before any minion dispatches.
 ---
 
 # Mission dandori
 
-The interrogation order Gru runs when planning a new mission. Walk the steps; do not skip ahead to filing or dispatch.
+The implementation plan, run after the mission is filed and before minions dispatch. Crew per work unit, scope guard, confirm.
 
-**Trigger.** Josh says "dandori" on new work, or Gru spots a new-mission proposal trigger (a request that's bigger than one issue and needs a verification beat).
+**Trigger.** Josh says "dandori" on a filed mission, or Gru reaches the post-filing gate on a multi-issue milestone.
 
-**Pairs with:** `designs/process/dandori.md` (human-readable canon) and `designs/process/missions-and-projects.md` (taxonomy).
+**Pairs with:** `designs/process/dandori.md` (high-level canon), `designs/process/missions-and-projects.md` (mission filing taxonomy), `ai/swarm/README.md` (dispatch flow that follows), memory `feedback_mission_lifecycle.md` (rule body, all four phases).
 
-## The eight steps
+## What dandori is not
 
-1. **Mission or issue?** Big enough for a milestone with a verification beat (Ride or CI gate), or just an Urgent issue? If one issue and the AC is the verification, file as Urgent and stop.
+- Pre-mission interrogation (reading ACs, listing ambiguities) is its own discipline, before filing.
+- Filing the mission (project, codename, milestone, Ride, attached issues) is its own step, before dandori.
 
-2. **Project.** Apply the linear-scope rule: a project's scope is what completes inside it. If the work spans multiple existing projects, the boundary is wrong; move issues, merge projects, or file a new one.
+Dandori is the impl plan, not the full mission walk.
 
-3. **Goals.** Terse numbered list, one line per goal, no prose.
+## The three steps
 
-4. **Scope-expansion guard.** For any goal that could sprawl (CI gate, audit, doc rewrite, contract change), name the cap. Broader work files as follow-up issues after the mission, never inside it.
+1. **Crew per work unit.** For each issue attached to the milestone, name:
+   - Impl writer (often folds in test authoring when the work is test code).
+   - Test author, paired with impl when a hook forces failing tests + impl into one commit.
+   - Reviewers: code-quality, gdscript-conventions, test-coverage by default; plus domain reviewers the diff fires (signals-lifecycle, godot-scene, save-format-warden, asset-pipeline, ci-and-workflows, docs-and-writing).
+   - Battlers: devils-advocate to stress-test the approach; integration-scenario-author for adversarial cross-system scenarios.
 
-5. **Ride.** Player playtest or CI run? Ride issue files in the same project with the milestone set. AC names the player-observable flows the rework must not regress, or the CI signal that proves the gate. Code-inspection findings file as Battle or code-review issues, not Ride ACs.
+   Each minion gets a codename from the rotating pool (Gravity Falls, Hitchhiker's, Oddworld, Omori, Outer Wilds Hearthians and Nomai, Martha) chosen to fit the case. Codename rotates per work unit; role is stable.
 
-6. **Mission codename.** Gru-canon: two-word handle from the Despicable Me / Minions lexicon. Opaque; the codename does not leak the mission's content. The milestone description does.
+2. **Scope-expansion guard.** For any goal that could sprawl (CI gate, audit, doc rewrite, contract change), name the cap. Broader work files as follow-up issues after the mission, never inside it.
 
-7. **Crew.** Per work unit:
-   - Impl writer.
-   - Test author, paired with impl when a hook forces failing tests + impl into one commit. Often folds into impl when the work itself is test code.
-   - Reviewers: code-quality, gdscript-conventions, test-coverage by default, plus domain reviewers the diff fires (signals-lifecycle, godot-scene, save-format-warden, asset-pipeline, ci-and-workflows, docs-and-writing).
-   - Battlers: devils-advocate to stress-test the approach; integration-scenario-author to write adversarial scenarios.
-
-   Each minion gets a codename from the rotating pool (Galaxy Friends, Hitchhiker's, Oddworld, Omori, Outer Wilds Hearthians and Nomai, Martha) chosen to fit the case. Codename rotates per work unit; role is stable.
-
-8. **Confirm.** List the project, milestone, goals, ride, codename, and full crew. Wait for go before dispatching.
-
-## What this skill replaces
-
-Memory rule `feedback_dandori_structure.md` mirrors this skill; both must agree. Update both when the rule changes.
+3. **Confirm.** List the crew and scope. Wait for go before dispatching.

--- a/ai/swarm/README.md
+++ b/ai/swarm/README.md
@@ -114,6 +114,16 @@ The swarm inherits the session-tier system from `ai/skills/gru/dispatch.md`. Eve
 
 Gru picks the dispatch tier from the task, not from the minion's ceiling. An `integration-scenario-author` invoked for a signal-chain test stays at Tier 0; the same minion writing a scene-fixture test dispatches at Tier 1 with a worktree.
 
+## Before dispatch
+
+For multi-issue work, three steps land before the swarm fans out:
+
+1. **Pre-mission interrogation.** Read each candidate's full AC, every design doc it references, and memory. Surface ambiguities to Josh; no codename, no filing until they settle. Detail in memory `feedback_mission_lifecycle.md` § Phase 1.
+2. **File the mission.** Project, codename, milestone with one-sentence description, Ride (if 2+ issues are integrated; depth matches whether the work composes end-to-end or is independent fixes), constituent issues attached to the milestone. Detail in [`../../designs/process/missions-and-projects.md`](../../designs/process/missions-and-projects.md) and memory `feedback_mission_lifecycle.md` § Phase 3.
+3. **Dandori.** Implementation plan: crew per work unit, scope-expansion guard, confirm before dispatch. Detail in [`../../designs/process/dandori.md`](../../designs/process/dandori.md) and `ai/skills/gru/dandori.md`.
+
+Single-issue work skips filing and dandori; the PR carries its own playtest at merge.
+
 ## Entry points
 
 Gru is entity-driven. Point Gru at a thing and Gru does the right thing.

--- a/designs/process/dandori.md
+++ b/designs/process/dandori.md
@@ -1,61 +1,34 @@
 # Mission dandori
 
-The interrogation order for planning a new mission. Walk the steps in order; don't skip to filing or dispatch.
+The implementation plan. Runs **after** the mission is filed (milestone, Ride, attached issues) and **before** minions dispatch. Crew per work unit, scope guard, confirm.
 
-Pairs with [`missions-and-projects.md`](missions-and-projects.md) (the nouns), [`flow-shapes.md`](flow-shapes.md) (bug / spike / feature, the shape of work inside a mission), and the swarm conventions in `ai/`.
+Pairs with [`missions-and-projects.md`](missions-and-projects.md) (the nouns, including how missions get filed) and [`flow-shapes.md`](flow-shapes.md) (the bug / spike / feature shape of work inside a mission).
 
-## 1. Mission or ticket?
+Pre-mission interrogation (reading ACs, listing ambiguities) and filing (project, codename, milestone, Ride, attached issues) come before dandori. See `missions-and-projects.md` for filing and `ai/swarm/README.md` for the swarm flow that follows.
 
-Is this big enough to be a mission, or is it a single Urgent ticket?
+## 1. Crew per work unit
 
-A mission needs a verification beat: a Ride (player playtest) or a clear non-player gate (e.g. CI run). If the work is one ticket and the AC is the verification, file it as Urgent and stop.
-
-## 2. Project
-
-Which project does the mission live in? Apply the linear-scope rule from `missions-and-projects.md`: a project's scope is what completes inside it. If the mission needs work in multiple existing projects, the boundaries are wrong; resolve by moving tickets, merging projects, or filing a new one.
-
-## 3. Goals
-
-Terse numbered list. One line per goal. No prose.
-
-## 4. Scope-expansion guard
-
-For any goal that could naturally sprawl (CI gate, audit, doc rewrite, contract change), name the cap. Broader work files as follow-up tickets after the mission, not inside it.
-
-## 5. Ride
-
-Player playtest or CI run? Ride ticket files in the same project with the milestone set. AC names the player-observable flows the rework must not regress, or the CI signal that proves the gate.
-
-Code-inspection findings file as separate Battle or code-review tickets, not Ride ACs.
-
-## 6. Mission codename
-
-Gru-canon: two-word handle from the Despicable Me / Minions lexicon. Opaque: the codename doesn't leak the mission's content. The milestone description does.
-
-## 7. Minion crew
-
-Full team per work unit:
+For each issue attached to the milestone, name the team:
 
 - **Impl** (writer of the change). Often folds in test authoring when the work is test code itself.
 - **Test author**, paired with impl when a hook or gate forces failing tests + impl into one commit.
-- **Reviewers**: code-quality, gdscript-conventions, test-coverage by default, plus the domain reviewers the diff fires (signals-lifecycle, godot-scene, save-format-warden, asset-pipeline, ci-and-workflows, docs-and-writing).
-- **Battlers**: devils-advocate to challenge the approach, integration-scenario-author to write adversarial scenarios that try to expose gaps.
+- **Reviewers**: code-quality, gdscript-conventions, test-coverage by default; plus the domain reviewers the diff fires (signals-lifecycle, godot-scene, save-format-warden, asset-pipeline, ci-and-workflows, docs-and-writing).
+- **Battlers**: devils-advocate to challenge the approach; integration-scenario-author to write adversarial cross-system scenarios.
 
-Each minion gets a codename from the pool (Galaxy Friends, Hitchhiker's, Oddworld, Omori, Outer Wilds Hearthians and Nomai, Martha) chosen to fit the case. Codename rotates per work unit; role is stable.
+Each minion gets a codename from the pool (Gravity Falls, Hitchhiker's, Oddworld, Omori, Outer Wilds Hearthians and Nomai, Martha) chosen to fit the case. Codename rotates per work unit; role is stable.
 
-## 8. Confirm before dispatch
+## 2. Scope-expansion guard
 
-List the crew and wait for go. Don't dispatch until the codename and crew are confirmed.
+For any goal that could naturally sprawl (CI gate, audit, doc rewrite, contract change), name the cap. Broader work files as follow-up tickets after the mission, not inside it.
+
+## 3. Confirm before dispatch
+
+List the crew and the scope. Wait for go. Don't dispatch until the codenames and the scope are confirmed.
 
 ## Worked example
 
-Vector Squared (Test Rework, 2026-04-27):
+Vector Squared (Test Rework, 2026-04-27), crew + scope:
 
-1. Mission, not ticket: scope spans timeout tests, integration contract, behavioural audit, CI gate.
-2. New project Test Rework. Tickets moved out of Minion Hardening (wrong scope: that project is for swarm/agent hardening).
-3. Goals: suite under 2s; real input on every player AC; behavioural review; patterns documented; CI gate.
-4. CI gate capped to one workflow step, one number. New gate types file as follow-ups.
-5. Ride: regression playtest. No new player surface to verify, but the rework could regress existing flows.
-6. Codename: Vector Squared.
-7. Crew: Feldspar (impl SH-254), Hornfels (impl SH-253), reviewers Marvin / Slartibartfast / Sunny / Mabel / Solanum / Aubrey / Riebeck, battlers Ford / Stranger / Abe / Kel.
-8. Confirm, then dispatch.
+- Crew: Feldspar (impl SH-254), Hornfels (impl SH-253), reviewers Marvin / Slartibartfast / Sunny / Mabel / Solanum / Aubrey / Riebeck, battlers Ford / Stranger / Abe / Kel.
+- Scope: CI gate capped to one workflow step, one number; new gate types file as follow-ups.
+- Confirm, then dispatch.


### PR DESCRIPTION
Restructure the dandori canon. The eight-step walk in `designs/process/dandori.md` and `ai/skills/gru/dandori.md` was conflating three distinct phases that happen in sequence:

1. **Pre-mission interrogation** (read ACs, list ambiguities) is its own discipline before filing.
2. **File the mission** (project, codename, milestone with one-sentence description, Ride, attached issues) lives in `missions-and-projects.md`.
3. **Dandori** narrows to the impl plan: crew per work unit, scope-expansion guard, confirm before dispatch.

The skill file and the canon doc now mirror each other at three steps. `ai/swarm/README.md` gains a Before-dispatch section that names all three phases and points readers at their canonical homes. Memory `feedback_mission_lifecycle.md` is the rule body for all four phases (counting codename as Phase 2 between interrogation and filing).

Supersedes the small dandori-skill cross-link in #718, which I'll close.