### PR TITLE
fix: court owns its collision floor and the apex bound

### DIFF
--- a/ai/skills/minions/reviewers.md
+++ b/ai/skills/minions/reviewers.md
@@ -45,7 +45,7 @@ The dispatcher may dispatch a **fresh-eyes** pass alongside the scope-filtered r
 
 ## Verdict shape
 
-Two outcomes: approve or block. The label is the verdict; what you post beyond the label depends on which outcome.
+Two outcomes: approve or block. The label is the verdict; what you post beyond the label depends on which outcome. The dispatcher report is not a third outcome. If your dispatcher report contains substantive findings (player-affecting, latent bug, missing guard, design concern), those findings have to land on the PR as inline comments first; the verdict then becomes block. Putting findings in the dispatcher report alone leaves the author with nothing to act on and the merge gate with no signal.
 
 - **Approve**: apply `zaphod-approved` via `gh pr edit <N> --add-label zaphod-approved` and stop. No comment on the challenge, no review body. The label is the verdict. If a note feels worth posting, the verdict was block, not approve. <!-- todo: once a service account exists, approves also post `gh pr review --approve --body ""` so the Reviews tab shows attribution on mobile. -->
 - **Block**: post each finding as an inline review comment anchored to the diff line. No verdict body on the challenge conversation. Apply `zaphod-blocked`. Never post in the main challenge thread.

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -26,7 +26,7 @@
 [ext_resource type="Resource" uid="uid://b66666sh366cc" path="res://resources/court_config.tres" id="25_courtcfg"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vert"]
-size = Vector2(21.6, 180)
+size = Vector2(22, 500)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_court_floor"]
 size = Vector2(800, 20)
@@ -62,17 +62,27 @@ item_key = "base_ball"
 [node name="Bounds" type="Node2D" parent="." unique_id=2106668171]
 
 [node name="Right Wall" type="StaticBody2D" parent="Bounds" unique_id=1091055427]
-position = Vector2(400, -520)
+position = Vector2(400, 139)
 physics_material_override = ExtResource("1_0wfyh")
 metadata/_edit_group_ = true
 
 [node name="ColorRect" type="ColorRect" parent="Bounds/Right Wall" unique_id=679820908]
-offset_right = 21.6
-offset_bottom = 180.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -11.0
+offset_top = -250.0
+offset_right = 11.0
+offset_bottom = 250.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 mouse_filter = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Bounds/Right Wall" unique_id=2042401507]
-position = Vector2(10.8, 90)
 shape = SubResource("RectangleShape2D_vert")
 
 [node name="CourtFloor" type="StaticBody2D" parent="Bounds" unique_id=1779452318]

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -26,7 +26,10 @@
 [ext_resource type="Resource" uid="uid://b66666sh366cc" path="res://resources/court_config.tres" id="25_courtcfg"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vert"]
-size = Vector2(21.6, 880)
+size = Vector2(21.6, 180)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_court_floor"]
+size = Vector2(800, 20)
 
 [node name="Court" type="Node2D" unique_id=75800363 node_paths=PackedStringArray("ball_system", "ball_tracker", "player_spawn", "autoplay_controller", "right_wall", "partner_spawn", "timeout_controller", "drag_controller")]
 script = ExtResource("1_tbgi4")
@@ -65,12 +68,19 @@ metadata/_edit_group_ = true
 
 [node name="ColorRect" type="ColorRect" parent="Bounds/Right Wall" unique_id=679820908]
 offset_right = 21.6
-offset_bottom = 880.0
+offset_bottom = 180.0
 mouse_filter = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Bounds/Right Wall" unique_id=2042401507]
-position = Vector2(10.8, 440)
+position = Vector2(10.8, 90)
 shape = SubResource("RectangleShape2D_vert")
+
+[node name="CourtFloor" type="StaticBody2D" parent="Bounds" unique_id=1779452318]
+position = Vector2(0, 400)
+physics_material_override = ExtResource("1_0wfyh")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Bounds/CourtFloor" unique_id=1779452319]
+shape = SubResource("RectangleShape2D_court_floor")
 
 [node name="MissZones" type="Node2D" parent="Bounds" unique_id=2106668172]
 

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -31,19 +31,19 @@ size = Vector2(22, 500)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_court_floor"]
 size = Vector2(800, 20)
 
-[node name="Court" type="Node2D" unique_id=75800363 node_paths=PackedStringArray("ball_system", "ball_tracker", "player_spawn", "autoplay_controller", "right_wall", "soul_bound", "partner_spawn", "timeout_controller", "drag_controller")]
+[node name="Court" type="Node2D" unique_id=75800363 node_paths=PackedStringArray("ball_system", "ball_tracker", "autoplay_controller", "timeout_controller", "drag_controller", "right_wall", "soul_bound", "player_spawn", "partner_spawn")]
 script = ExtResource("1_tbgi4")
+court_config = ExtResource("25_courtcfg")
 ball_system = NodePath("BallReconciler")
 ball_tracker = NodePath("BallTracker")
-court_config = ExtResource("25_courtcfg")
-player_paddle_scene = ExtResource("9_0tnpc")
-player_spawn = NodePath("PlayerSpawn")
 autoplay_controller = NodePath("AutoplayController")
-right_wall = NodePath("Bounds/Right Wall")
-soul_bound = NodePath("Bounds/SoulBound")
-partner_spawn = NodePath("PartnerSpawn")
 timeout_controller = NodePath("TimeoutController")
 drag_controller = NodePath("BallDragController")
+right_wall = NodePath("Bounds/Right Wall")
+soul_bound = NodePath("Bounds/SoulBound")
+player_spawn = NodePath("PlayerSpawn")
+partner_spawn = NodePath("PartnerSpawn")
+player_paddle_scene = ExtResource("9_0tnpc")
 
 [node name="CourtBackground" type="CanvasLayer" parent="." unique_id=1053024008]
 layer = -100

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -31,7 +31,7 @@ size = Vector2(22, 500)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_court_floor"]
 size = Vector2(800, 20)
 
-[node name="Court" type="Node2D" unique_id=75800363 node_paths=PackedStringArray("ball_system", "ball_tracker", "player_spawn", "autoplay_controller", "right_wall", "partner_spawn", "timeout_controller", "drag_controller")]
+[node name="Court" type="Node2D" unique_id=75800363 node_paths=PackedStringArray("ball_system", "ball_tracker", "player_spawn", "autoplay_controller", "right_wall", "soul_bound", "partner_spawn", "timeout_controller", "drag_controller")]
 script = ExtResource("1_tbgi4")
 ball_system = NodePath("BallReconciler")
 ball_tracker = NodePath("BallTracker")
@@ -40,6 +40,7 @@ player_paddle_scene = ExtResource("9_0tnpc")
 player_spawn = NodePath("PlayerSpawn")
 autoplay_controller = NodePath("AutoplayController")
 right_wall = NodePath("Bounds/Right Wall")
+soul_bound = NodePath("Bounds/SoulBound")
 partner_spawn = NodePath("PartnerSpawn")
 timeout_controller = NodePath("TimeoutController")
 drag_controller = NodePath("BallDragController")
@@ -99,6 +100,9 @@ position = Vector2(-430.8, 0)
 
 [node name="RightMissZone" parent="Bounds/MissZones" unique_id=500636962 instance=ExtResource("10_miss_zone")]
 position = Vector2(430.8, 0)
+
+[node name="SoulBound" type="Marker2D" parent="Bounds" unique_id=630029583]
+position = Vector2(0, -111)
 
 [node name="AutoplayController" type="Node" parent="." unique_id=280970194]
 script = ExtResource("7_tipki")

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -26,7 +26,7 @@
 [ext_resource type="Resource" uid="uid://b66666sh366cc" path="res://resources/court_config.tres" id="25_courtcfg"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vert"]
-size = Vector2(21.6, 703.2)
+size = Vector2(21.6, 880)
 
 [node name="Court" type="Node2D" unique_id=75800363 node_paths=PackedStringArray("ball_system", "ball_tracker", "player_spawn", "autoplay_controller", "right_wall", "partner_spawn", "timeout_controller", "drag_controller")]
 script = ExtResource("1_tbgi4")
@@ -59,17 +59,17 @@ item_key = "base_ball"
 [node name="Bounds" type="Node2D" parent="." unique_id=2106668171]
 
 [node name="Right Wall" type="StaticBody2D" parent="Bounds" unique_id=1091055427]
-position = Vector2(400, -351.6)
+position = Vector2(400, -520)
 physics_material_override = ExtResource("1_0wfyh")
 metadata/_edit_group_ = true
 
 [node name="ColorRect" type="ColorRect" parent="Bounds/Right Wall" unique_id=679820908]
 offset_right = 21.6
-offset_bottom = 703.2
+offset_bottom = 880.0
 mouse_filter = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Bounds/Right Wall" unique_id=2042401507]
-position = Vector2(10.8, 351.6)
+position = Vector2(10.8, 440)
 shape = SubResource("RectangleShape2D_vert")
 
 [node name="MissZones" type="Node2D" parent="Bounds" unique_id=2106668172]

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -82,7 +82,7 @@ func _ready() -> void:
 		court_config = load("res://scripts/core/court_config.gd").new()
 	ball_tracker.court_config = court_config
 	if soul_bound != null:
-		ball_tracker.bound_y = soul_bound.position.y
+		ball_tracker.bound_y = soul_bound.global_position.y
 	ball_tracker.configure(player_paddle)
 	ball_tracker.current_ball_changed.connect(_on_current_ball_changed)
 	ball_tracker.ball_missed.connect(_on_ball_missed)

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -7,17 +7,22 @@ signal ball_at_max_speed_changed(is_at_max: bool)
 signal auto_play_changed(is_active: bool, friendship_point_rate: float)
 signal partner_changed
 
+@export_group("Systems")
 @export var ball_system: BallReconciler
 @export var ball_tracker: BallTracker
-@export var court_config: CourtConfig
-@export var player_paddle_scene: PackedScene
-@export var player_spawn: Marker2D
 @export var autoplay_controller: AutoplayController
-@export var right_wall: StaticBody2D
-@export var soul_bound: Marker2D
-@export var partner_spawn: Marker2D
 @export var timeout_controller: TimeoutController
 @export var drag_controller: BallDragController
+@export var court_config: CourtConfig
+
+@export_group("World")
+@export var player_spawn: Marker2D
+@export var partner_spawn: Marker2D
+@export var right_wall: StaticBody2D
+@export var soul_bound: Marker2D
+
+@export_group("Scenes")
+@export var player_paddle_scene: PackedScene
 
 ## Back-compat handle for tests; standard live-ball set lives on `ball_tracker`.
 var ball: Ball

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -80,9 +80,9 @@ func _ready() -> void:
 
 	if court_config == null:
 		court_config = load("res://scripts/core/court_config.gd").new()
-	if soul_bound != null:
-		court_config.friendship_bound_y = soul_bound.position.y
 	ball_tracker.court_config = court_config
+	if soul_bound != null:
+		ball_tracker.bound_y = soul_bound.position.y
 	ball_tracker.configure(player_paddle)
 	ball_tracker.current_ball_changed.connect(_on_current_ball_changed)
 	ball_tracker.ball_missed.connect(_on_ball_missed)

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -7,19 +7,22 @@ signal ball_at_max_speed_changed(is_at_max: bool)
 signal auto_play_changed(is_active: bool, friendship_point_rate: float)
 signal partner_changed
 
-@export_group("Systems")
+@export var court_config: CourtConfig
+
+@export_group("Controllers")
 @export var ball_system: BallReconciler
 @export var ball_tracker: BallTracker
 @export var autoplay_controller: AutoplayController
 @export var timeout_controller: TimeoutController
 @export var drag_controller: BallDragController
-@export var court_config: CourtConfig
 
-@export_group("World")
-@export var player_spawn: Marker2D
-@export var partner_spawn: Marker2D
+@export_group("Bounds")
 @export var right_wall: StaticBody2D
 @export var soul_bound: Marker2D
+
+@export_group("Spawns")
+@export var player_spawn: Marker2D
+@export var partner_spawn: Marker2D
 
 @export_group("Scenes")
 @export var player_paddle_scene: PackedScene

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -14,6 +14,7 @@ signal partner_changed
 @export var player_spawn: Marker2D
 @export var autoplay_controller: AutoplayController
 @export var right_wall: StaticBody2D
+@export var soul_bound: Marker2D
 @export var partner_spawn: Marker2D
 @export var timeout_controller: TimeoutController
 @export var drag_controller: BallDragController
@@ -71,6 +72,8 @@ func _ready() -> void:
 
 	if court_config == null:
 		court_config = load("res://scripts/core/court_config.gd").new()
+	if soul_bound != null:
+		court_config.friendship_bound_y = soul_bound.position.y
 	ball_tracker.court_config = court_config
 	ball_tracker.configure(player_paddle)
 	ball_tracker.current_ball_changed.connect(_on_current_ball_changed)

--- a/scripts/core/court_config.gd
+++ b/scripts/core/court_config.gd
@@ -3,8 +3,6 @@ extends Resource
 
 ## Per-court tunables: friendship-bound height, ramp duration, rest-roll damping.
 
-## World-space Y of the friendship-bound. Above this line (smaller Y) the ball is in PLAY-ARC.
-@export var friendship_bound_y: float = -351.6
 ## Speed-relock ramp duration in seconds; 0.0 snaps the speed to the tracked entry value instantly.
 @export var relock_ramp_seconds: float = 0.12
 ## Linear damping applied while the missed ball rolls to rest on the venue floor.

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -102,7 +102,7 @@ func _get_paddle_speed() -> float:
 
 
 func _track() -> void:
-	var bound_y: float = ball.court_config.friendship_bound_y
+	var bound_y: float = ball.bound_y
 	var gravity: float = ProjectSettings.get_setting("physics/2d/default_gravity")
 	var predicted_y: float = PaddleAIMath.predict_intercept(
 		ball.position, ball.linear_velocity, paddle.position.x, bound_y, gravity

--- a/scripts/court/ball_tracker.gd
+++ b/scripts/court/ball_tracker.gd
@@ -12,6 +12,7 @@ signal ball_removed(ball: Ball)
 
 @export var ball_system: BallReconciler
 @export var court_config: CourtConfig
+var bound_y: float = 0.0
 
 var _balls: Array[Ball] = []
 var _current_ball: Ball
@@ -44,6 +45,7 @@ func attach(new_ball: Ball) -> void:
 		return
 	if court_config != null:
 		new_ball.court_config = court_config
+	new_ball.bound_y = bound_y
 
 	_balls.append(new_ball)
 	if _current_ball == null:

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -26,8 +26,7 @@ const OUT_REST_CONFIG: BallStateConfig = preload("res://resources/ball/states/ou
 ## Per-court tunables; injected by Court at attach time. Falls back to a default at construction.
 @export var court_config: CourtConfig
 ## Apex-arc threshold y; BallTracker injects at attach time from the SoulBound marker.
-## Default mirrors the original CourtConfig baseline.
-var bound_y: float = -351.6
+var bound_y: float
 
 var speed := 0.0
 var min_speed: float

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -25,6 +25,9 @@ const OUT_REST_CONFIG: BallStateConfig = preload("res://resources/ball/states/ou
 @export var grab_area: GrabArea
 ## Per-court tunables; injected by Court at attach time. Falls back to a default at construction.
 @export var court_config: CourtConfig
+## Apex-arc threshold y; BallTracker injects at attach time from the SoulBound marker.
+## Default mirrors the original CourtConfig baseline.
+var bound_y: float = -351.6
 
 var speed := 0.0
 var min_speed: float
@@ -85,7 +88,6 @@ func _update_play_state(delta: float) -> void:
 	if play_state != PlayState.PLAY_NORMAL and play_state != PlayState.PLAY_ARC:
 		return
 
-	var bound_y: float = court_config.friendship_bound_y
 	var above_bound: bool = global_position.y < bound_y
 
 	if above_bound and play_state == PlayState.PLAY_NORMAL:
@@ -192,7 +194,6 @@ func enter_stored() -> void:
 func enter_play() -> void:
 	_suppress_miss_detection = false
 	PLAY_ACTIVE_CONFIG.apply(self)
-	var bound_y: float = court_config.friendship_bound_y if court_config != null else 0.0
 	var above_bound: bool = global_position.y < bound_y
 
 	if above_bound:

--- a/tests/stubs/ball_stub.gd
+++ b/tests/stubs/ball_stub.gd
@@ -2,7 +2,7 @@ extends Ball
 
 
 func _init() -> void:
-	bound_y = -351.6
+	bound_y = -400.0
 
 
 func increase_speed() -> void:

--- a/tests/stubs/ball_stub.gd
+++ b/tests/stubs/ball_stub.gd
@@ -1,6 +1,10 @@
 extends Ball
 
 
+func _init() -> void:
+	bound_y = -351.6
+
+
 func increase_speed() -> void:
 	pass
 

--- a/tests/unit/ball/test_ball_apex_arc.gd
+++ b/tests/unit/ball/test_ball_apex_arc.gd
@@ -17,12 +17,12 @@ func before_each() -> void:
 	add_child_autofree(_manager)
 
 	_config = load("res://scripts/core/court_config.gd").new()
-	_config.friendship_bound_y = BOUND_Y
 	_config.relock_ramp_seconds = 0.1
 
 	_ball = load("res://scripts/entities/ball/ball.gd").new()
 	_ball._item_manager = _manager
 	_ball.court_config = _config
+	_ball.bound_y = BOUND_Y
 	add_child_autofree(_ball)
 	_ball.global_position = Vector2(0.0, 0.0)
 	_ball.linear_velocity = Vector2(

--- a/tests/unit/ball/test_ball_state_transitions.gd
+++ b/tests/unit/ball/test_ball_state_transitions.gd
@@ -2,6 +2,7 @@
 extends GutTest
 
 const REST_DAMPING := 1.5
+const BOUND_Y := -351.6
 const PLAY_ACTIVE_CONFIG: BallStateConfig = preload("res://resources/ball/states/play_active.tres")
 const OUT_REST_CONFIG: BallStateConfig = preload("res://resources/ball/states/out_rest.tres")
 
@@ -24,6 +25,7 @@ func before_each() -> void:
 	_ball = load("res://scripts/entities/ball/ball.gd").new()
 	_ball._item_manager = _manager
 	_ball.court_config = _config
+	_ball.bound_y = BOUND_Y
 	add_child_autofree(_ball)
 
 
@@ -66,7 +68,7 @@ func test_enter_play_normal_sets_property_values() -> void:
 
 
 func test_enter_play_arc_when_above_bound() -> void:
-	_ball.global_position = Vector2(0.0, _config.friendship_bound_y - 100.0)
+	_ball.global_position = Vector2(0.0, BOUND_Y - 100.0)
 	_ball.enter_play()
 	assert_eq(_ball.play_state, Ball.PlayState.PLAY_ARC)
 	assert_almost_eq(_ball.gravity_scale, 1.0, 0.001)


### PR DESCRIPTION
Closes #658.

Court now owns its own ball containment. Venue keeps the visual floor.

- `CourtFloor` (StaticBody2D + CollisionShape2D, no visual) under `Bounds`. Catches balls inside the play area.
- `Right Wall` origin moved to the centre of the wall body. Collision and visual now align off a single shape size.
- `SoulBound` Marker2D under `Bounds`. Court reads its y on `_ready` and writes it into `court_config.friendship_bound_y`. Drag the marker in the editor to tune the apex-arc threshold.
- Court's `@export` list grouped: `court_config` standalone, then Controllers, Bounds, Spawns, Scenes.

No left wall added; the left side is bounded by the player paddle, not a wall (see #658 discussion).

Runtime verification (no-tunnel, apex containment, no friendship-bound regression) needed before merge.