### PR TITLE
fix: guard rack slot lookup against overflow stacking

### DIFF
--- a/scripts/items/rack_display.gd
+++ b/scripts/items/rack_display.gd
@@ -51,8 +51,14 @@ func refresh() -> void:
 			continue
 		if marker_count == 0:
 			continue
-		var marker_index: int = min(index, marker_count - 1)
-		var slot: Node2D = _build_slot(definition, _slot_markers[marker_index].position)
+
+		if index >= marker_count:
+			push_error(
+				"RackDisplay: kit items exceed marker count; skipping overflow key %s" % item_key
+			)
+			continue
+
+		var slot: Node2D = _build_slot(definition, _slot_markers[index].position)
 		slot_container.add_child(slot)
 		_slots.append(slot)
 	_apply_slot_visibility()
@@ -120,8 +126,16 @@ func get_slot_position_for(item_key: String) -> Vector2:
 	if index < 0 or _slot_markers.is_empty():
 		return Vector2.ZERO
 
-	var marker_index: int = min(index, _slot_markers.size() - 1)
-	return _slot_markers[marker_index].global_position
+	if index >= _slot_markers.size():
+		push_error(
+			(
+				"RackDisplay: no slot marker for kit index %d (key %s); rack has %d markers"
+				% [index, item_key, _slot_markers.size()]
+			)
+		)
+		return Vector2.ZERO
+
+	return _slot_markers[index].global_position
 
 
 func _attach_slot_input(slot: Node2D, item_key: String) -> void:

--- a/tests/unit/items/test_rack_slot_overflow.gd
+++ b/tests/unit/items/test_rack_slot_overflow.gd
@@ -1,0 +1,78 @@
+## #679: rack must not stack stored balls into the same slot.
+extends GutTest
+
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+
+
+func _make_rack(manager: Node, marker_count: int) -> RackDisplay:
+	var rack: RackDisplay = RackDisplayScript.new()
+	rack.role = &"ball"
+
+	var slot_container := Node2D.new()
+	slot_container.name = "SlotContainer"
+	rack.add_child(slot_container)
+
+	for index in marker_count:
+		var marker := Node2D.new()
+		marker.name = "SlotMarker%d" % index
+		marker.position = Vector2(index * 32, 0)
+		slot_container.add_child(marker)
+
+	rack.slot_container = slot_container
+	rack.configure(manager)
+	add_child_autofree(rack)
+	return rack
+
+
+func _seed_manager(ball_keys: Array[String]) -> Node:
+	var manager: Node = ItemFactory.create_manager(self)
+	var typed_items: Array[ItemDefinition] = []
+	for key in ball_keys:
+		typed_items.append(ItemTestHelpersScript.make_ball_item(key))
+	manager.items.assign(typed_items)
+	manager.economy.friendship_point_balance = 100000
+	return manager
+
+
+func test_every_stored_ball_lands_at_a_distinct_slot_position() -> void:
+	var keys: Array[String] = ["ball_a", "ball_b", "ball_c", "ball_d"]
+	var manager: Node = _seed_manager(keys)
+	var rack: RackDisplay = _make_rack(manager, 8)
+
+	var reconciler: BallReconciler = BallReconcilerScript.new()
+	reconciler.configure(manager)
+	reconciler.ball_rack = rack
+	add_child_autofree(reconciler)
+
+	for key in keys:
+		manager.take(key)
+	await get_tree().process_frame
+
+	var seen_positions: Array[Vector2] = []
+	for key in keys:
+		var ball: Ball = reconciler.get_ball_for_key(key)
+		assert_not_null(ball, "stored ball spawned for %s" % key)
+		assert_false(
+			seen_positions.has(ball.global_position),
+			"ball %s at %s collides with an earlier slot" % [key, ball.global_position]
+		)
+		seen_positions.append(ball.global_position)
+
+
+func test_distinct_keys_resolve_to_distinct_marker_positions() -> void:
+	var keys: Array[String] = ["ball_a", "ball_b", "ball_c", "ball_d"]
+	var manager: Node = _seed_manager(keys)
+	var rack: RackDisplay = _make_rack(manager, 8)
+	for key in keys:
+		manager.take(key)
+
+	var positions: Array[Vector2] = []
+	for key in keys:
+		var slot_position: Vector2 = rack.get_slot_position_for(key)
+		assert_false(
+			positions.has(slot_position),
+			"slot lookup for %s collides with an earlier key at %s" % [key, slot_position]
+		)
+		positions.append(slot_position)

--- a/tests/unit/items/test_rack_slot_overflow.gd.uid
+++ b/tests/unit/items/test_rack_slot_overflow.gd.uid
@@ -1,0 +1,1 @@
+uid://ctwpalvy5cy7


### PR DESCRIPTION
Closes #679

When stored balls exceeded the rack's marker count, both `refresh()` and `get_slot_position_for()` clamped to the last marker with `min(index, marker_count - 1)`, stacking multiple balls at the same world position. The clamp is now an explicit overflow check that `push_error`s and returns a safe sentinel (empty slot render, `Vector2.ZERO` lookup) rather than colliding placements.

Runtime verification belongs to the runtime-verifier minion; this PR ships the static fix plus two unit tests asserting distinct slot positions across the registered stored-ball set.

Agent-Role: gdscript-implementer