### PR TITLE
chore: reorder AutoplayController properties in court.tscn

### DIFF
--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -106,8 +106,8 @@ position = Vector2(0, -111)
 
 [node name="AutoplayController" type="Node" parent="." unique_id=280970194 node_paths=PackedStringArray("timeout_controller")]
 script = ExtResource("7_tipki")
-config = ExtResource("8_85g3d")
 timeout_controller = NodePath("../TimeoutController")
+config = ExtResource("8_85g3d")
 
 [node name="TimeoutController" type="Node" parent="." unique_id=1998734210]
 script = ExtResource("19_timeout")


### PR DESCRIPTION
Editor reorder noise from opening court.tscn. No behavioural change.