### PR TITLE
Add diegetic achievements concept note

### DIFF
--- a/designs/concept/INDEX.md
+++ b/designs/concept/INDEX.md
@@ -13,3 +13,4 @@ Per-mechanic and per-mechanic-set design specs.
 | [The Game of Volley](the-game.md) | Cooperative rally rules and the duel variant. |
 | [The Break](the-break.md) | The rupture between Construction and Reality. |
 | [Venue](venue.md) | The setting where the protagonist volleys. |
+| [Achievements](achievements.md) | Feats surface diegetically, the world reporting them in its own voice. |

--- a/designs/concept/achievements.md
+++ b/designs/concept/achievements.md
@@ -1,0 +1,5 @@
+# Achievements
+
+Achievements are part of the world, not a meta UI layer over it. A feat surfaces diegetically, the world itself noticing what the protagonist did and reporting it back in its own voice, the way an in-world news report carries an event. The achievement is the world reacting, not a panel announcing.
+
+Open: the reporting voice and the triggers are Josh's to set.


### PR DESCRIPTION
Adds a short working-position design note establishing that achievements are part of the world rather than a meta UI layer: a feat surfaces diegetically, the world noticing it and reporting it in its own voice like an in-world news report. The note states the direction only and stubs the open pieces (reporting voice and triggers) in one line, since that fiction is not set. Also adds a matching pointer row to the concept INDEX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)