### PR TITLE
Starter-item-set design doc

### DIFF
--- a/designs/01-prototype/INDEX.md
+++ b/designs/01-prototype/INDEX.md
@@ -14,6 +14,7 @@ The public demo on itch.io. Core loop, first-pass assets, playable by strangers.
 |    | - [Items (design)](design/items.md) |
 |    | - [Starter Items (design)](design/starter-items.md) |
 |    | - [Prototype Item Effect Blocks (tech)](tech/05-items.md) |
+|    | - [Starter Item Effect Blocks (tech)](tech/05a-starter-item-effects.md) |
 | 07 | [Effect System](tech/04-effect-system.md) |
 | 08 | **The Venue and Its Systems** |
 |    | - [The Venue](08-venue.md) |

--- a/designs/01-prototype/INDEX.md
+++ b/designs/01-prototype/INDEX.md
@@ -12,6 +12,7 @@ The public demo on itch.io. Core loop, first-pass assets, playable by strangers.
 | 05 | [Upgrade Shop Mechanics](05-upgrade-shop-mechanics.md) |
 | 06 | **Items** |
 |    | - [Items (design)](design/items.md) |
+|    | - [Starter Items (design)](design/starter-items.md) |
 |    | - [Prototype Item Effect Blocks (tech)](tech/05-items.md) |
 | 07 | [Effect System](tech/04-effect-system.md) |
 | 08 | **The Venue and Its Systems** |

--- a/designs/01-prototype/design/items.md
+++ b/designs/01-prototype/design/items.md
@@ -148,18 +148,6 @@ Leveling fully repairs the mirror, resetting cracks to zero and the multiplier b
 
 True power is in synergy with other items (future design).
 
-### Cadence
-
-Whistle + out of tune. Standard coach's whistle, brass tarnished, plays a note that's slightly flat. You can feel it in your teeth.
-
-| State | Description |
-|---|---|
-| Default | "Sounds wrong" |
-| After first ceiling raise | "Don't stop. Won't stop" |
-| Post-Break | "Was anyone listening?" |
-
-The whistle sets the tempo. Ball speed oscillates in waves: ramping up and down unpredictably. When the ball reaches max speed, the ceiling raises and speed keeps climbing.
-
 ---
 
 ## Simple stat items

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -29,3 +29,13 @@ Balls are drawn toward the player, curving toward where you reach.
 ## Cadence (pick)
 
 Role: equipment : neck
+
+Whistle + out of tune. Standard coach's whistle, brass tarnished, plays a note that's slightly flat. You can feel it in your teeth.
+
+| State | Description |
+|---|---|
+| Default | "Sounds wrong" |
+| After first ceiling raise | "Don't stop. Won't stop" |
+| Post-Break | "Was anyone listening?" |
+
+The whistle sets the tempo. Ball speed oscillates in waves: ramping up and down unpredictably. When the ball reaches max speed, the ceiling raises and speed keeps climbing.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -5,7 +5,7 @@ The player starts with the initial ball and racquet; these items add to that, ne
 ## Ball: split-and-merge (name TODO)
 
 Role: ball
-At consolidation it splits, and each higher tier splits into one more ball (2 at the first, +1 per tier after). 
+At consolidation it splits, and each consolidation after adds one more ball (2 at the first, +1 per consolidation after).
 Collide them to merge for a soul burst. 
 Not merging is a missed bonus, no penalty.
 

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,33 +1,15 @@
 # Starter Items
 
-The items Zach stocks his stall with in Act I, drawn from the four childhood friends (the protagonist, Zach, Fern, Steph). The player starts with nothing; these are their first items and first lesson in what items are. Mostly sports objects, each weird or interesting in a way that hints at its effect. Learned by owning, not reading. See [the narrative outline](../narrative/outline.md).
-
-## Principles
-
-- Five items. Each effect felt in one rally.
-- Each a distinct verb, never four flavours of "bigger".
-- The four functional items stay simple; the shopkeeper's pick may be complex.
-- First soul spend cheap and obviously felt.
-
-## The set
-
-Early Volley is self-controlled and the player rarely misses, so the set rewards the build, not survival. The build pays out on the consolidation beat (SH-437; tier ladder in [20-ball-speed-tiers.md](../20-ball-speed-tiers.md)).
+Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Mostly sports, weird. Five items, distinct verbs, felt in one rally, paying out on consolidation (SH-437).
 
 | Slot | Group | Effect |
 |---|---|---|
-| 1 | Capability | Levitate higher (arc interaction open) |
+| 1 | Capability | Levitate higher; soul-bound and arc rise with you |
 | 2 | Yield | More soul per volley |
 | 3 | Momentum | Compounds across the streak |
 | 4 | doubled (TODO) | Second item on one build group |
-| Pick | Tempo | Cadence: oscillation plus tier-skip, the complex pick |
+| Pick | Tempo | Cadence: oscillation plus tier-skip (complex) |
 
-Pull-from groups: Capability, Yield, Momentum, plus Tempo for the pick. **Ceiling is cut** to later progression: felt only at the top of the climb, which a beginner never reaches. Out, and why: the miss-cluster (no missing early), Synergy (build-around), Risk/Reward (variance), Field-changing (competes with acceleration), Slot-expanding (premature), Partner-enhancing (Martha barely arrived).
-
-## Interest without complexity
-
-The object's thing-and-twist and its variant reveals; expressive feedback; hooking the consolidation beat the loop already generates. No added rules.
-
-## TODO
-
-- Per-item cards (appearance and effect), SH-436's acceptance criteria.
-- Slot 4's group; confirm Cadence as the pick.
+- Cut: Ceiling (felt only at the top).
+- Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
+- TODO: per-item cards (appearance, effect); slot 4 group; confirm Cadence.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,0 +1,91 @@
+# Starter Items
+
+The starter set is the items Zach stocks his stall with in Act I. They are drawn from the four childhood friends: the protagonist, Zach, Fern, and Steph. The player starts with nothing, so these are their first items and their first lesson in what items are. Mostly sports objects, not all, each one weird or interesting in a way that hints at its effect. See [the narrative outline](../narrative/outline.md).
+
+This doc owns the shape of the set: which build groups it pulls from, why each group is in or out, and which five items fill the slots. Per-item cards (appearance and effect) follow the format in [items.md](items.md) and are stubbed below.
+
+---
+
+## Design principles
+
+The set is research-grounded, not intuited.
+
+- **Small.** Five items. Slay the Spire ships four starter relics, each one legible line. The choice-overload literature (Iyengar and Lepper's jam study; the 7 plus or minus 2 working-memory ceiling) says a beginner's first menu should sit well under that ceiling.
+- **Felt in one rally.** Each effect is immediately perceptible in a single rally. The player learns by owning, not by reading.
+- **Orthogonal.** Each item is a distinct verb, never four flavours of "bigger." This is Harvey Smith's orthogonal unit differentiation: items earn their place by doing something the others do not.
+- **Simple.** The four functional items carry no complexity: no triggers to track, no build to assemble. The shopkeeper's pick may be more complex.
+- **Cheap first spend.** The first soul spend is cheap and obviously felt, so the economy teaches itself.
+
+Grounded in roguelite starter-relic design, the choice-overload literature, and incremental-game onboarding.
+
+---
+
+## The loop the set teaches
+
+Early Volley is self-controlled and the player generally does not miss, so the set rewards the build, not survival.
+
+The build: consecutive hits gather soul and accelerate the rally. At a tier ceiling the soul consolidates (tier completion), the ball drops to the next tier's floor and climbs again. The top tier opens a Peak.
+
+The starter items pay out on the consolidation beat. Soul consolidation is tracked as SH-437; the tier ladder it sits on is in [20-ball-speed-tiers.md](../20-ball-speed-tiers.md).
+
+---
+
+## Pull-from groups
+
+The set pulls from three build groups, and leaves a fourth for the pick.
+
+- **Capability.** A flat lift to what the player already does. The cheap, legible on-ramp.
+- **Yield.** More soul per volley, banking at consolidation.
+- **Momentum.** Value compounds the longer the streak holds, releasing at consolidation.
+- **Tempo** is reserved for the pick.
+
+### Why Ceiling is cut
+
+Ceiling is not a starter group. A ceiling or extra-tier effect is felt only at the top of the climb, which a beginner does not reach. It fails the felt-in-one-rally bar. It belongs to later progression.
+
+### Excluded groups, with reasons
+
+- **The miss-cluster** (Defensive, Consolation, Recovery): nothing to defend when the player does not miss.
+- **Synergy:** build-around, the opposite of simple.
+- **Risk/Reward:** variance confuses a learner.
+- **Field-changing:** competes with the ball's own acceleration.
+- **Slot-expanding:** premature.
+- **Partner-enhancing:** Martha has barely arrived.
+
+---
+
+## The five items
+
+Four simple functional items, one per build group plus a second item doubling one group. Plus the shopkeeper's pick.
+
+| Slot | Group | Notes |
+|---|---|---|
+| 1 | Capability | Flat lift to current play |
+| 2 | Yield | More soul per volley |
+| 3 | Momentum | Compounds across the streak |
+| 4 | (doubled group, **TODO**) | Second item on one of the three build groups; which is open |
+| Pick | Tempo | Cadence |
+
+### The pick: Cadence
+
+Cadence is the shopkeeper's pick, a Tempo item, more complex than the four functional items. It is re-rooted from its coach-whistle fiction as a childhood whistle from the four friends.
+
+Its oscillation plus its tier-skip lets the pick act on the consolidation beat that the simple items only pay out on. Where the four simple items wait for consolidation to arrive, Cadence reaches the beat sooner.
+
+---
+
+## Interest without complexity
+
+Three levers carry the set's interest, none of which add rules.
+
+- **The object itself.** Thing-and-twist: weird, and the three-variant description reveals over time.
+- **Expressive feedback.** The effect is seen and felt escalating, not read off a stat.
+- **The consolidation beat.** The set hooks the beat the loop already generates rather than inventing a new one.
+
+---
+
+## TODO
+
+- Per-item cards: appearance and effect for each of the five (SH-436's acceptance criteria).
+- Which build group slot four doubles, open.
+- Confirm Cadence as the pick.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -4,7 +4,7 @@ Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Ste
 
 | Role | Item | Effect |
 |---|---|---|
-| ball | TODO | At consolidation, splits in two; collide them to merge for a soul burst. Not merging is a missed bonus, no penalty. |
+| ball | TODO | Splits at consolidation; each higher tier splits into one more ball (2 at the first, +1 per tier after). Collide them to merge for a soul burst. Not merging is a missed bonus, no penalty. |
 | equipment | TODO | |
 | court | TODO | |
 | doubled (TODO) | TODO | |

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,91 +1,33 @@
 # Starter Items
 
-The starter set is the items Zach stocks his stall with in Act I. They are drawn from the four childhood friends: the protagonist, Zach, Fern, and Steph. The player starts with nothing, so these are their first items and their first lesson in what items are. Mostly sports objects, not all, each one weird or interesting in a way that hints at its effect. See [the narrative outline](../narrative/outline.md).
+The items Zach stocks his stall with in Act I, drawn from the four childhood friends (the protagonist, Zach, Fern, Steph). The player starts with nothing; these are their first items and first lesson in what items are. Mostly sports objects, each weird or interesting in a way that hints at its effect. Learned by owning, not reading. See [the narrative outline](../narrative/outline.md).
 
-This doc owns the shape of the set: which build groups it pulls from, why each group is in or out, and which five items fill the slots. Per-item cards (appearance and effect) follow the format in [items.md](items.md) and are stubbed below.
+## Principles
 
----
+- Five items. Each effect felt in one rally.
+- Each a distinct verb, never four flavours of "bigger".
+- The four functional items stay simple; the shopkeeper's pick may be complex.
+- First soul spend cheap and obviously felt.
 
-## Design principles
+## The set
 
-The set is research-grounded, not intuited.
+Early Volley is self-controlled and the player rarely misses, so the set rewards the build, not survival. The build pays out on the consolidation beat (SH-437; tier ladder in [20-ball-speed-tiers.md](../20-ball-speed-tiers.md)).
 
-- **Small.** Five items. Slay the Spire ships four starter relics, each one legible line. The choice-overload literature (Iyengar and Lepper's jam study; the 7 plus or minus 2 working-memory ceiling) says a beginner's first menu should sit well under that ceiling.
-- **Felt in one rally.** Each effect is immediately perceptible in a single rally. The player learns by owning, not by reading.
-- **Orthogonal.** Each item is a distinct verb, never four flavours of "bigger." This is Harvey Smith's orthogonal unit differentiation: items earn their place by doing something the others do not.
-- **Simple.** The four functional items carry no complexity: no triggers to track, no build to assemble. The shopkeeper's pick may be more complex.
-- **Cheap first spend.** The first soul spend is cheap and obviously felt, so the economy teaches itself.
-
-Grounded in roguelite starter-relic design, the choice-overload literature, and incremental-game onboarding.
-
----
-
-## The loop the set teaches
-
-Early Volley is self-controlled and the player generally does not miss, so the set rewards the build, not survival.
-
-The build: consecutive hits gather soul and accelerate the rally. At a tier ceiling the soul consolidates (tier completion), the ball drops to the next tier's floor and climbs again. The top tier opens a Peak.
-
-The starter items pay out on the consolidation beat. Soul consolidation is tracked as SH-437; the tier ladder it sits on is in [20-ball-speed-tiers.md](../20-ball-speed-tiers.md).
-
----
-
-## Pull-from groups
-
-The set pulls from three build groups, and leaves a fourth for the pick.
-
-- **Capability.** A flat lift to what the player already does. The cheap, legible on-ramp.
-- **Yield.** More soul per volley, banking at consolidation.
-- **Momentum.** Value compounds the longer the streak holds, releasing at consolidation.
-- **Tempo** is reserved for the pick.
-
-### Why Ceiling is cut
-
-Ceiling is not a starter group. A ceiling or extra-tier effect is felt only at the top of the climb, which a beginner does not reach. It fails the felt-in-one-rally bar. It belongs to later progression.
-
-### Excluded groups, with reasons
-
-- **The miss-cluster** (Defensive, Consolation, Recovery): nothing to defend when the player does not miss.
-- **Synergy:** build-around, the opposite of simple.
-- **Risk/Reward:** variance confuses a learner.
-- **Field-changing:** competes with the ball's own acceleration.
-- **Slot-expanding:** premature.
-- **Partner-enhancing:** Martha has barely arrived.
-
----
-
-## The five items
-
-Four simple functional items, one per build group plus a second item doubling one group. Plus the shopkeeper's pick.
-
-| Slot | Group | Notes |
+| Slot | Group | Effect |
 |---|---|---|
-| 1 | Capability | Flat lift to current play |
+| 1 | Capability | Levitate higher (arc interaction open) |
 | 2 | Yield | More soul per volley |
 | 3 | Momentum | Compounds across the streak |
-| 4 | (doubled group, **TODO**) | Second item on one of the three build groups; which is open |
-| Pick | Tempo | Cadence |
+| 4 | doubled (TODO) | Second item on one build group |
+| Pick | Tempo | Cadence: oscillation plus tier-skip, the complex pick |
 
-### The pick: Cadence
-
-Cadence is the shopkeeper's pick, a Tempo item, more complex than the four functional items. It is re-rooted from its coach-whistle fiction as a childhood whistle from the four friends.
-
-Its oscillation plus its tier-skip lets the pick act on the consolidation beat that the simple items only pay out on. Where the four simple items wait for consolidation to arrive, Cadence reaches the beat sooner.
-
----
+Pull-from groups: Capability, Yield, Momentum, plus Tempo for the pick. **Ceiling is cut** to later progression: felt only at the top of the climb, which a beginner never reaches. Out, and why: the miss-cluster (no missing early), Synergy (build-around), Risk/Reward (variance), Field-changing (competes with acceleration), Slot-expanding (premature), Partner-enhancing (Martha barely arrived).
 
 ## Interest without complexity
 
-Three levers carry the set's interest, none of which add rules.
-
-- **The object itself.** Thing-and-twist: weird, and the three-variant description reveals over time.
-- **Expressive feedback.** The effect is seen and felt escalating, not read off a stat.
-- **The consolidation beat.** The set hooks the beat the loop already generates rather than inventing a new one.
-
----
+The object's thing-and-twist and its variant reveals; expressive feedback; hooking the consolidation beat the loop already generates. No added rules.
 
 ## TODO
 
-- Per-item cards: appearance and effect for each of the five (SH-436's acceptance criteria).
-- Which build group slot four doubles, open.
-- Confirm Cadence as the pick.
+- Per-item cards (appearance and effect), SH-436's acceptance criteria.
+- Slot 4's group; confirm Cadence as the pick.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,17 +1,15 @@
 # Starter Items
 
-Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph).
+Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Built across the three item roles; each effect serves the early goal (soul on consolidation, reach consolidation faster).
 
-| Slot | Group | Effect |
+| Role | Item | Effect |
 |---|---|---|
-| 1 | Reward | Soul paid on consolidation |
-| 2 | Control (TODO) | Shape where the ball goes |
-| 3 | (TODO) | |
-| 4 | (TODO) | |
-| Pick | Tempo | Cadence: oscillation plus tier-skip (complex) |
+| ball | TODO | |
+| equipment | TODO | |
+| court | TODO | |
+| doubled (TODO) | TODO | |
+| equipment (pick) | Cadence | Oscillation plus tier-skip (complex) |
 
-- Cut to progression (furthered later, not a starter): Ceiling; Levitation (the protagonist gains soul-control over the game).
+- Cut to progression: Ceiling; Levitation.
 - Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
-- Pay out on consolidation.
-- Distinct goal-serving verbs are thin (Reward, Tempo, maybe Control); the set likely shrinks rather than pads.
-- TODO: remaining slots; per-item cards; confirm Cadence.
+- TODO: per-item effects and objects; the doubled role; confirm Cadence.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -25,7 +25,6 @@ Role: equipment. Oscillation plus tier-skip; the complex shopkeeper's pick. Obje
 ## To design
 
 - Objects and names (a few still open).
-- Confirm Cadence as the pick.
 
 ---
 

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -10,13 +10,17 @@ Role: ball. Splits at consolidation, and each higher tier splits into one more b
 
 Role: equipment, worn on the head. Lets you header the ball, a new contact distinct from the racquet hit; a header struck at the apex of the arc bursts soul. Pulls play upward. Object: a childhood helmet of the four.
 
+## Soul motes (name TODO)
+
+Role: equipment. Every hit explodes soul motes off the ball. They drift to you and auto-collect; steering the ball back through them gathers more, faster. A passive trickle with a skill ceiling. Object: TODO.
+
 ## Cadence (pick)
 
 Role: equipment. Oscillation plus tier-skip; the complex shopkeeper's pick. Object: a childhood whistle of the four.
 
 ## To design
 
-- Two more items, ball or equipment role, each a unique gameplay-change.
+- One more item, ball or equipment role, a unique gameplay-change.
 - Objects and names for every item.
 - Confirm Cadence as the pick.
 

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -4,13 +4,14 @@ Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Ste
 
 | Slot | Group | Effect |
 |---|---|---|
-| 1 | Capability | Levitate higher; soul-bound and arc rise with you |
-| 2 | Yield | More soul per volley |
-| 3 | Momentum | Compounds across the streak |
-| 4 | doubled (TODO) | Second item on one build group |
+| 1 | Reward | Soul paid on consolidation |
+| 2 | Control (TODO) | Shape where the ball goes |
+| 3 | (TODO) | |
+| 4 | (TODO) | |
 | Pick | Tempo | Cadence: oscillation plus tier-skip (complex) |
 
-- Cut: Ceiling (felt only at the top).
+- Cut to progression (furthered later, not a starter): Ceiling; Levitation (the protagonist gains soul-control over the game).
 - Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
 - Pay out on consolidation.
-- TODO: per-item cards; slot 4 group; confirm Cadence.
+- Distinct goal-serving verbs are thin (Reward, Tempo, maybe Control); the set likely shrinks rather than pads.
+- TODO: remaining slots; per-item cards; confirm Cadence.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,16 +1,23 @@
 # Starter Items
 
-Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Ball and equipment roles only (court ships later). Each effect is a unique gameplay-change, not a stat, serving the early goal.
+Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Ball and equipment roles; court ships later. Each effect is a unique gameplay-change, not a stat.
 
-| Role | Effect | Object (thing + twist) | Name |
-|---|---|---|---|
-| ball | Splits at consolidation, +1 ball per tier; collide them to merge for a soul burst. Not merging is a missed bonus. | TODO | TODO |
-| equipment | TODO | TODO | TODO |
-| ball / equipment | TODO | TODO | TODO |
-| ball / equipment | TODO | TODO | TODO |
-| equipment (pick) | Oscillation plus tier-skip; the complex pick. | TODO (childhood whistle) | Cadence |
+## Ball: split-and-merge (name TODO)
+
+Role: ball. Splits at consolidation, and each higher tier splits into one more ball (2 at the first, +1 per tier after). Collide them to merge for a soul burst. Not merging is a missed bonus, no penalty.
+
+## Cadence (pick)
+
+Role: equipment. Oscillation plus tier-skip; the complex shopkeeper's pick. Object: a childhood whistle of the four.
+
+## To design
+
+- Three more items, ball or equipment role, each a unique gameplay-change.
+- Objects and names for every item.
+- Confirm Cadence as the pick.
+
+---
 
 - Court items ship later.
 - Cut to progression: Ceiling; Levitation.
 - Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
-- TODO: effects for the open slots; objects and names (items.md card); confirm Cadence.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -6,13 +6,17 @@ Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Ste
 
 Role: ball. Splits at consolidation, and each higher tier splits into one more ball (2 at the first, +1 per tier after). Collide them to merge for a soul burst. Not merging is a missed bonus, no penalty.
 
+## Helmet (name TODO)
+
+Role: equipment, worn on the head. Lets you header the ball, a new contact distinct from the racquet hit; a header struck at the apex of the arc bursts soul. Pulls play upward. Object: a childhood helmet of the four.
+
 ## Cadence (pick)
 
 Role: equipment. Oscillation plus tier-skip; the complex shopkeeper's pick. Object: a childhood whistle of the four.
 
 ## To design
 
-- Three more items, ball or equipment role, each a unique gameplay-change.
+- Two more items, ball or equipment role, each a unique gameplay-change.
 - Objects and names for every item.
 - Confirm Cadence as the pick.
 

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,33 +1,31 @@
 # Starter Items
 
-Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). The player starts with the initial ball and racquet; these items add to that, new balls and worn gear. Court ships later. Each effect is a unique gameplay-change, not a stat.
+The player starts with the initial ball and racquet; these items add to that, new balls and worn gear.
 
 ## Ball: split-and-merge (name TODO)
 
-Role: ball (a new ball). At consolidation it splits, and each higher tier splits into one more ball (2 at the first, +1 per tier after). Collide them to merge for a soul burst. Not merging is a missed bonus, no penalty.
+Role: ball
+At consolidation it splits, and each higher tier splits into one more ball (2 at the first, +1 per tier after). 
+Collide them to merge for a soul burst. 
+Not merging is a missed bonus, no penalty.
 
 ## Helmet (name TODO)
 
-Role: equipment, worn on the head. Lets you header the ball, a new contact distinct from the racquet hit; a header struck at the apex of the arc bursts soul. Pulls play upward. Object: a childhood helmet of the four.
+Role: equipment : head
+Lets you header the ball, a new contact distinct from the racquet hit; a header struck at the apex of the arc bursts soul.
 
-## Soul motes (friendship bracelet)
+## Friendship bracelet
 
-Role: equipment, worn on the wrist. Each hit sheds a soul bead off the ball; beads drift to you and auto-collect, and routing the ball back through them gathers more. Soul is the bond, and the bracelet is that bond shedding into collectible beads. Object: the four's childhood friendship bracelet, never runs down, the beads warm.
+Role: equipment : arm
+
+Worn on the wrist. 
+Each hit sheds a soul bead off the ball; beads drift and can be collected via the ball. The beads never run out.
 
 ## Magnetism (name TODO)
 
-Role: equipment, worn. Balls are drawn toward the player, curving toward where you reach, so the rally flows and split balls drift back into reach instead of scattering. Object: a childhood magnet of the four (a horseshoe, a found lump of lodestone).
+Role: equipment
+Balls are drawn toward the player, curving toward where you reach.
 
 ## Cadence (pick)
 
-Role: equipment. The complex shopkeeper's pick, specced among the prototype effect blocks. Object: a childhood whistle of the four.
-
-## To design
-
-- Objects and names (a few still open).
-
----
-
-- Court items ship later.
-- Cut to progression: Ceiling; Levitation.
-- Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
+Role: equipment : neck

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -10,9 +10,9 @@ Role: ball. Splits at consolidation, and each higher tier splits into one more b
 
 Role: equipment, worn on the head. Lets you header the ball, a new contact distinct from the racquet hit; a header struck at the apex of the arc bursts soul. Pulls play upward. Object: a childhood helmet of the four.
 
-## Soul motes (name TODO)
+## Soul motes (friendship bracelet)
 
-Role: equipment. Every hit explodes soul motes off the ball. They drift to you and auto-collect; steering the ball back through them gathers more, faster. A passive trickle with a skill ceiling. Object: TODO.
+Role: equipment, worn on the wrist. Each hit sheds a soul bead off the ball; beads drift to you and auto-collect, and routing the ball back through them gathers more. Soul is the bond, and the bracelet is that bond shedding into collectible beads. Object: the four's childhood friendship bracelet, never runs down, the beads warm.
 
 ## Cadence (pick)
 

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -14,14 +14,17 @@ Role: equipment, worn on the head. Lets you header the ball, a new contact disti
 
 Role: equipment, worn on the wrist. Each hit sheds a soul bead off the ball; beads drift to you and auto-collect, and routing the ball back through them gathers more. Soul is the bond, and the bracelet is that bond shedding into collectible beads. Object: the four's childhood friendship bracelet, never runs down, the beads warm.
 
+## Magnetism (name TODO)
+
+Role: equipment, worn. Balls are drawn toward the characters (player and partner), curving toward whoever is reaching, so the rally flows and the split balls drift back into reach instead of scattering. Object: a childhood magnet of the four (a horseshoe, a found lump of lodestone).
+
 ## Cadence (pick)
 
 Role: equipment. Oscillation plus tier-skip; the complex shopkeeper's pick. Object: a childhood whistle of the four.
 
 ## To design
 
-- One more item, ball or equipment role, a unique gameplay-change.
-- Objects and names for every item.
+- Objects and names (a few still open).
 - Confirm Cadence as the pick.
 
 ---

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -10,10 +10,6 @@ Role: ball (a new ball). At consolidation it splits, and each higher tier splits
 
 Role: equipment, worn on the head. Lets you header the ball, a new contact distinct from the racquet hit; a header struck at the apex of the arc bursts soul. Pulls play upward. Object: a childhood helmet of the four.
 
-## Spike (name TODO)
-
-Role: equipment, worn. From up high you can spike the ball, slam it down hard and fast, the offensive twin to the helmet's header: rise to the high ball, head it up to keep the rally building, or spike it down to attack. Its home is the duel (drive the opponent into a miss); in a cooperative rally it is a high-risk, high-soul flourish. Payoff and object: TODO.
-
 ## Soul motes (friendship bracelet)
 
 Role: equipment, worn on the wrist. Each hit sheds a soul bead off the ball; beads drift to you and auto-collect, and routing the ball back through them gathers more. Soul is the bond, and the bracelet is that bond shedding into collectible beads. Object: the four's childhood friendship bracelet, never runs down, the beads warm.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,6 +1,6 @@
 # Starter Items
 
-Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Item framework, card format, and categories: [items.md](items.md).
+Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph).
 
 | Slot | Group | Effect |
 |---|---|---|
@@ -12,5 +12,5 @@ Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Ste
 
 - Cut: Ceiling (felt only at the top).
 - Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
-- Pay out on consolidation (SH-437).
-- TODO: per-item cards (items.md format); slot 4 group; confirm Cadence.
+- Pay out on consolidation.
+- TODO: per-item cards; slot 4 group; confirm Cadence.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,15 +1,16 @@
 # Starter Items
 
-Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Built across the three item roles; each effect serves the early goal (soul on consolidation, reach consolidation faster).
+Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Ball and equipment roles only (court ships later). Each effect is a unique gameplay-change, not a stat, serving the early goal.
 
-| Role | Item | Effect |
-|---|---|---|
-| ball | TODO | Splits at consolidation; each higher tier splits into one more ball (2 at the first, +1 per tier after). Collide them to merge for a soul burst. Not merging is a missed bonus, no penalty. |
-| equipment | TODO | |
-| doubled (TODO) | TODO | |
-| equipment (pick) | Cadence | Oscillation plus tier-skip (complex) |
+| Role | Effect | Object (thing + twist) | Name |
+|---|---|---|---|
+| ball | Splits at consolidation, +1 ball per tier; collide them to merge for a soul burst. Not merging is a missed bonus. | TODO | TODO |
+| equipment | TODO | TODO | TODO |
+| ball / equipment | TODO | TODO | TODO |
+| ball / equipment | TODO | TODO | TODO |
+| equipment (pick) | Oscillation plus tier-skip; the complex pick. | TODO (childhood whistle) | Cadence |
 
-- Court items ship later; this set is ball and equipment only.
+- Court items ship later.
 - Cut to progression: Ceiling; Levitation.
 - Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
-- TODO: per-item effects and objects; the doubled role; confirm Cadence.
+- TODO: effects for the open slots; objects and names (items.md card); confirm Cadence.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,6 +1,6 @@
 # Starter Items
 
-Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Mostly sports, weird. Five items, distinct verbs, felt in one rally, paying out on consolidation (SH-437).
+Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Item framework, card format, and categories: [items.md](items.md).
 
 | Slot | Group | Effect |
 |---|---|---|
@@ -12,4 +12,5 @@ Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Ste
 
 - Cut: Ceiling (felt only at the top).
 - Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
-- TODO: per-item cards (appearance, effect); slot 4 group; confirm Cadence.
+- Pay out on consolidation (SH-437).
+- TODO: per-item cards (items.md format); slot 4 group; confirm Cadence.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -6,10 +6,10 @@ Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Ste
 |---|---|---|
 | ball | TODO | Splits at consolidation; each higher tier splits into one more ball (2 at the first, +1 per tier after). Collide them to merge for a soul burst. Not merging is a missed bonus, no penalty. |
 | equipment | TODO | |
-| court | TODO | |
 | doubled (TODO) | TODO | |
 | equipment (pick) | Cadence | Oscillation plus tier-skip (complex) |
 
+- Court items ship later; this set is ball and equipment only.
 - Cut to progression: Ceiling; Levitation.
 - Out: miss-cluster, Synergy, Risk/Reward, Field-changing, Slot-expanding, Partner-enhancing.
 - TODO: per-item effects and objects; the doubled role; confirm Cadence.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -10,6 +10,10 @@ Role: ball (a new ball). At consolidation it splits, and each higher tier splits
 
 Role: equipment, worn on the head. Lets you header the ball, a new contact distinct from the racquet hit; a header struck at the apex of the arc bursts soul. Pulls play upward. Object: a childhood helmet of the four.
 
+## Spike (name TODO)
+
+Role: equipment, worn. From up high you can spike the ball, slam it down hard and fast, the offensive twin to the helmet's header: rise to the high ball, head it up to keep the rally building, or spike it down to attack. Its home is the duel (drive the opponent into a miss); in a cooperative rally it is a high-risk, high-soul flourish. Payoff and object: TODO.
+
 ## Soul motes (friendship bracelet)
 
 Role: equipment, worn on the wrist. Each hit sheds a soul bead off the ball; beads drift to you and auto-collect, and routing the ball back through them gathers more. Soul is the bond, and the bracelet is that bond shedding into collectible beads. Object: the four's childhood friendship bracelet, never runs down, the beads warm.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -1,10 +1,10 @@
 # Starter Items
 
-Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). Ball and equipment roles; court ships later. Each effect is a unique gameplay-change, not a stat.
+Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Steph). The player starts with the initial ball and racquet; these items add to that, new balls and worn gear. Court ships later. Each effect is a unique gameplay-change, not a stat.
 
 ## Ball: split-and-merge (name TODO)
 
-Role: ball. Splits at consolidation, and each higher tier splits into one more ball (2 at the first, +1 per tier after). Collide them to merge for a soul burst. Not merging is a missed bonus, no penalty.
+Role: ball (a new ball). At consolidation it splits, and each higher tier splits into one more ball (2 at the first, +1 per tier after). Collide them to merge for a soul burst. Not merging is a missed bonus, no penalty.
 
 ## Helmet (name TODO)
 

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -30,12 +30,6 @@ Balls are drawn toward the player, curving toward where you reach.
 
 Role: equipment : neck
 
-Whistle + out of tune. Standard coach's whistle, brass tarnished, plays a note that's slightly flat. You can feel it in your teeth.
-
-| State | Description |
-|---|---|
-| Default | "Sounds wrong" |
-| After first ceiling raise | "Don't stop. Won't stop" |
-| Post-Break | "Was anyone listening?" |
+Whistle + out of tune. Standard coach's whistle, brass tarnished, plays a note that's slightly flat.
 
 The whistle sets the tempo. Ball speed oscillates in waves: ramping up and down unpredictably. When the ball reaches max speed, the ceiling raises and speed keeps climbing.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -4,7 +4,7 @@ Zach's stall, Act I. Childhood objects of the four (protagonist, Zach, Fern, Ste
 
 | Role | Item | Effect |
 |---|---|---|
-| ball | TODO | |
+| ball | TODO | At consolidation, splits in two; collide them to merge for a soul burst. Not merging is a missed bonus, no penalty. |
 | equipment | TODO | |
 | court | TODO | |
 | doubled (TODO) | TODO | |

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -16,11 +16,11 @@ Role: equipment, worn on the wrist. Each hit sheds a soul bead off the ball; bea
 
 ## Magnetism (name TODO)
 
-Role: equipment, worn. Balls are drawn toward the characters (player and partner), curving toward whoever is reaching, so the rally flows and the split balls drift back into reach instead of scattering. Object: a childhood magnet of the four (a horseshoe, a found lump of lodestone).
+Role: equipment, worn. Balls are drawn toward the player, curving toward where you reach, so the rally flows and split balls drift back into reach instead of scattering. Object: a childhood magnet of the four (a horseshoe, a found lump of lodestone).
 
 ## Cadence (pick)
 
-Role: equipment. Oscillation plus tier-skip; the complex shopkeeper's pick. Object: a childhood whistle of the four.
+Role: equipment. The complex shopkeeper's pick, specced among the prototype effect blocks. Object: a childhood whistle of the four.
 
 ## To design
 

--- a/designs/01-prototype/tech/05a-starter-item-effects.md
+++ b/designs/01-prototype/tech/05a-starter-item-effects.md
@@ -12,11 +12,11 @@ Effect 2
   outcome: soul_burst(scale_by current_tier)
 ```
 
-Split fires on soul consolidation; the only read of the tier ladder is `current_tier` for the count, so there is no dependency on the unbuilt SH-88 system.
+Split fires on soul consolidation; there is no dependency on the milestone system.
 
 Split balls are ephemeral. They carry `is_temporary = true` (the flag `BallReconciler` already skips on adoption) and a `source_key` back-reference to the parent item. They attach to `BallTracker` so effects and magnetism reach them, but never enter `BallReconciler._balls_by_key`, so the save providers and reconcile never see them. Dragged off-court a split ball is destroyed, not racked: the drag controller's off-court path (`ball_drag_controller.gd`) branches on `is_temporary`.
 
-Merge keeps the survivor's `source_key` (both copies share it, so no key arbitration) and takes the max speed and tier of the pair. `on_balls_close` is a per-frame pairwise distance check over `BallTracker.get_balls()`, not a RigidBody contact: closing speed up to twice world-max is the tunnelling regime, and a distance test sidesteps CCD.
+Merge keeps the survivor's `source_key` (both copies share it, so no key arbitration) and takes the max speed and tier of the pair. `on_balls_close` is a per-frame pairwise distance check over `BallTracker.get_balls()`, not a RigidBody contact: closing speed up to twice world-max is the tunnelling regime, and a distance test sidesteps continuous collision detection.
 
 Levels and cost/scaling: TBD.
 

--- a/designs/01-prototype/tech/05a-starter-item-effects.md
+++ b/designs/01-prototype/tech/05a-starter-item-effects.md
@@ -1,31 +1,39 @@
 # Starter Item Effect Blocks
 
-Tech spike for the starter items (SH-436): each effect as trigger, condition, outcome, plus the primitives the effect system would need. Numbers are tuning, left open. Cadence is already specced among the prototype effect blocks.
+Tech spike for the starter items (SH-436): each effect as trigger, condition, outcome, plus the engine work each needs against the system as built. Numbers are tuning, left open. Cadence is already specced among the prototype effect blocks.
+
+Soul is the canonical name for the currency the code still calls `friendship` (`ItemManager.add_friendship_points`, `friendship_points_per_hit`). The rename is pending and tracked separately; every soul outcome below routes through that existing economy path.
 
 ## Split (ball)
 
 ```
 Effect 1
-  trigger: on_tier_completed(tier)
-  outcome: split_ball(count = tier + 1)
+  trigger: on_consolidation
+  outcome: split_ball(count = current_tier + 1)
 Effect 2
-  trigger: on_balls_collide
+  trigger: on_balls_close
   outcome: merge_balls
-  outcome: soul_burst(scale_by tier)
+  outcome: soul_burst(scale_by current_tier)
 ```
 
-Split count rises with the tier; merging is the player driving two balls together. Levels and cost/scaling: TBD.
+Split fires at the consolidation beat, not on a tier-ladder event; the only read of the tier ladder is `current_tier` for the count, so there is no dependency on the unbuilt SH-88 system.
+
+Split balls are ephemeral. They carry `is_temporary = true` (the flag `BallReconciler` already skips on adoption) and a `source_key` back-reference to the parent item. They attach to `BallTracker` so effects and magnetism reach them, but never enter `BallReconciler._balls_by_key`, so the save providers and reconcile never see them. Dragged off-court a split ball is destroyed, not racked: the drag controller's off-court path (`ball_drag_controller.gd`) branches on `is_temporary`.
+
+Merge keeps the survivor's `source_key` (both copies share it, so no key arbitration) and takes the max speed and tier of the pair. `on_balls_close` is a per-frame pairwise distance check over `BallTracker.get_balls()`, not a RigidBody contact: closing speed up to twice world-max is the tunnelling regime, and a distance test sidesteps CCD.
+
+Levels and cost/scaling: TBD.
 
 ## Helmet (equipment)
 
 ```
-grants: header (a head contact, distinct from the racquet)
+grants: header (reworked racquet contact, struck with the head)
 Effect 1
   trigger: on_header_at_apex
   outcome: soul_burst
 ```
 
-Levels (burst size) and cost/scaling: TBD.
+The header reworks the existing racquet collision rather than adding a head collider or a second input path. Apex is an enumerated arc phase: the ball's arc state gains an APEX value between rising and falling, built on the `bound_y` / PLAY_ARC machinery already in `ball.gd`, and `on_header_at_apex` fires only in that phase. Levels (burst size) and cost/scaling: TBD.
 
 ## Friendship bracelet (equipment)
 
@@ -35,25 +43,28 @@ Effect 1
   outcome: spawn_soul_motes(n)
 Effect 2
   trigger: on_mote_gathered
-  outcome: add_soul
+  outcome: soul_burst
 ```
 
-Motes drift to the player and auto-gather; routing the ball through them gathers more. Levels (motes per hit) and cost/scaling: TBD.
+Motes auto-gather to the player only; uncollected motes expire at rally end. Ball-through-mote re-collection reuses the merge distance test, not physics contact. Levels (motes per hit) and cost/scaling: TBD.
 
 ## Magnetism (equipment)
 
 ```
 Effect 1
   trigger: always
-  outcome: attract_balls_to_characters(strength)
+  outcome: stat(ball_magnetism, +strength)
 ```
 
-A passive pull of every ball toward the player and partner. Levels (strength) and cost/scaling: TBD.
+Mostly built: `ball_magnetism` is a registered stat and `BallEffectProcessor._apply_magnetism` already pulls each ball toward a paddle every frame. The delta is retargeting that pull to the player only; today it picks the nearest paddle. So this is a stat always-effect, not a new primitive. Levels (strength) and cost/scaling: TBD.
 
-## New primitives the effect system needs
+## Engine work
 
-- `header` contact and an `on_header_at_apex` trigger (helmet).
-- `split_ball`, an `on_balls_collide` trigger, `merge_balls` (split).
+The effect system as built carries five outcome types (`stat`, `stat_until_miss`, `oscillate_stat`, `halve_streak`, `game_action`), and `process_event` returns a payload-free `Array[StringName]`. So every outcome below that carries a parameter is a dedicated Outcome subclass with its own `apply(context)`, not a key on the game-action channel:
+
+- `split_ball`, `merge_balls`, an `on_consolidation` trigger, and an `on_balls_close` distance check (split).
+- `soul_burst`, a calculated grant through `ItemManager.add_friendship_points` (split, helmet, bracelet).
 - `spawn_soul_motes` plus mote entities and an `on_mote_gathered` trigger (bracelet).
-- `attract_balls_to_characters`, a passive force (magnetism).
-- `soul_burst` outcome (shared).
+- a reworked racquet contact and an `on_header_at_apex` trigger keyed to the arc-phase enum (helmet).
+
+Magnetism needs no new primitive; it is a stat effect on the existing `ball_magnetism` pull, retargeted to the player.

--- a/designs/01-prototype/tech/05a-starter-item-effects.md
+++ b/designs/01-prototype/tech/05a-starter-item-effects.md
@@ -5,11 +5,11 @@
 ```
 Effect 1
   trigger: on_consolidation
-  outcome: split_ball(count = current_tier + 1)
+  outcome: split_ball(count = consolidations + 1)
 Effect 2
   trigger: on_balls_close
   outcome: merge_balls
-  outcome: soul_burst(scale_by current_tier)
+  outcome: soul_burst(scale_by consolidations)
 ```
 
 Split fires on soul consolidation; there is no dependency on the milestone system.

--- a/designs/01-prototype/tech/05a-starter-item-effects.md
+++ b/designs/01-prototype/tech/05a-starter-item-effects.md
@@ -1,8 +1,4 @@
-# Starter Item Effect Blocks
-
-Tech spike for the starter items (SH-436): each effect as trigger, condition, outcome, plus the engine work each needs against the system as built. Numbers are tuning, left open. Cadence is already specced among the prototype effect blocks.
-
-Soul is the canonical name for the currency the code still calls `friendship` (`ItemManager.add_friendship_points`, `friendship_points_per_hit`). The rename is pending and tracked separately; every soul outcome below routes through that existing economy path.
+# Starter Item Effects
 
 ## Split (ball)
 
@@ -16,7 +12,7 @@ Effect 2
   outcome: soul_burst(scale_by current_tier)
 ```
 
-Split fires at the consolidation beat, not on a tier-ladder event; the only read of the tier ladder is `current_tier` for the count, so there is no dependency on the unbuilt SH-88 system.
+Split fires on soul consolidation; the only read of the tier ladder is `current_tier` for the count, so there is no dependency on the unbuilt SH-88 system.
 
 Split balls are ephemeral. They carry `is_temporary = true` (the flag `BallReconciler` already skips on adoption) and a `source_key` back-reference to the parent item. They attach to `BallTracker` so effects and magnetism reach them, but never enter `BallReconciler._balls_by_key`, so the save providers and reconcile never see them. Dragged off-court a split ball is destroyed, not racked: the drag controller's off-court path (`ball_drag_controller.gd`) branches on `is_temporary`.
 

--- a/designs/01-prototype/tech/05a-starter-item-effects.md
+++ b/designs/01-prototype/tech/05a-starter-item-effects.md
@@ -36,13 +36,13 @@ The header reworks the existing racquet collision rather than adding a head coll
 ```
 Effect 1
   trigger: on_hit
-  outcome: spawn_soul_motes(n)
+  outcome: spawn_soul_beads(n)
 Effect 2
-  trigger: on_mote_gathered
+  trigger: on_bead_gathered
   outcome: soul_burst
 ```
 
-Motes auto-gather to the player only; uncollected motes expire at rally end. Ball-through-mote re-collection reuses the merge distance test, not physics contact. Levels (motes per hit) and cost/scaling: TBD.
+Beads auto-gather to the player only; uncollected beads expire at rally end. Ball-through-bead re-collection reuses the merge distance test, not physics contact. Levels (beads per hit) and cost/scaling: TBD.
 
 ## Magnetism (equipment)
 
@@ -60,7 +60,7 @@ The effect system as built carries five outcome types (`stat`, `stat_until_miss`
 
 - `split_ball`, `merge_balls`, an `on_consolidation` trigger, and an `on_balls_close` distance check (split).
 - `soul_burst`, a calculated grant through `ItemManager.add_friendship_points` (split, helmet, bracelet).
-- `spawn_soul_motes` plus mote entities and an `on_mote_gathered` trigger (bracelet).
+- `spawn_soul_beads` plus bead entities and an `on_bead_gathered` trigger (bracelet).
 - a reworked racquet contact and an `on_header_at_apex` trigger keyed to the arc-phase enum (helmet).
 
 Magnetism needs no new primitive; it is a stat effect on the existing `ball_magnetism` pull, retargeted to the player.

--- a/designs/01-prototype/tech/05a-starter-item-effects.md
+++ b/designs/01-prototype/tech/05a-starter-item-effects.md
@@ -1,0 +1,59 @@
+# Starter Item Effect Blocks
+
+Tech spike for the starter items (SH-436): each effect as trigger, condition, outcome, plus the primitives the effect system would need. Numbers are tuning, left open. Cadence is already specced among the prototype effect blocks.
+
+## Split (ball)
+
+```
+Effect 1
+  trigger: on_tier_completed(tier)
+  outcome: split_ball(count = tier + 1)
+Effect 2
+  trigger: on_balls_collide
+  outcome: merge_balls
+  outcome: soul_burst(scale_by tier)
+```
+
+Split count rises with the tier; merging is the player driving two balls together. Levels and cost/scaling: TBD.
+
+## Helmet (equipment)
+
+```
+grants: header (a head contact, distinct from the racquet)
+Effect 1
+  trigger: on_header_at_apex
+  outcome: soul_burst
+```
+
+Levels (burst size) and cost/scaling: TBD.
+
+## Friendship bracelet (equipment)
+
+```
+Effect 1
+  trigger: on_hit
+  outcome: spawn_soul_motes(n)
+Effect 2
+  trigger: on_mote_gathered
+  outcome: add_soul
+```
+
+Motes drift to the player and auto-gather; routing the ball through them gathers more. Levels (motes per hit) and cost/scaling: TBD.
+
+## Magnetism (equipment)
+
+```
+Effect 1
+  trigger: always
+  outcome: attract_balls_to_characters(strength)
+```
+
+A passive pull of every ball toward the player and partner. Levels (strength) and cost/scaling: TBD.
+
+## New primitives the effect system needs
+
+- `header` contact and an `on_header_at_apex` trigger (helmet).
+- `split_ball`, an `on_balls_collide` trigger, `merge_balls` (split).
+- `spawn_soul_motes` plus mote entities and an `on_mote_gathered` trigger (bracelet).
+- `attract_balls_to_characters`, a passive force (magnetism).
+- `soul_burst` outcome (shared).


### PR DESCRIPTION
Adds `designs/01-prototype/design/starter-items.md` capturing the Act I starter-item-set design: the role of the set (Zach's Act I stall, drawn from the four childhood friends), research-grounded design principles, the consolidation-beat loop it teaches, the build groups it pulls from with reasons for the cut Ceiling group and each exclusion, the five items (four simple functional items plus the Cadence pick), and the three interest-without-complexity levers. Per-item cards are stubbed as TODO. Serves SH-436; work continuing, so this stays a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)