### PR TITLE
Add levitation progression design note

### DIFF
--- a/designs/01-prototype/INDEX.md
+++ b/designs/01-prototype/INDEX.md
@@ -40,3 +40,4 @@ The public demo on itch.io. Core loop, first-pass assets, playable by strangers.
 | 20 | [Ball Speed Tiers and Physics Ceiling](20-ball-speed-tiers.md) |
 | 20a | [Ball Speed Tier Progression](20a-ball-speed-tier-progression.md) |
 | 21 | [Ball Lifecycle](tech/02-ball-lifecycle.md) |
+| 22 | [Levitation Progression](design/levitation-progression.md) |

--- a/designs/01-prototype/design/levitation-progression.md
+++ b/designs/01-prototype/design/levitation-progression.md
@@ -1,26 +1,14 @@
 # Levitation Progression
 
-Levitation is the protagonist's soul-control: a trained, cumulative track. Not a kit item, not bought. Deepens across the whole game.
-
----
-
 ## Banking
 
-- Increases by time aloft. Sustained levitation during a rally banks soul-control.
-- Cumulative. The ball's per-hit speed resets each rally; soul-control only climbs.
-
-## Thresholds
-
-- Threshold-gated. Crossing a threshold advances soul-control.
-- Same shape as the ball consolidating at a tier ceiling, and as qualifying for a round match through the class volley record.
-- Advancing raises the soul-bound: the player commands more vertical court, and the arc rises with them.
+- Increases by time aloft. Sustained levitation during a rally increases the max levitation height.
+- Cumulative.
 
 ## Ladder
 
-- Grows up the milestone ladder, local community to world.
-- Ceiling is Act III's travel between construct and reality at will.
+- A specific minimum height is required for each level, local to world.
 
 ## Tuning
 
-- Per-second rate: open.
-- Thresholds: open.
+- Per-second rate

--- a/designs/01-prototype/design/levitation-progression.md
+++ b/designs/01-prototype/design/levitation-progression.md
@@ -1,0 +1,26 @@
+# Levitation Progression
+
+Levitation is the protagonist's soul-control: a trained, cumulative track. Not a kit item, not bought. Deepens across the whole game.
+
+---
+
+## Banking
+
+- Increases by time aloft. Sustained levitation during a rally banks soul-control.
+- Cumulative. The ball's per-hit speed resets each rally; soul-control only climbs.
+
+## Thresholds
+
+- Threshold-gated. Crossing a threshold advances soul-control.
+- Same shape as the ball consolidating at a tier ceiling, and as qualifying for a round match through the class volley record.
+- Advancing raises the soul-bound: the player commands more vertical court, and the arc rises with them.
+
+## Ladder
+
+- Grows up the milestone ladder, local community to world.
+- Ceiling is Act III's travel between construct and reality at will.
+
+## Tuning
+
+- Per-second rate: open.
+- Thresholds: open.


### PR DESCRIPTION
Documents levitation as the protagonist's trained, cumulative soul-control track: banks by time aloft, advances on threshold crossings, raises the soul-bound so the player commands more vertical court, and climbs the milestone ladder toward Act III's travel between construct and reality at will. Adds a row to the prototype INDEX; numbers left as tuning.