### PR TITLE
chore: widen debrief skill triggers to close-the-mission and pulse

### DIFF
--- a/ai/skills/gru/debrief.md
+++ b/ai/skills/gru/debrief.md
@@ -1,6 +1,6 @@
 ---
 name: debrief
-description: Scrum-style process retrospective on a mission, swarm, ride, or session. Looks back at blockers, improvements, and the action items that come out of those. NOT a report on what shipped. Read on "debrief", "mission complete", "retro", "wrap-up", "done with X".
+description: Scrum-style process retrospective on a mission, swarm, ride, or session. Looks back at blockers, improvements, and the action items that come out of those. NOT a report on what shipped. Read on "debrief", "mission complete", "mission close", "close the mission", "pulse", "retro", "wrap-up", "done with X".
 ---
 
 # Debrief
@@ -29,4 +29,4 @@ The shape is scrum-style. Open with blockers, name the improvements they earn, r
 
 ## Triggers
 
-Read this skill when the user prompt or task notification names any of: `debrief`, `mission complete`, `mission close`, `wrap up`, `retro`, `done with X`. The UserPromptSubmit hook at `~/.claude/hooks/debrief-flow-signal.sh` injects a reminder when the trigger phrase appears.
+Read this skill when the user prompt or task notification names any of: `debrief`, `mission complete`, `mission close`, `close the mission`, `pulse`, `wrap up`, `retro`, `done with X`. The UserPromptSubmit hook at `~/.claude/hooks/debrief-flow-signal.sh` injects a reminder when the trigger phrase appears.


### PR DESCRIPTION
The debrief-flow hook matched "mission close" but not "close the mission", so a mission-close phrasing fell through to an inline summary instead of the six-step debrief flow. The hook regex is already widened (it is a user-global file); this lands the matching change to the skill's own trigger list so the two stay in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)