### PR TITLE
docs: realise the starter item set

### DIFF
--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -13,6 +13,7 @@ Not merging is a missed bonus, no penalty.
 ## Helmet (name TODO)
 
 Role: equipment : head
+A pink cycling helmet, Steph's; it doesn't fit.
 Lets you header the ball, a new contact distinct from the racquet hit; a header struck at the apex of the arc bursts soul.
 
 ## Friendship bracelet

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -5,6 +5,7 @@ The player starts with the initial ball and racquet; these items add to that, ne
 ## Ball: split-and-merge (name TODO)
 
 Role: ball
+A ball of goop Zach found under the floorboards.
 At consolidation it splits, and each consolidation after adds one more ball (2 at the first, +1 per consolidation after).
 Collide them to merge for a soul burst. 
 Not merging is a missed bonus, no penalty.

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -26,6 +26,7 @@ Each hit sheds a soul bead off the ball; beads drift and can be collected via th
 ## Magnetism (name TODO)
 
 Role: equipment
+A comeback ball from an old toybox.
 Balls are drawn toward the player, curving toward where you reach.
 
 ## Cadence (pick)

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -18,7 +18,7 @@ Lets you header the ball, a new contact distinct from the racquet hit; a header 
 
 Role: equipment : arm
 
-Worn on the wrist. 
+One of a twinned pair; Zach wears the other.
 Each hit sheds a soul bead off the ball; beads drift and can be collected via the ball. The beads never run out.
 
 ## Magnetism (name TODO)


### PR DESCRIPTION
The realisation pass on the starter item set (SH-438). Each item now carries an object and a meaning rather than a bare effect stub:

- the split-and-merge ball is a ball of goop Zach found under the floorboards
- the helmet is Steph's pink cycling helmet that doesn't fit
- the friendship bracelet is one of a twinned pair, the protagonist's and Zach's
- the magnetism item is a comeback ball from an old toybox

Cadence was already realised in SH-436. Following the terser starter-items register, the cards stay object plus effect, with no Default/Power-revealed/Post-Break table.

Names are left deferred by design. The three upgrade levels per item are deferred to SH-439 as gameplay work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)