### PR TITLE
docs: retire the voice label

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -1,6 +1,6 @@
 ---
 name: User Story
-about: Player-facing capability (use for feature, draft when player-facing, voice, etc.)
+about: Player-facing capability (use for feature, draft when player-facing, etc.)
 ---
 
 <!-- Guide: designs/process/ticket-writing.md -->

--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -9,7 +9,7 @@ Every ticket carries one intent label that names its discipline and its tier. La
 | **tech**     | `spike`       | `feature` | (`bug` restores) |
 | **art**      | `study`       | `asset`   | `revision` |
 | **music**    | `concept`     | `cue`     | `rework`   |
-| **writing**  | `voice`       | `draft`   | `rewrite`  |
+| **writing**  | -             | `draft`   | `rewrite`  |
 | **design**   | `discovery`   | -         | `tune`     |
 | **audio**    | -             | `sfx`     | -          |
 
@@ -39,7 +39,6 @@ Three intents plus `bug` as its own shape. Pick the label whose discipline and t
 
 ### Writing
 
-- **`voice`**: explore the voice and tone before committing to written content. Output: a bible entry a draft can cite.
 - **`draft`**: produce new written content ready for integration.
 - **`rewrite`**: evolve existing written content as the creative direction develops.
 
@@ -58,7 +57,7 @@ Three intents plus `bug` as its own shape. Pick the label whose discipline and t
 
 1. **Which discipline owns the work?** Tech, art, music, writing, design, audio.
 2. **Which tier?**
-   - **Explore** if the answer is not yet known. Spike, study, concept, voice, discovery.
+   - **Explore** if the answer is not yet known. Spike, study, concept, discovery.
    - **Produce** if the output is a concrete deliverable. Feature, asset, cue, draft, sfx.
    - **Evolve** if iterating on something that already exists. Revision, rework, rewrite, tune.
    - **Bug** if the system has drifted from intended behaviour.

--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -14,7 +14,7 @@ The one-page cheat sheet for filing tickets lives in `CLAUDE.md` under "Linear T
 
 If you have landed here as a contributor, welcome. This section covers how to read a ticket so you can dive in with confidence. The practical side, picking up a ticket, running the project, submitting a PR, lives in [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
-**Ticket shape.** Every ticket carries a label from the [intent taxonomy](labels.md): `feature`, `spike`, `bug`, `study`, `asset`, `revision`, `concept`, `cue`, `rework`, `voice`, `draft`, `rewrite`, `discovery`, `tune`, or `sfx`. The label tells you what kind of output is expected and which discipline the work belongs to. The body tells you what done looks like. If the label and the body disagree, ask in the thread; the body usually wins.
+**Ticket shape.** Every ticket carries a label from the [intent taxonomy](labels.md): `feature`, `spike`, `bug`, `study`, `asset`, `revision`, `concept`, `cue`, `rework`, `draft`, `rewrite`, `discovery`, `tune`, or `sfx`. The label tells you what kind of output is expected and which discipline the work belongs to. The body tells you what done looks like. If the label and the body disagree, ask in the thread; the body usually wins.
 
 **Acceptance criteria are the contract.** If the AC is met, the ticket is done. If any of it is unclear, ask in the ticket thread before opening a PR; we would rather answer a question than ask for a rework.
 
@@ -53,7 +53,7 @@ Our label taxonomy follows a pattern across most disciplines:
 | tech      | spike                 | feature                 | (bug restores)        |
 | art       | study                 | asset                   | revision              |
 | music     | concept               | cue                     | rework                |
-| writing   | voice                 | draft                   | rewrite               |
+| writing   | -                     | draft                   | rewrite               |
 | design    | discovery             | -                       | tune                  |
 | sfx       | -                     | sfx                     | -                     |
 
@@ -61,11 +61,11 @@ Three intents, plus `bug` as its own shape.
 
 ### Explore
 
-The question comes first, the output second. An explore ticket answers a question: can we, how would we, what would this feel like. The artifact (a spike writeup, a concept sketch, a voice sample, a discovery prototype) is evidence of the answer, not the point.
+The question comes first, the output second. An explore ticket answers a question: can we, how would we, what would this feel like. The artifact (a spike writeup, a concept sketch, a discovery prototype) is evidence of the answer, not the point.
 
 "Done" means the question is answered and a decision is documented. Coverage matters more than polish. A discovery prototype that kills three options and points at a fourth is a win.
 
-Timebox the work. Kent Beck's original spike, in *Extreme Programming Explained* (1999), is time-bounded investigation producing knowledge, not shippable code. Same applies to studies, concepts, voice explorations.
+Timebox the work. Kent Beck's original spike, in *Extreme Programming Explained* (1999), is time-bounded investigation producing knowledge, not shippable code. Same applies to studies and concepts.
 
 ### Produce
 
@@ -129,11 +129,9 @@ Winifred Phillips (*A Composer's Guide to Game Music*, MIT Press, 2014) gives th
 
 ### Writing
 
-Labels: `voice`, `draft`, `rewrite`.
+Labels: `draft`, `rewrite`.
 
-Hannah Nicklin (*Writing for Games*, 2022) frames voice work as bible entries distinct from content, which matches our three-tier split. Emily Short's blog and Steve Ince (*Writing for Video Games*, 2006) are the other primary references.
-
-**Voice** (explore). A bible entry for a character or register: vocabulary, rhythm, taboos, sample lines. "Done" is an approved entry the draft work can cite. No scene content lives here.
+Hannah Nicklin (*Writing for Games*, 2022), Emily Short's blog, and Steve Ince (*Writing for Video Games*, 2006) are the primary references for writing tickets.
 
 **Draft** (produce). A scene, barks, UI copy, a codex entry. Carries scene goal, required information beats (what must the player know after this), word or line budget, branch count, barks needed. Ince's 2006 clause, "what must the player know after this scene", is the most useful AC anchor.
 
@@ -165,7 +163,7 @@ There is no `explore` or `evolve` label for sfx at Shuck. Exploration folds into
 
 ## Templates
 
-### User Story (player-facing feature, voice or draft when content is player-facing)
+### User Story (player-facing feature, draft when content is player-facing)
 
 ```
 As a [role]


### PR DESCRIPTION
The `voice` label (writing-discipline explore tier, "explore the voice and tone before committing") is deleted in both Linear and GitHub. This removes it from where it was documented: the label taxonomy in `labels.md`, both taxonomy tables and the Writing section in `ticket-writing.md`, and the user-story issue template.

Writing keeps `draft` and `rewrite`; its explore cell is now empty. The Nicklin, Short, and Ince citations stay as writing references, without the now-defunct three-tier framing. The audio "voice-stealing" term is unrelated and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)