### PR TITLE
fix: stop wiki sync doubling the .md extension

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -112,7 +112,7 @@ jobs:
               flat="$(title_case "${dir//\//-}").md"
             else
               flat_stem="$(title_case "${rel//\//-}")"
-              flat="${flat_stem%.Md}.md"
+              flat="${flat_stem%.md}.md"
             fi
             [ "$dir" = "." ] && dir=""
             copy_with_rewrite "$src" "wiki/$flat" "$dir"


### PR DESCRIPTION
The design-to-wiki sync named every non-INDEX page with a doubled extension, `X.md.md`, so the publisher created pages like `North-Star.md` and the rewritten links, which drop the `.md`, 404'd on the wiki. INDEX-derived pages were fine, which is why folder links worked and file links did not.

The cause was one character: the non-INDEX filename stripped the extension with `%.Md`, but `title_case.py` leaves the extension lowercase, so the strip matched nothing and `.md` was appended on top of the existing one. Using `%.md` strips the real extension before re-adding it.

The existing `*.md.md` pages will linger as orphans in the wiki repo until a one-time cleanup removes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)