### PR TITLE
Add reviewer fan-out path-map (#371)

### DIFF
--- a/ai/skills/minions/path-map.json
+++ b/ai/skills/minions/path-map.json
@@ -1,5 +1,5 @@
 {
-  "_source": "Mirrors the reviewer scope table in ai/skills/minions/reviewers.md. Both must stay in sync; that doc is the human-readable canon, this file is the machine-readable copy the reviewer fan-out guard reads (SH-229).",
+  "_source": "Mirrors the reviewer scope table in ai/skills/minions/reviewers.md. Both must stay in sync; that doc is the human-readable canon, this file is the machine-readable copy the reviewer fan-out guard reads (#371).",
   "_check_run_naming": "Each reviewer posts a check_run named '<reviewer> reviewer', e.g. 'code-quality reviewer'. The fan-out guard resolves the expected reviewer set from path_rules below, then asserts each expected check_run is present and green on the head SHA.",
   "path_rules": [
     { "glob": "scripts/**/*.gd", "reviewers": ["code-quality", "gdscript-conventions"] },

--- a/ai/skills/minions/path-map.json
+++ b/ai/skills/minions/path-map.json
@@ -1,5 +1,5 @@
 {
-  "_source": "Mirrors the 'Your scope' table in ai/skills/minions/reviewers.md. Both must stay in sync; that doc is the human-readable canon, this file is the machine-readable copy the reviewer fan-out guard reads (SH-229).",
+  "_source": "Mirrors the reviewer scope table in ai/skills/minions/reviewers.md. Both must stay in sync; that doc is the human-readable canon, this file is the machine-readable copy the reviewer fan-out guard reads (SH-229).",
   "_check_run_naming": "Each reviewer posts a check_run named '<reviewer> reviewer', e.g. 'code-quality reviewer'. The fan-out guard resolves the expected reviewer set from path_rules below, then asserts each expected check_run is present and green on the head SHA.",
   "path_rules": [
     { "glob": "scripts/**/*.gd", "reviewers": ["code-quality", "gdscript-conventions"] },

--- a/ai/skills/minions/path-map.json
+++ b/ai/skills/minions/path-map.json
@@ -1,0 +1,28 @@
+{
+  "_source": "Mirrors the 'Your scope' table in ai/skills/minions/reviewers.md. Both must stay in sync; that doc is the human-readable canon, this file is the machine-readable copy the reviewer fan-out guard reads (SH-229).",
+  "_check_run_naming": "Each reviewer posts a check_run named '<reviewer> reviewer', e.g. 'code-quality reviewer'. The fan-out guard resolves the expected reviewer set from path_rules below, then asserts each expected check_run is present and green on the head SHA.",
+  "path_rules": [
+    { "glob": "scripts/**/*.gd", "reviewers": ["code-quality", "gdscript-conventions"] },
+    { "glob": "scripts/progression/**", "reviewers": ["save-format-warden"] },
+    { "glob": "tests/**/*.gd", "reviewers": ["test-coverage"] },
+    { "glob": "**/*.tscn", "reviewers": ["godot-scene"] },
+    { "glob": "**/*.tres", "reviewers": ["godot-scene"] },
+    { "glob": "project.godot", "reviewers": ["asset-pipeline"] },
+    { "glob": "**/*.import", "reviewers": ["asset-pipeline"] },
+    { "glob": "export_presets.cfg", "reviewers": ["asset-pipeline"] },
+    { "glob": ".github/**", "reviewers": ["ci-and-workflows"] },
+    { "glob": "**/*.md", "reviewers": ["docs-and-writing"] }
+  ],
+  "content_triggered": [
+    {
+      "reviewer": "signals-lifecycle",
+      "applies_when": "diff adds or changes signal wiring or tree lifecycle: connect(, emit(, tree_exit, or a new autoload",
+      "path_resolvable": false
+    },
+    {
+      "reviewer": "save-format-warden",
+      "applies_when": "diff touches a save-persistent resource beyond scripts/progression/**",
+      "path_resolvable": false
+    }
+  ]
+}


### PR DESCRIPTION
First slice of #371. Adds `ai/skills/minions/path-map.json`, a machine-readable mirror of the reviewer scope table in `ai/skills/minions/reviewers.md`.

The forthcoming reviewer fan-out guard workflow reads this file to resolve which reviewers a PR's changed files require, then asserts each expected reviewer check_run is present and green on the head SHA. This PR lands the data only; nothing consumes it yet, so it changes no behaviour and touches no gate.

Two reviewers (signals-lifecycle, save-format-warden) are content-triggered rather than path-resolvable; they are recorded in a separate section and flagged `path_resolvable: false`.

Part of #371 (GitHub App identity already created and verified; aggregator workflow and branch-protection changes follow in later PRs).