### PR TITLE
Add bot synthesis review poster workflow (#371)

### DIFF
--- a/.github/bot-identity.md
+++ b/.github/bot-identity.md
@@ -1,0 +1,22 @@
+# Bot identity: shuck-volley-bot
+
+The swarm's automated actions on this repo run under a GitHub App, `shuck-volley-bot[bot]`, so agent-driven reviews are attributed to a distinct identity in the Reviews tab rather than appearing as the maintainer's own actions.
+
+## Account
+
+- **Type:** GitHub App, owned by the `shuck-dev` org.
+- **App ID:** stored in the `BOT_APP_ID` repo secret.
+- **Private key:** stored in the `BOT_APP_PRIVATE_KEY` repo secret. No local copy is kept; tokens are minted inside workflows.
+- **Installation:** installed on `shuck-dev`, scoped to this repo only.
+
+## Scope
+
+Repository permissions: Pull requests (read/write), Checks (read/write), Contents (read), Metadata (read). No organisation or account permissions. The App cannot be added as a requested reviewer (GitHub Apps are not requestable); it posts reviews via the API.
+
+## Token handling
+
+Workflows mint a short-lived installation token (five minutes) from the App ID and private key at run time, scoped to this repo. The token is never persisted. The bot cannot approve a PR it authored, so it is the reviewer identity, not the PR author.
+
+## Rotation
+
+To rotate the private key: generate a new key in the App settings (Organization settings, Developer settings, GitHub Apps, shuck-volley-bot, Private keys), update the `BOT_APP_PRIVATE_KEY` secret, then revoke the old key. The App ID does not change.

--- a/.github/workflows/bot-review.yml
+++ b/.github/workflows/bot-review.yml
@@ -1,0 +1,83 @@
+name: Bot Synthesis Review
+
+# Posts a single synthesis review on a PR under the shuck-volley-bot[bot]
+# identity. The organiser (main Claude session) resolves reviewer consensus
+# from the dispatched reviewers' reports, then triggers this workflow with the
+# resolved verdict. CI never runs Claude on PR events (prompt-injection
+# surface), so this is a mechanical poster fired by deliberate workflow_dispatch
+# only, never by a pull_request trigger.
+#
+# The App private key stays in repo secrets; it is never minted locally. The
+# installation token is short-lived (five minutes) and scoped to this repo.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to review
+        required: true
+        type: string
+      event:
+        description: Review verdict
+        required: true
+        type: choice
+        options:
+          - APPROVE
+          - REQUEST_CHANGES
+          - COMMENT
+      body:
+        description: Synthesis summary (review body)
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bot-review-${{ inputs.pr }}
+  cancel-in-progress: false
+
+jobs:
+  post-review:
+    name: Post synthesis review as the bot
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Mint installation token and post review
+        env:
+          APP_ID: ${{ secrets.BOT_APP_ID }}
+          APP_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          PR: ${{ inputs.pr }}
+          EVENT: ${{ inputs.event }}
+          BODY: ${{ inputs.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+          keyfile="$(mktemp)"
+          trap 'rm -f "$keyfile"' EXIT
+          printf '%s' "$APP_KEY" > "$keyfile"
+
+          header="$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)"
+          now="$(date +%s)"
+          payload="$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((now - 10))" "$((now + 300))" "$APP_ID" | b64url)"
+          sig="$(printf '%s.%s' "$header" "$payload" | openssl dgst -sha256 -sign "$keyfile" -binary | b64url)"
+          jwt="$header.$payload.$sig"
+
+          iid="$(curl -sf -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/installation" | jq -r '.id')"
+          tok="$(curl -sf -X POST -H "Authorization: Bearer $jwt" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/$iid/access_tokens" | jq -r '.token')"
+
+          headsha="$(curl -sf -H "Authorization: token $tok" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/pulls/$PR" | jq -r '.head.sha')"
+
+          jq -n --arg sha "$headsha" --arg ev "$EVENT" --arg body "$BODY" \
+            '{commit_id: $sha, event: $ev, body: $body}' \
+            | curl -sf -X POST -H "Authorization: token $tok" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/pulls/$PR/reviews" --data @- > /dev/null
+
+          echo "Posted $EVENT review on PR #$PR as shuck-volley-bot[bot] (head $headsha)."


### PR DESCRIPTION
First implementation slice of #371, all additive, touches no existing gate.

Adds `.github/workflows/bot-review.yml`, a `workflow_dispatch`-only workflow that posts one synthesis review on a PR under the `shuck-volley-bot[bot]` identity. The organiser resolves reviewer consensus in-session from the dispatched reviewers' reports, then triggers the workflow with the resolved verdict (`gh workflow run bot-review.yml -f pr=N -f event=APPROVE`). The workflow mints a short-lived installation token from the `BOT_APP_ID` / `BOT_APP_PRIVATE_KEY` secrets and posts the review via the API.

It runs no Claude and has no `pull_request` trigger, so it is not a prompt-injection surface; it fires only on deliberate dispatch. The App private key never leaves repo secrets.

Also adds `.github/bot-identity.md` naming the account, scope, token handling, and rotation.

The zaphod-label retirement and the gate rewire (moving the block signal off `zaphod-blocked` onto the bot review) are deliberately not in this PR; they touch the live merge gate and land as later, separately-reviewed changes.