### PR TITLE
Guard Linear IDs in commits and branch names (#771)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,6 +15,11 @@ commit-msg:
     check-format:
       run: ./scripts/ci/check_commit_msg.sh {1}
 
+pre-push:
+  commands:
+    branch-name:
+      run: ./scripts/ci/check_branch_name.sh
+
 pre-commit:
   piped: true
   commands:

--- a/scripts/ci/check_branch_name.sh
+++ b/scripts/ci/check_branch_name.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Reject branch names that carry a Linear-style ID instead of the GitHub issue
+# number. The repo convention is feature/<gh-number>-<slug>; Linear's
+# gitBranchName field emits feature/sh-N-..., which must be overridden. A bare
+# gh- prefix is also wrong (the number alone, no prefix).
+#
+# Reads the branch from $1 if given, otherwise the current HEAD. Used as a
+# lefthook pre-push command.
+set -euo pipefail
+
+branch="${1:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")}"
+[ -z "$branch" ] && exit 0
+[ "$branch" = "HEAD" ] && exit 0
+
+case "$branch" in
+  feature/[Ss][Hh]-[0-9]*|feature/[Gg][Hh]-[0-9]*)
+    echo >&2
+    echo "branch-name: rejected '$branch'" >&2
+    echo "  Use the GitHub issue number, not the Linear ID and not a gh- prefix:" >&2
+    echo "    feature/<gh-number>-<slug>   e.g. feature/371-bot-synthesis-review" >&2
+    echo "  Linear's gitBranchName emits feature/sh-N-...; override it." >&2
+    echo >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/scripts/ci/check_commit_msg.sh
+++ b/scripts/ci/check_commit_msg.sh
@@ -65,6 +65,14 @@ if [[ "$subject" =~ $codename_anywhere_re ]]; then
   errors+=("subject contains a [Codename] tag; move it to an 'Agent-Role:' trailer")
 fi
 
+# No Linear ticket ID (SH-N) anywhere in the message, subject or body. The open
+# repo audience follows the GitHub issue number (#N); a Linear ID is private.
+# The boundary excludes a preceding alphanumeric so UTF-8, SHA-256, SSH-1, and
+# words like "wish-3" do not trip it.
+if printf '%s' "$msg_body" | grep -qiE '(^|[^a-z0-9])sh-[0-9]+'; then
+  errors+=("message references a Linear ID (SH-N); use the GitHub issue number (#N) instead")
+fi
+
 if (( ${#errors[@]} > 0 )); then
   echo >&2
   echo "commit-msg: rejected by Volley commit-format rule" >&2


### PR DESCRIPTION
Closes #771. Mechanical enforcement of the GitHub-number-over-Linear-ID convention, beyond the memory rule and the existing prefix-only commit check.

- `scripts/ci/check_commit_msg.sh`: now rejects a Linear ID anywhere in the message, not just at the subject start. The pattern is boundary-anchored to the `sh-<digits>` shape, so `UTF-8`, `SHA-256`, `SSH-1`, and words like `wish-3` do not trip it.
- `scripts/ci/check_branch_name.sh` (new) + a lefthook `pre-push` command: rejects `feature/sh-N` (Linear's `gitBranchName` shape) and `feature/gh-N`, steering to `feature/<gh-number>-<slug>`.

This is the gate that would have caught the three places a Linear ID leaked in recently (a mid-subject commit ref, a body ref, and a `feature/sh-` branch).

Note: `lefthook.yml` sets `no_auto_install: true`, so `lefthook install` must be run once for the new `pre-push` hook to register locally. The commit-msg change is live on the next commit.