### PR TITLE
Retry actionlint download, skip on flake (#729)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -124,11 +124,23 @@ jobs:
         if: steps.cache-actionlint.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/.local/bin
-          curl -sSfL https://github.com/rhysd/actionlint/releases/download/v${{ env.ACTIONLINT_VERSION }}/actionlint_${{ env.ACTIONLINT_VERSION }}_linux_amd64.tar.gz \
-            | tar -xz -C ~/.local/bin actionlint
+          url="https://github.com/rhysd/actionlint/releases/download/v${{ env.ACTIONLINT_VERSION }}/actionlint_${{ env.ACTIONLINT_VERSION }}_linux_amd64.tar.gz"
+          for attempt in 1 2 3; do
+            if curl -sSfL "$url" | tar -xz -C ~/.local/bin actionlint; then
+              exit 0
+            fi
+            echo "actionlint download attempt $attempt failed; retrying" >&2
+            sleep "$((attempt * 3))"
+          done
+          echo "::warning::actionlint download failed after 3 attempts; skipping actionlint this run"
 
       - name: actionlint
-        run: ~/.local/bin/actionlint -color
+        run: |
+          if [ -x ~/.local/bin/actionlint ]; then
+            ~/.local/bin/actionlint -color
+          else
+            echo "::warning::actionlint binary unavailable (download flake); skipping"
+          fi
 
   lint:
     name: Lint


### PR DESCRIPTION
Closes #729. A transient 502 from the actionlint release CDN no longer hard-fails the `Lint` gate.

The actionlint install step now retries the download three times (3/6/9s backoff). If it genuinely cannot fetch, it warns and exits 0; the `actionlint` step then checks for the binary and skips with a warning rather than erroring. Real actionlint findings still fail (the binary runs and its exit code propagates), and the warm-cache path is untouched (a cache hit skips the install entirely).

Verified the retry-then-skip and binary-guard logic in isolation; YAML parses.