### PR TITLE
fix: AI ball-tracking and venue side-bound collision

### DIFF
--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -72,12 +72,14 @@ shape = SubResource("RectangleShape2D_s1xkn")
 
 [node name="VenueLeftBound" type="StaticBody2D" parent="." unique_id=1925147373]
 position = Vector2(-1700, 0)
+collision_layer = 4
 
 [node name="VenueLeftBoundShape" type="CollisionShape2D" parent="VenueLeftBound" unique_id=324592534]
 shape = SubResource("RectangleShape2D_j16ra")
 
 [node name="VenueRightBound" type="StaticBody2D" parent="." unique_id=1541086575]
 position = Vector2(1920, 0)
+collision_layer = 4
 
 [node name="VenueRightBoundShape" type="CollisionShape2D" parent="VenueRightBound" unique_id=1823696433]
 shape = SubResource("RectangleShape2D_j16ra")

--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://dumhl1skwhd7q" path="res://scenes/dev_hud.tscn" id="4_hud"]
 [ext_resource type="Script" uid="uid://s5unp15ypwlr" path="res://scripts/core/venue_camera.gd" id="5_wttuf"]
 [ext_resource type="PackedScene" uid="uid://dnx2do12mtfyp" path="res://scenes/workshop.tscn" id="6_s1xkn"]
+[ext_resource type="Script" uid="uid://dqv0f22hkxsa2" path="res://scripts/core/venue_bound_debug_draw.gd" id="7_bound"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_floor"]
 size = Vector2(4000, 40)
@@ -35,8 +36,8 @@ dev_item_panel = NodePath("DevHUD/DevItemUI")
 
 [node name="Camera" type="Camera2D" parent="." unique_id=1084046387 node_paths=PackedStringArray("left_anchor", "right_anchor")]
 script = ExtResource("5_wttuf")
-left_anchor = NodePath("../LeftEdge")
-right_anchor = NodePath("../RightEdge")
+left_anchor = NodePath("../VenueLeftBound")
+right_anchor = NodePath("../VenueRightBound")
 
 [node name="VenueFloor" type="StaticBody2D" parent="." unique_id=984529763]
 position = Vector2(0, 410)
@@ -58,28 +59,26 @@ position = Vector2(720, 3.13)
 [node name="Workshop" parent="." unique_id=1830461434 instance=ExtResource("6_s1xkn")]
 position = Vector2(-1500, 0)
 
-[node name="LeftEdge" type="Marker2D" parent="." unique_id=679568217]
-position = Vector2(-1700, 0)
-
-[node name="RightEdge" type="Marker2D" parent="." unique_id=858790739]
-position = Vector2(1920, 0)
-
 [node name="VenueCeiling" type="StaticBody2D" parent="." unique_id=1902326706]
 position = Vector2(0, -1500)
 
 [node name="VenueCeilingShape" type="CollisionShape2D" parent="VenueCeiling" unique_id=1648054464]
 shape = SubResource("RectangleShape2D_s1xkn")
 
-[node name="VenueLeftBound" type="StaticBody2D" parent="." unique_id=1925147373]
+[node name="VenueLeftBound" type="StaticBody2D" parent="." unique_id=1925147373 node_paths=PackedStringArray("collision_shape")]
 position = Vector2(-1700, 0)
 collision_layer = 4
+script = ExtResource("7_bound")
+collision_shape = NodePath("VenueLeftBoundShape")
 
 [node name="VenueLeftBoundShape" type="CollisionShape2D" parent="VenueLeftBound" unique_id=324592534]
 shape = SubResource("RectangleShape2D_j16ra")
 
-[node name="VenueRightBound" type="StaticBody2D" parent="." unique_id=1541086575]
+[node name="VenueRightBound" type="StaticBody2D" parent="." unique_id=1541086575 node_paths=PackedStringArray("collision_shape")]
 position = Vector2(1920, 0)
 collision_layer = 4
+script = ExtResource("7_bound")
+collision_shape = NodePath("VenueRightBoundShape")
 
 [node name="VenueRightBoundShape" type="CollisionShape2D" parent="VenueRightBound" unique_id=1823696433]
 shape = SubResource("RectangleShape2D_j16ra")

--- a/scripts/core/autoplay_controller.gd
+++ b/scripts/core/autoplay_controller.gd
@@ -32,8 +32,8 @@ func _on_timeout_started() -> void:
 	autoplay_toggled.emit(false)
 
 
-func _ball_approaching() -> bool:
-	return ball.linear_velocity.x < 0.0 and ball.position.x > paddle.position.x
+func _ball_approaches(target: RigidBody2D) -> bool:
+	return target.linear_velocity.x < 0.0 and target.position.x > paddle.position.x
 
 
 func _get_paddle_speed() -> float:

--- a/scripts/core/autoplay_controller.gd
+++ b/scripts/core/autoplay_controller.gd
@@ -32,7 +32,7 @@ func _on_timeout_started() -> void:
 	autoplay_toggled.emit(false)
 
 
-func _ball_approaches(target: RigidBody2D) -> bool:
+func _ball_approaches(target: Ball) -> bool:
 	return target.linear_velocity.x < 0.0 and target.position.x > paddle.position.x
 
 

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -4,7 +4,7 @@ extends Node
 @export var paddle: CharacterBody2D
 @export var config: PaddleAIConfig
 
-var ball: RigidBody2D
+var ball: Ball
 
 var _enabled := false
 var _tracker: BallTracker
@@ -78,7 +78,7 @@ func _physics_process(_delta: float) -> void:
 
 
 ## Soonest-to-arrive in-play approaching ball; signal-bound `ball` when none qualifies.
-func _select_tracked_ball() -> RigidBody2D:
+func _select_tracked_ball() -> Ball:
 	if _tracker == null:
 		return ball
 
@@ -101,7 +101,7 @@ func _select_tracked_ball() -> RigidBody2D:
 	return best if best != null else ball
 
 
-func _ball_in_play(target: RigidBody2D) -> bool:
+func _ball_in_play(target: Ball) -> bool:
 	var state: Ball.PlayState = target.play_state
 	return state == Ball.PlayState.PLAY_NORMAL or state == Ball.PlayState.PLAY_ARC
 
@@ -118,7 +118,7 @@ func is_enabled() -> bool:
 
 
 ## Override: whether the given ball's x-direction counts as "coming toward me."
-func _ball_approaches(_target: RigidBody2D) -> bool:
+func _ball_approaches(_target: Ball) -> bool:
 	assert(false, "PaddleAIController._ball_approaches() is abstract")
 	return false
 

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -88,10 +88,13 @@ func _select_tracked_ball() -> RigidBody2D:
 	for candidate in _tracker.get_balls():
 		if candidate == null or not _ball_in_play(candidate) or not _ball_approaches(candidate):
 			continue
+
 		var speed_x: float = absf(candidate.linear_velocity.x)
 		if speed_x < 1.0:
 			continue
+
 		var arrival: float = absf(paddle.position.x - candidate.position.x) / speed_x
+
 		if arrival < best_time:
 			best_time = arrival
 			best = candidate

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -61,7 +61,6 @@ func _physics_process(_delta: float) -> void:
 	if not _enabled:
 		return
 
-	# Cover the soonest-arriving approaching ball; fall back to the tracker ball when none qualifies.
 	ball = _select_tracked_ball()
 	if ball == null:
 		return
@@ -82,8 +81,10 @@ func _physics_process(_delta: float) -> void:
 func _select_tracked_ball() -> RigidBody2D:
 	if _tracker == null:
 		return ball
+
 	var best: Ball = null
 	var best_time: float = INF
+
 	for candidate in _tracker.get_balls():
 		if candidate == null or not _ball_in_play(candidate) or not _ball_approaches(candidate):
 			continue

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -36,55 +36,70 @@ func bind_tracker(tracker: BallTracker) -> void:
 			_tracker.ball_added.disconnect(_on_tracker_ball_added)
 		if _tracker.ball_removed.is_connected(_on_tracker_ball_removed):
 			_tracker.ball_removed.disconnect(_on_tracker_ball_removed)
-		if _tracker.current_ball_changed.is_connected(_on_tracker_current_ball_changed):
-			_tracker.current_ball_changed.disconnect(_on_tracker_current_ball_changed)
 	_tracker = tracker
 	if _tracker == null:
 		return
 	_tracker.ball_added.connect(_on_tracker_ball_added)
 	_tracker.ball_removed.connect(_on_tracker_ball_removed)
-	_tracker.current_ball_changed.connect(_on_tracker_current_ball_changed)
-
+	# Route already-tracked balls through the same handler so subclass overrides fire.
 	var existing: Ball = _tracker.get_current_ball()
-	ball = existing
-
-	# Route already-tracked balls through the handler so subclass enable-lifecycle fires.
 	if existing != null:
 		_on_tracker_ball_added(existing)
 
 
-## The live ball is whichever the tracker treats as current; a STORED ball never becomes current.
-func _on_tracker_current_ball_changed(new_current: Ball) -> void:
-	ball = new_current
+func _on_tracker_ball_added(new_ball: Ball) -> void:
+	ball = new_ball
 
 
-## Override hook for subclass enable-lifecycle; the live ball ref follows current_ball_changed.
-func _on_tracker_ball_added(_new_ball: Ball) -> void:
-	pass
-
-
+## Autoplay is a player intent toggle; transient ball-replacement (grab + drop) must not flip it off.
 func _on_tracker_ball_removed(_old_ball: Ball) -> void:
-	pass
+	var fallback: Ball = _tracker.get_current_ball() if _tracker != null else null
+	ball = fallback
 
 
 func _physics_process(_delta: float) -> void:
-	if not _enabled or ball == null:
+	if not _enabled:
+		return
+
+	# Multi-ball is live: cover the approaching ball that arrives soonest, falling
+	# back to the tracker-driven `ball` when none qualifies (single-ball parity).
+	ball = _select_tracked_ball()
+	if ball == null:
 		return
 
 	_maybe_resample_noise()
 
-	if not _ball_in_play():
+	if not _ball_in_play(ball):
 		_drift_to_center()
 		return
 
-	if _ball_approaching():
+	if _ball_approaches(ball):
 		_track()
 	else:
 		_drift_to_center()
 
 
-func _ball_in_play() -> bool:
-	var state: Ball.PlayState = ball.play_state
+## Soonest-to-arrive in-play approaching ball; signal-bound `ball` when none qualifies.
+func _select_tracked_ball() -> RigidBody2D:
+	if _tracker == null:
+		return ball
+	var best: Ball = null
+	var best_time: float = INF
+	for candidate in _tracker.get_balls():
+		if candidate == null or not _ball_in_play(candidate) or not _ball_approaches(candidate):
+			continue
+		var speed_x: float = absf(candidate.linear_velocity.x)
+		if speed_x < 1.0:
+			continue
+		var arrival: float = absf(paddle.position.x - candidate.position.x) / speed_x
+		if arrival < best_time:
+			best_time = arrival
+			best = candidate
+	return best if best != null else ball
+
+
+func _ball_in_play(target: RigidBody2D) -> bool:
+	var state: Ball.PlayState = target.play_state
 	return state == Ball.PlayState.PLAY_NORMAL or state == Ball.PlayState.PLAY_ARC
 
 
@@ -99,9 +114,9 @@ func is_enabled() -> bool:
 	return _enabled
 
 
-## Override: which ball x-direction counts as "coming toward me."
-func _ball_approaching() -> bool:
-	assert(false, "PaddleAIController._ball_approaching() is abstract")
+## Override: whether the given ball's x-direction counts as "coming toward me."
+func _ball_approaches(_target: RigidBody2D) -> bool:
+	assert(false, "PaddleAIController._ball_approaches() is abstract")
 	return false
 
 

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -61,8 +61,7 @@ func _physics_process(_delta: float) -> void:
 	if not _enabled:
 		return
 
-	# Multi-ball is live: cover the approaching ball that arrives soonest, falling
-	# back to the tracker-driven `ball` when none qualifies (single-ball parity).
+	# Cover the soonest-arriving approaching ball; fall back to the tracker ball when none qualifies.
 	ball = _select_tracked_ball()
 	if ball == null:
 		return

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -36,25 +36,35 @@ func bind_tracker(tracker: BallTracker) -> void:
 			_tracker.ball_added.disconnect(_on_tracker_ball_added)
 		if _tracker.ball_removed.is_connected(_on_tracker_ball_removed):
 			_tracker.ball_removed.disconnect(_on_tracker_ball_removed)
+		if _tracker.current_ball_changed.is_connected(_on_tracker_current_ball_changed):
+			_tracker.current_ball_changed.disconnect(_on_tracker_current_ball_changed)
 	_tracker = tracker
 	if _tracker == null:
 		return
 	_tracker.ball_added.connect(_on_tracker_ball_added)
 	_tracker.ball_removed.connect(_on_tracker_ball_removed)
-	# Route already-tracked balls through the same handler so subclass overrides fire.
+	_tracker.current_ball_changed.connect(_on_tracker_current_ball_changed)
+
 	var existing: Ball = _tracker.get_current_ball()
+	ball = existing
+
+	# Route already-tracked balls through the handler so subclass enable-lifecycle fires.
 	if existing != null:
 		_on_tracker_ball_added(existing)
 
 
-func _on_tracker_ball_added(new_ball: Ball) -> void:
-	ball = new_ball
+## The live ball is whichever the tracker treats as current; a STORED ball never becomes current.
+func _on_tracker_current_ball_changed(new_current: Ball) -> void:
+	ball = new_current
 
 
-## Autoplay is a player intent toggle; transient ball-replacement (grab + drop) must not flip it off.
+## Override hook for subclass enable-lifecycle; the live ball ref follows current_ball_changed.
+func _on_tracker_ball_added(_new_ball: Ball) -> void:
+	pass
+
+
 func _on_tracker_ball_removed(_old_ball: Ball) -> void:
-	var fallback: Ball = _tracker.get_current_ball() if _tracker != null else null
-	ball = fallback
+	pass
 
 
 func _physics_process(_delta: float) -> void:

--- a/scripts/core/partner_ai_controller.gd
+++ b/scripts/core/partner_ai_controller.gd
@@ -9,7 +9,7 @@ func _on_tracker_ball_added(new_ball: Ball) -> void:
 		set_enabled(true)
 
 
-func _ball_approaches(target: RigidBody2D) -> bool:
+func _ball_approaches(target: Ball) -> bool:
 	return target.linear_velocity.x > 0.0 and target.position.x < paddle.position.x
 
 

--- a/scripts/core/partner_ai_controller.gd
+++ b/scripts/core/partner_ai_controller.gd
@@ -9,8 +9,8 @@ func _on_tracker_ball_added(new_ball: Ball) -> void:
 		set_enabled(true)
 
 
-func _ball_approaching() -> bool:
-	return ball.linear_velocity.x > 0.0 and ball.position.x < paddle.position.x
+func _ball_approaches(target: RigidBody2D) -> bool:
+	return target.linear_velocity.x > 0.0 and target.position.x < paddle.position.x
 
 
 func _get_paddle_speed() -> float:

--- a/scripts/core/venue_bound_debug_draw.gd
+++ b/scripts/core/venue_bound_debug_draw.gd
@@ -1,0 +1,29 @@
+@tool
+class_name VenueBoundDebugDraw
+extends StaticBody2D
+
+## Editor-and-debug-only outline of a venue bound; never drawn in a release build.
+@export var debug_color: Color = Color(1.0, 0.2, 0.2, 0.5)
+@export var collision_shape: CollisionShape2D
+
+
+func _ready() -> void:
+	if not Engine.is_editor_hint() and not OS.is_debug_build():
+		return
+
+	queue_redraw()
+
+
+func _draw() -> void:
+	if not Engine.is_editor_hint() and not OS.is_debug_build():
+		return
+
+	if collision_shape == null:
+		return
+
+	var rectangle: RectangleShape2D = collision_shape.shape as RectangleShape2D
+	if rectangle == null:
+		return
+
+	var bounds := Rect2(collision_shape.position - rectangle.size * 0.5, rectangle.size)
+	draw_rect(bounds, debug_color)

--- a/scripts/core/venue_bound_debug_draw.gd.uid
+++ b/scripts/core/venue_bound_debug_draw.gd.uid
@@ -1,0 +1,1 @@
+uid://dqv0f22hkxsa2

--- a/tests/hooks/pre_run_hook.gd
+++ b/tests/hooks/pre_run_hook.gd
@@ -24,6 +24,8 @@ const EXCLUDE_PATHS = [
 	"res://scripts/items/effect/outcome.gd",
 	# Drawing-heavy @tool Control; _draw paths are untouched in headless tests
 	"res://scripts/court/speed_bar.gd",
+	# Editor/debug-only @tool draw of the venue bounds; _draw paths skip in headless
+	"res://scripts/core/venue_bound_debug_draw.gd",
 	# SH-297: pure enum + label container; only consumed via const access from callers.
 	"res://scripts/items/cursor_state.gd",
 ]

--- a/tests/unit/paddle/test_paddle_ai_tracker_binding.gd
+++ b/tests/unit/paddle/test_paddle_ai_tracker_binding.gd
@@ -131,3 +131,31 @@ func test_rebind_to_null_disconnects_prior_signals() -> void:
 	_tracker.attach(ball)
 
 	assert_null(_controller.ball, "after unbind, tracker emissions no longer reach controller")
+
+
+# Player autoplay shares the base class and the same tracker (court.gd binds it).
+# Under multi-ball it must lock onto the soonest-arriving ball it should cover,
+# not whichever the tracker happens to call current. Autoplay covers balls
+# moving left (vx < 0) that are still to its right (ball.x > paddle.x at x=0).
+func test_autoplay_selects_soonest_arriving_ball_under_multiball() -> void:
+	_paddle.position = Vector2(0.0, 0.0)
+	_controller.bind_tracker(_tracker)
+
+	var far_ball: Ball = _spawn_ball()
+	far_ball.position = Vector2(300.0, 0.0)
+	far_ball.linear_velocity = Vector2(-100.0, 0.0)
+	var near_ball: Ball = _spawn_ball()
+	near_ball.position = Vector2(50.0, 0.0)
+	near_ball.linear_velocity = Vector2(-200.0, 0.0)
+	# Attach near first, far last: the signal-bound `ball` ends up on far_ball,
+	# so selection must actively override it to prove it isn't a no-op.
+	_tracker.attach(near_ball)
+	_tracker.attach(far_ball)
+	_controller.set_enabled(true)
+	assert_eq(
+		_controller.ball, far_ball, "precondition: signal-bound ball is the last-attached far ball"
+	)
+
+	_controller._physics_process(0.016)
+
+	assert_eq(_controller.ball, near_ball, "autoplay covers the soonest-arriving approaching ball")

--- a/tests/unit/paddle/test_paddle_ai_tracker_binding.gd
+++ b/tests/unit/paddle/test_paddle_ai_tracker_binding.gd
@@ -133,10 +133,7 @@ func test_rebind_to_null_disconnects_prior_signals() -> void:
 	assert_null(_controller.ball, "after unbind, tracker emissions no longer reach controller")
 
 
-# Player autoplay shares the base class and the same tracker (court.gd binds it).
-# Under multi-ball it must lock onto the soonest-arriving ball it should cover,
-# not whichever the tracker happens to call current. Autoplay covers balls
-# moving left (vx < 0) that are still to its right (ball.x > paddle.x at x=0).
+# Autoplay under multi-ball locks onto the soonest-arriving ball it should cover, not the current one.
 func test_autoplay_selects_soonest_arriving_ball_under_multiball() -> void:
 	_paddle.position = Vector2(0.0, 0.0)
 	_controller.bind_tracker(_tracker)
@@ -147,8 +144,7 @@ func test_autoplay_selects_soonest_arriving_ball_under_multiball() -> void:
 	var near_ball: Ball = _spawn_ball()
 	near_ball.position = Vector2(50.0, 0.0)
 	near_ball.linear_velocity = Vector2(-200.0, 0.0)
-	# Attach near first, far last: the signal-bound `ball` ends up on far_ball,
-	# so selection must actively override it to prove it isn't a no-op.
+	# Attach far last so the signal-bound ball is far_ball; selection must override it.
 	_tracker.attach(near_ball)
 	_tracker.attach(far_ball)
 	_controller.set_enabled(true)

--- a/tests/unit/paddle/test_partner_ai_controller.gd
+++ b/tests/unit/paddle/test_partner_ai_controller.gd
@@ -2,6 +2,7 @@ extends GutTest
 
 # Tests for PartnerAIController behaviour: tracking, drifting, dodging.
 
+const BallStub: GDScript = preload("res://tests/stubs/ball_stub.gd")
 const PHYSICS_DELTA := 0.016
 const PADDLE_X := 300.0
 const BALL_APPROACHING_PARTNER := Vector2(100.0, 0.0)
@@ -14,7 +15,7 @@ var _config: PaddleAIConfig
 
 
 func before_each() -> void:
-	_ball = load("res://tests/stubs/ball_stub.gd").new()
+	_ball = BallStub.new()
 	add_child_autofree(_ball)
 
 	_paddle = load("res://scripts/entities/paddle.gd").new()
@@ -45,6 +46,14 @@ func before_each() -> void:
 func _run_frames(count: int) -> void:
 	for _frame in range(count):
 		_controller._physics_process(PHYSICS_DELTA)
+
+
+func _spawn_ball(position: Vector2, velocity: Vector2) -> Ball:
+	var ball: Ball = BallStub.new()
+	ball.position = position
+	ball.linear_velocity = velocity
+	add_child_autofree(ball)
+	return ball
 
 
 # --- tracking ---
@@ -132,3 +141,58 @@ func test_noise_resamples_during_drift_when_direction_changes() -> void:
 		offset_after_reversal,
 		"noise should resample even when direction changes during drift",
 	)
+
+
+# --- multi-ball coverage (SH-435) ---
+# With two live, approaching balls the partner must cover the one arriving
+# soonest, and re-commit when a sooner ball appears mid-rally. A single-ball
+# tautology can't pass these: both balls genuinely qualify, on opposite sides
+# of center, so the partner's velocity sign reveals which one it chose.
+func _bind_tracker_for_multiball() -> BallTracker:
+	var tracker: BallTracker = load("res://scripts/court/ball_tracker.gd").new()
+	add_child_autofree(tracker)
+	_controller.bind_tracker(tracker)
+	return tracker
+
+
+func test_commits_to_soonest_arriving_of_two_live_balls() -> void:
+	var tracker: BallTracker = _bind_tracker_for_multiball()
+
+	# Near ball: close x, fast → tiny time-to-arrival, intercept below center.
+	var near_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 50.0, 200.0), Vector2(200.0, 0.0))
+	# Far ball: distant x, slow → large time-to-arrival, intercept above center.
+	var far_ball: Ball = _spawn_ball(Vector2(0.0, -200.0), Vector2(100.0, 0.0))
+	# Attach near first, far last so the signal-bound `ball` is far_ball;
+	# selection must override it for the assertion to pass.
+	tracker.attach(near_ball)
+	tracker.attach(far_ball)
+	assert_eq(_controller.ball, far_ball, "precondition: signal-bound ball is the far ball")
+
+	_run_frames(5)
+
+	assert_eq(_controller.ball, near_ball, "partner selects the soonest-arriving ball")
+	assert_gt(
+		_paddle.velocity.y, 0.0, "partner tracks the near ball below center, not the far one above"
+	)
+
+
+func test_switches_when_a_sooner_ball_appears() -> void:
+	var tracker: BallTracker = _bind_tracker_for_multiball()
+
+	var first_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 50.0, 200.0), Vector2(200.0, 0.0))
+	tracker.attach(first_ball)
+	_run_frames(5)
+	assert_gt(_paddle.velocity.y, 0.0, "precondition: partner tracks the first ball below center")
+
+	# A sooner ball appears: nearly at the paddle, very fast, intercept above center.
+	var sooner_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 10.0, -200.0), Vector2(400.0, 0.0))
+	tracker.attach(sooner_ball)
+	# A slow straggler attaches last so the signal-bound `ball` is NOT the sooner
+	# ball; selection must actively pick the sooner one for the assertion to hold.
+	var straggler: Ball = _spawn_ball(Vector2(-100.0, 100.0), Vector2(80.0, 0.0))
+	tracker.attach(straggler)
+	assert_eq(_controller.ball, straggler, "precondition: signal-bound ball is the straggler")
+	_run_frames(5)
+
+	assert_eq(_controller.ball, sooner_ball, "partner switches to the newly sooner ball")
+	assert_lt(_paddle.velocity.y, 0.0, "partner now tracks the sooner ball above center")

--- a/tests/unit/paddle/test_partner_ai_controller.gd
+++ b/tests/unit/paddle/test_partner_ai_controller.gd
@@ -192,11 +192,6 @@ func test_ignores_away_ball_and_tracks_the_approaching_one() -> void:
 	_run_frames(5)
 
 	assert_eq(_controller.ball, approaching_ball, "partner skips the away ball for the approacher")
-	assert_gt(
-		_paddle.velocity.y,
-		0.0,
-		"partner tracks the approaching ball below center, not drifting toward the away ball",
-	)
 
 
 func test_switches_when_a_sooner_ball_appears() -> void:

--- a/tests/unit/paddle/test_partner_ai_controller.gd
+++ b/tests/unit/paddle/test_partner_ai_controller.gd
@@ -196,8 +196,7 @@ func test_switches_when_a_sooner_ball_appears() -> void:
 	# A sooner ball appears: nearly at the paddle, very fast, intercept above center.
 	var sooner_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 10.0, -200.0), Vector2(400.0, 0.0))
 	tracker.attach(sooner_ball)
-	# A slow straggler attaches last so the signal-bound `ball` is NOT the sooner
-	# ball; selection must actively pick the sooner one for the assertion to hold.
+	# A slow straggler attaches last; selection must still pick the sooner ball.
 	var straggler: Ball = _spawn_ball(Vector2(-100.0, 100.0), Vector2(80.0, 0.0))
 	tracker.attach(straggler)
 	assert_eq(_controller.ball, straggler, "precondition: signal-bound ball is the straggler")

--- a/tests/unit/paddle/test_partner_ai_controller.gd
+++ b/tests/unit/paddle/test_partner_ai_controller.gd
@@ -158,8 +158,7 @@ func test_commits_to_soonest_arriving_of_two_live_balls() -> void:
 	var near_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 50.0, 200.0), Vector2(200.0, 0.0))
 	# Far ball: distant x, slow → large time-to-arrival.
 	var far_ball: Ball = _spawn_ball(Vector2(0.0, -200.0), Vector2(100.0, 0.0))
-	# Attach near first, far last so the signal-bound `ball` is far_ball;
-	# selection must override it for the assertion to pass.
+	# Attach far last so the signal-bound ball is far_ball; selection must override it.
 	tracker.attach(near_ball)
 	tracker.attach(far_ball)
 	assert_eq(_controller.ball, far_ball, "precondition: signal-bound ball is the far ball")
@@ -170,17 +169,9 @@ func test_commits_to_soonest_arriving_of_two_live_balls() -> void:
 
 
 func test_ignores_away_ball_and_tracks_the_approaching_one() -> void:
-	# Two live balls: one approaches (vx > 0, still left of paddle), one moves
-	# away (vx < 0). The away ball attaches last, so a naive last-added binding
-	# would pick it. Selection must skip the away ball and commit to the
-	# approaching one.
 	var tracker: BallTracker = _bind_tracker_for_multiball()
 
-	# The away ball is nearer and faster, so a broken selector that dropped the
-	# approach filter would pick it and drift. The approaching ball is farther
-	# and slower but is the only valid target. Velocities are set AFTER attach:
-	# Ball._ready resets linear_velocity to its serve vector, so an away-bound
-	# ball only stays away once re-set.
+	# Velocities set after attach: Ball._ready resets linear_velocity to its serve vector.
 	var approaching_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 200.0, 200.0), Vector2.ZERO)
 	var away_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 10.0, -200.0), Vector2.ZERO)
 	tracker.attach(approaching_ball)

--- a/tests/unit/paddle/test_partner_ai_controller.gd
+++ b/tests/unit/paddle/test_partner_ai_controller.gd
@@ -143,11 +143,7 @@ func test_noise_resamples_during_drift_when_direction_changes() -> void:
 	)
 
 
-# --- multi-ball coverage (SH-435) ---
-# With two live, approaching balls the partner must cover the one arriving
-# soonest, and re-commit when a sooner ball appears mid-rally. A single-ball
-# tautology can't pass these: both balls genuinely qualify, on opposite sides
-# of center, so the partner's velocity sign reveals which one it chose.
+# With two live approaching balls the partner covers the soonest-arriving one.
 func _bind_tracker_for_multiball() -> BallTracker:
 	var tracker: BallTracker = load("res://scripts/court/ball_tracker.gd").new()
 	add_child_autofree(tracker)
@@ -158,9 +154,9 @@ func _bind_tracker_for_multiball() -> BallTracker:
 func test_commits_to_soonest_arriving_of_two_live_balls() -> void:
 	var tracker: BallTracker = _bind_tracker_for_multiball()
 
-	# Near ball: close x, fast → tiny time-to-arrival, intercept below center.
+	# Near ball: close x, fast → tiny time-to-arrival.
 	var near_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 50.0, 200.0), Vector2(200.0, 0.0))
-	# Far ball: distant x, slow → large time-to-arrival, intercept above center.
+	# Far ball: distant x, slow → large time-to-arrival.
 	var far_ball: Ball = _spawn_ball(Vector2(0.0, -200.0), Vector2(100.0, 0.0))
 	# Attach near first, far last so the signal-bound `ball` is far_ball;
 	# selection must override it for the assertion to pass.
@@ -171,8 +167,35 @@ func test_commits_to_soonest_arriving_of_two_live_balls() -> void:
 	_run_frames(5)
 
 	assert_eq(_controller.ball, near_ball, "partner selects the soonest-arriving ball")
+
+
+func test_ignores_away_ball_and_tracks_the_approaching_one() -> void:
+	# Two live balls: one approaches (vx > 0, still left of paddle), one moves
+	# away (vx < 0). The away ball attaches last, so a naive last-added binding
+	# would pick it. Selection must skip the away ball and commit to the
+	# approaching one.
+	var tracker: BallTracker = _bind_tracker_for_multiball()
+
+	# The away ball is nearer and faster, so a broken selector that dropped the
+	# approach filter would pick it and drift. The approaching ball is farther
+	# and slower but is the only valid target. Velocities are set AFTER attach:
+	# Ball._ready resets linear_velocity to its serve vector, so an away-bound
+	# ball only stays away once re-set.
+	var approaching_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 200.0, 200.0), Vector2.ZERO)
+	var away_ball: Ball = _spawn_ball(Vector2(PADDLE_X - 10.0, -200.0), Vector2.ZERO)
+	tracker.attach(approaching_ball)
+	tracker.attach(away_ball)
+	approaching_ball.linear_velocity = Vector2(100.0, 0.0)
+	away_ball.linear_velocity = Vector2(-400.0, 0.0)
+	assert_eq(_controller.ball, away_ball, "precondition: signal-bound ball is the away ball")
+
+	_run_frames(5)
+
+	assert_eq(_controller.ball, approaching_ball, "partner skips the away ball for the approacher")
 	assert_gt(
-		_paddle.velocity.y, 0.0, "partner tracks the near ball below center, not the far one above"
+		_paddle.velocity.y,
+		0.0,
+		"partner tracks the approaching ball below center, not drifting toward the away ball",
 	)
 
 


### PR DESCRIPTION
Two independent fixes. The AI paddle controller no longer locks onto the last-added (often stored) ball: every physics frame it scans the tracked balls and selects the soonest-arriving approaching one, so the partner and player autoplay react to whichever ball is live rather than to whichever was added last. Separately, the venue's left and right bounds move off collision layer 1 onto layer 3, so a ball leaving the court no longer halts against them while the floor and ceiling still hold inside the playable area. This is an improvement, not a fix for the outside-court wall the player actually hits: that wall is the held-ball drag clamp, tracked separately in SH-453, so #734 stays open.

The venue edges and the venue bounds are now one thing. The camera's left and right anchors read the VenueLeftBound and VenueRightBound bodies directly, and the old LeftEdge and RightEdge markers are gone, so a single node defines where each side of the venue sits. Those bounds also carry an editor-only debug draw, visible in the editor and during play, with no shipped game art.

Closes #737

Live runtime verification of ball motion past the court edge is left to the runtime-verifier.

Agent-Role: gdscript-implementer