### PR TITLE
ci: commit-msg gate requires a Signed-off-by trailer

### DIFF
--- a/scripts/ci/check_commit_msg.sh
+++ b/scripts/ci/check_commit_msg.sh
@@ -10,6 +10,7 @@
 #   - No `SH-N` prefix in subject.
 #   - No `[Codename]` suffix or `[Codename]` anywhere in subject.
 #   - Total message length (all lines combined) must be under 400 chars.
+#   - A `Signed-off-by:` trailer is present (DCO; commit with -s).
 #
 # Skips merge commits, revert commits, and fixup/squash commits.
 
@@ -63,6 +64,11 @@ fi
 codename_anywhere_re='\[[A-Z][a-zA-Z]+\]'
 if [[ "$subject" =~ $codename_anywhere_re ]]; then
   errors+=("subject contains a [Codename] tag; move it to an 'Agent-Role:' trailer")
+fi
+
+# Signed-off-by trailer required (DCO). Catch a missing -s here, before CI rejects it.
+if ! printf '%s\n' "$msg_body" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
+  errors+=("missing Signed-off-by trailer; commit with -s (DCO requires it on every commit)")
 fi
 
 if (( ${#errors[@]} > 0 )); then


### PR DESCRIPTION
The local commit-msg hook (`scripts/ci/check_commit_msg.sh`) validated subject format but never checked for a `Signed-off-by` trailer, so a commit made without `-s` passed locally and only failed DCO in CI after push (as #784 and #785 did). This adds the signoff check to the same gate, so a missing `-s` is caught at commit time. Merge, revert, and fixup commits are skipped, matching the existing carve-outs and DCO's own exemptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)