### PR TITLE
docs: commit Linear lane semantics as a single source

### DIFF
--- a/designs/ai/INDEX.md
+++ b/designs/ai/INDEX.md
@@ -6,6 +6,7 @@ How the agent system that helps build Volley! is shaped, and what it's allowed t
 |---|---|
 | [Swarm Architecture](swarm-architecture.md) | The ten-stage mission lifecycle (interrogate through cleanup), then the rationale: the Gru-and-minions model, two pools, scratchpad layout, worktree discipline, session tiers, PR verdict flow, and the open spikes still in motion. |
 | [Dispatcher Focus and WIP](dispatcher-focus-and-wip.md) | Why the dispatcher caps its own open coordination threads and parallelises through fan-out: the throughput math, the switching tax, and the orchestrator-worker evidence. |
+| [Lane Semantics](lane-semantics.md) | The Linear lane from Vault to Closed, what each state's trigger is (Completed = merged, Closed = released via the carnival), and the two hard rules: forward only, and never a close trailer. |
 
 ## Agent-assisted writing
 

--- a/designs/ai/lane-semantics.md
+++ b/designs/ai/lane-semantics.md
@@ -1,0 +1,31 @@
+# Linear Lane Semantics
+
+How a Volley issue moves from idea to released, what each state means, and the two rules that keep the board honest. This is the single source. The agent memory and the Linear status descriptions both point here.
+
+## The lane
+
+An issue advances along one lane and never moves backward:
+
+Vault, Ready, Dispatched, Challenged, Completed, Closed.
+
+Two states sit off to the side. Triage holds incoming external work before it joins the lane. Retired holds work that was cancelled or superseded, so it leaves the lane sideways rather than reaching the end.
+
+## What each state means
+
+The order alone is not enough; each transition has a concrete trigger, and getting the trigger right is what matters.
+
+**Vault** is the backlog: work to be done someday. **Ready** is work planned for a cycle, promoted by Josh, who owns cycle membership. **Dispatched** means an agent is actively working the issue; it flips the moment the work is dispatched, not when the issue is merely picked up. **Challenged** means the pull request is open and the work is up for review; it moves the instant the PR opens, not at merge.
+
+**Completed means the work merged.** That is the whole meaning. Linear's branch-name integration sets it automatically when the PR merges, so no manual move and no close trailer are needed. Verification does not live here.
+
+**Closed means the work was released to production** through the cycle release carnival. The carnival is itself the regression test, the gate that confirms nothing else broke before shipping. The release pipeline sets Closed; it is never a hand-move and never something a PR merge should reach.
+
+Verification lives in the Ride, not on the issue. A Ride is Josh playtesting the merged build; a closed Ride is what certifies the merged work holds. The issue reaching Completed says it merged, and the Ride closing says it was confirmed. Those are two separate facts on two separate surfaces.
+
+## The two hard rules
+
+**Forward only.** Once an issue advances, it never moves to an earlier state, even when a rework cycle tempts a move back to Dispatched. The state records the most-advanced step the work has reached. The one genuine exception is regression: when a Ride or post-merge playtest catches an already-Completed fix breaking again, the issue reopens forward to Ready because the work is genuinely re-opened, not because a state was overshot.
+
+**Never write a close trailer.** A PR body must not carry the GitHub close keyword (the word closes, fixes, or resolves followed by an issue number). That keyword fires GitHub's own issue-close, which drags the linked Linear issue past Completed all the way to Closed, two states too far, and falsely reads as released. The Linear branch-name integration already moves the issue to Completed on merge. If a link is wanted, use a plain issue reference with no close keyword.
+
+This second rule is the one that drifts. Roughly one in four PRs has historically tripped it, and the cleanup is manual every time. The branch name, not the PR body, is what should drive Linear movement.


### PR DESCRIPTION
The Linear lane (Vault to Closed), each state's trigger, and the two hard rules lived only in agent memory and two Linear status descriptions. Neither is human-browsable from the repo. This adds a committed source under `designs/ai/`, and the agent memory now points at it.

The two rules it pins down, both of which drifted during the Anteater 2 mission (SH-434):

- **Forward only.** An issue never moves to an earlier state; the regression case reopens forward to Ready.
- **Never a close trailer.** The GitHub close keyword overshoots the Linear lane two states to Closed. Linear's branch-name integration already moves a merged issue to Completed.

It also records the state meanings settled this session: Completed = merged, Closed = released via the cycle release carnival (the regression test), and verification lives in the Ride, not the issue.

Came out of the Anteater 2 debrief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)