### PR TITLE
chore: retire zaphod-conflicts label

### DIFF
--- a/designs/process/labels.md
+++ b/designs/process/labels.md
@@ -99,17 +99,13 @@ Separate from intent labels, a small set of GitHub labels are applied automatica
 
 ### AI review state
 
-The reviewer verdict is not a label. Specialist reviewers from `.claude/agents/` post inline findings and report their verdict to the organiser, which posts one bot synthesis review every review round under `shuck-volley-bot[bot]` via `.github/workflows/bot-review.yml`: an approval on a clean pass, request-changes if any reviewer blocked. That review is an advisory signal, not a merge decision.
+The reviewer verdict is not a label. Specialist reviewers from `.claude/agents/` post inline findings and report their verdict to the organiser, which posts one bot synthesis review every review round under `shuck-volley-bot[bot]` via `.github/workflows/bot-review.yml`: an approval on a clean pass, request-changes if any reviewer blocked. That review is an advisory signal, not a merge decision. A branch that conflicts with `main` is handled the same way, by a bot request-changes noting the conflict, not by a label.
 
-> **About the name.** "Zaphod" is the pan-galactic president from *The Hitchhiker's Guide to the Galaxy*: a two-headed alien whose extra head was added "to do all the lying, swearing and lounging about." The `zaphod-*` family collects the bot-applied PR labels (the merge-conflict flag, the dependency bumps) under one multi-headed figure. The leading `z` is also a sort hack: GitHub's label picker uses the Unicode Collation Algorithm, which treats most punctuation and emoji as primary-ignorable, so the only reliable way to push a label to the bottom of the picker is a text prefix that sorts late alphabetically. `z*` does that; `zaphod-*` happens to do that AND name the labels.
+> **About the name.** "Zaphod" is the pan-galactic president from *The Hitchhiker's Guide to the Galaxy*: a two-headed alien whose extra head was added "to do all the lying, swearing and lounging about." The `zaphod-*` family now collects only the bot-applied dependency-bump labels under one multi-headed figure. The leading `z` is also a sort hack: GitHub's label picker uses the Unicode Collation Algorithm, which treats most punctuation and emoji as primary-ignorable, so the only reliable way to push a label to the bottom of the picker is a text prefix that sorts late alphabetically. `z*` does that; `zaphod-*` happens to do that AND name the labels.
 
 ### Merge gate
 
-The required status checks are `Tests` and `Lint`. The maintainer reviews and merges by hand (Merge when ready); that manual merge is the approval. The agent reviewer verdict (the bot synthesis review) is attribution, not a required check.
-
-### Merge state
-
-- **`has-conflicts`**: applied manually when a branch needs to merge `main` in but conflicts block the merge. Remove once the conflict is resolved. GitHub's native merge queue handles pre-merge rebasing on `main`.
+The required status checks are `Tests` and `Lint`. The maintainer reviews and merges by hand (Merge when ready); that manual merge is the approval. The agent reviewer verdict (the bot synthesis review) is attribution, not a required check. GitHub's native merge queue handles pre-merge rebasing on `main`.
 
 ### Dependency updates
 


### PR DESCRIPTION
Branch conflicts with `main` are now surfaced by the bot's request-changes review, the same mechanism as any reviewer block, not by a label. This deletes the `zaphod-conflicts` label and corrects `designs/process/labels.md`: the merge-state section's manual conflict flag is removed, conflict handling folds into the AI-review-state description, and the Zaphod naming note now says the family holds only the dependabot labels.

The three `zaphod-dep*` labels are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)