### PR TITLE
feat: add speed tier table and court-derived world max

### DIFF
--- a/resources/court_config.tres
+++ b/resources/court_config.tres
@@ -4,3 +4,4 @@
 
 [resource]
 script = ExtResource("1_courtcfg")
+court_half_width = 300.0

--- a/resources/speed_tier_table.tres
+++ b/resources/speed_tier_table.tres
@@ -1,0 +1,29 @@
+[gd_resource type="Resource" script_class="SpeedTierTable" load_steps=5 format=3 uid="uid://csh437tiertbl0"]
+
+[ext_resource type="Script" uid="uid://bj6k0psydteb8" path="res://scripts/core/speed_tier_table.gd" id="1_table"]
+[ext_resource type="Script" uid="uid://biro0uh4dcwbj" path="res://scripts/core/speed_tier.gd" id="2_tier"]
+
+[sub_resource type="Resource" id="Tier0"]
+script = ExtResource("2_tier")
+floor_fraction = 0.3125
+ceiling_fraction = 0.541667
+max_range_fraction = 0.472222
+reward = ""
+
+[sub_resource type="Resource" id="Tier1"]
+script = ExtResource("2_tier")
+floor_fraction = 0.472222
+ceiling_fraction = 0.722222
+max_range_fraction = 0.25
+reward = "tier1_peak"
+
+[sub_resource type="Resource" id="Tier2"]
+script = ExtResource("2_tier")
+floor_fraction = 0.652778
+ceiling_fraction = 0.861111
+max_range_fraction = 0.208333
+reward = "top_peak"
+
+[resource]
+script = ExtResource("1_table")
+tiers = Array[ExtResource("2_tier")]([SubResource("Tier0"), SubResource("Tier1"), SubResource("Tier2")])

--- a/scripts/core/court_config.gd
+++ b/scripts/core/court_config.gd
@@ -1,10 +1,19 @@
 class_name CourtConfig
 extends Resource
 
-## Per-court tunables: friendship-bound height, ramp duration, rest-roll damping.
+## Per-court tunables: court width, friendship-bound height, ramp duration, rest-roll damping.
 
+## Half the court's paddle-to-paddle span in pixels; spawns, miss zones, and the world speed max derive from it.
+@export var court_half_width: float = 300.0
+## Seconds a fair crossing must outlast so the receiver can move and react; sets the world speed max against the crossing.
+@export var fair_crossing_seconds: float = 0.833333
 ## Speed-relock ramp duration in seconds; 0.0 snaps the speed to the tracked entry value instantly.
 @export var relock_ramp_seconds: float = 0.12
 ## Linear damping applied while the missed ball rolls to rest on the venue floor.
 # TODO(SH-394): move into a SurfaceConfig that also owns the floor PhysicsMaterial.
 @export var rest_roll_damping: float = 1.5
+
+
+## Top speed any ball may reach, derived from the court crossing: 2 * half_width / fair_crossing_seconds.
+func world_max_speed() -> float:
+	return (2.0 * court_half_width) / fair_crossing_seconds

--- a/scripts/core/game_rules.gd
+++ b/scripts/core/game_rules.gd
@@ -3,8 +3,11 @@ extends RefCounted
 
 const BASE_CONFIG: BaseStatsConfig = preload("res://resources/base_stats.tres")
 const PADDLE_CONFIG: PaddleConfig = preload("res://resources/paddle_stats.tres")
+const SPEED_TIER_TABLE: SpeedTierTable = preload("res://resources/speed_tier_table.tres")
 
 ## Typed base-stats config. Read fields directly; combine modifiers via `Stats.resolve`.
 static var base: BaseStatsConfig = BASE_CONFIG
 ## Typed paddle-stats config. Read fields directly; combine modifiers via `Stats.resolve`.
 static var paddle: PaddleConfig = PADDLE_CONFIG
+## Ball-speed ladder. Tier bounds are fractions of the court-derived world max; read via `get_tier`.
+static var speed_tiers: SpeedTierTable = SPEED_TIER_TABLE

--- a/scripts/core/speed_tier.gd
+++ b/scripts/core/speed_tier.gd
@@ -1,0 +1,13 @@
+class_name SpeedTier
+extends Resource
+
+## One rung of the speed ladder. Bounds are fractions of the derived world max so widening the court rescales the whole ladder.
+
+## Tier entry speed as a fraction of BALL_WORLD_MAX_SPEED.
+@export_range(0.0, 1.0) var floor_fraction := 0.0
+## Tier ceiling speed as a fraction of BALL_WORLD_MAX_SPEED; crossing it completes the tier.
+@export_range(0.0, 1.0) var ceiling_fraction := 0.0
+## Per-tier promotion of the flat ball_speed_max_range stat, as a fraction of BALL_WORLD_MAX_SPEED.
+@export_range(0.0, 1.0) var max_range_fraction := 0.0
+## Reward key fired on tier completion; empty means no reward.
+@export var reward := ""

--- a/scripts/core/speed_tier.gd.uid
+++ b/scripts/core/speed_tier.gd.uid
@@ -1,0 +1,1 @@
+uid://biro0uh4dcwbj

--- a/scripts/core/speed_tier_table.gd
+++ b/scripts/core/speed_tier_table.gd
@@ -1,0 +1,21 @@
+class_name SpeedTierTable
+extends Resource
+
+## The ball-speed ladder; entry bounds are fractions of the derived world max and the tier count is data.
+
+@export var tiers: Array[SpeedTier] = []
+
+
+## Returns the tier at index, clamping to the first or last entry when out of range.
+func get_tier(index: int) -> SpeedTier:
+	if tiers.is_empty():
+		return null
+
+	var clamped := clampi(index, 0, tiers.size() - 1)
+
+	return tiers[clamped]
+
+
+## Number of tiers in the ladder.
+func tier_count() -> int:
+	return tiers.size()

--- a/scripts/core/speed_tier_table.gd.uid
+++ b/scripts/core/speed_tier_table.gd.uid
@@ -1,0 +1,1 @@
+uid://bj6k0psydteb8

--- a/tests/unit/core/test_speed_tier_table.gd
+++ b/tests/unit/core/test_speed_tier_table.gd
@@ -1,0 +1,51 @@
+extends GutTest
+
+const CourtConfigScript: GDScript = preload("res://scripts/core/court_config.gd")
+const SpeedTierTableResource: SpeedTierTable = preload("res://resources/speed_tier_table.tres")
+
+
+func test_world_max_derives_720_at_default_width() -> void:
+	var config: CourtConfig = CourtConfigScript.new()
+
+	assert_almost_eq(config.world_max_speed(), 720.0, 0.5)
+
+
+func test_world_max_scales_with_court_width() -> void:
+	var config: CourtConfig = CourtConfigScript.new()
+	config.court_half_width = 600.0
+
+	assert_almost_eq(config.world_max_speed(), 1440.0, 1.0)
+
+
+func test_table_has_three_tiers() -> void:
+	assert_eq(SpeedTierTableResource.tier_count(), 3)
+
+
+func test_get_tier_clamps_below_range() -> void:
+	assert_eq(SpeedTierTableResource.get_tier(-5), SpeedTierTableResource.get_tier(0))
+
+
+func test_get_tier_clamps_above_range() -> void:
+	assert_eq(SpeedTierTableResource.get_tier(99), SpeedTierTableResource.get_tier(2))
+
+
+func test_tier0_floor_resolves_to_base_min() -> void:
+	var config: CourtConfig = CourtConfigScript.new()
+	var world_max: float = config.world_max_speed()
+	var tier0: SpeedTier = SpeedTierTableResource.get_tier(0)
+
+	assert_almost_eq(tier0.floor_fraction * world_max, 225.0, 1.0)
+
+
+func test_tier0_max_range_carries_base_stats_value() -> void:
+	var config: CourtConfig = CourtConfigScript.new()
+	var world_max: float = config.world_max_speed()
+	var tier0: SpeedTier = SpeedTierTableResource.get_tier(0)
+
+	assert_almost_eq(tier0.max_range_fraction * world_max, 340.0, 1.0)
+
+
+func test_top_tier_ceiling_stays_under_world_max() -> void:
+	var top: SpeedTier = SpeedTierTableResource.get_tier(2)
+
+	assert_lt(top.ceiling_fraction, 1.0)

--- a/tests/unit/core/test_speed_tier_table.gd.uid
+++ b/tests/unit/core/test_speed_tier_table.gd.uid
@@ -1,0 +1,1 @@
+uid://ct21vkf51rfjk


### PR DESCRIPTION
Adds the data foundation for ball speed tiers: a `SpeedTierTable` resource owned by `GameRules` with three tier entries storing floor, ceiling, and per-tier max range as fractions of the court-derived world max, plus a clamping `get_tier` accessor. `CourtConfig` gains `court_half_width` and a `world_max_speed` derivation that reproduces 720 at the default width so existing tuning keeps its meaning. Scope is data and accessors only; ball speed methods, items, and the speed bar stack on this in later units.

Agent-Role: Stanford (gdscript-implementer)