### PR TITLE
docs: add split-shape step to dandori

### DIFF
--- a/.claude/skills/dandori/SKILL.md
+++ b/.claude/skills/dandori/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dandori
-description: Gru's implementation-plan walk, run after the mission milestone is filed and before any minion dispatches. Per work unit, name the crew, recon the surfaces, name the scope cap, confirm. Not the mission-shape walk; that is stages 1 to 3 of the lifecycle.
+description: Gru's implementation-plan walk, run after the mission milestone is filed and before any minion dispatches. Per work unit, name the crew, recon the surfaces, name the scope cap, decide the split shape, confirm. Not the mission-shape walk; that is stages 1 to 3 of the lifecycle.
 ---
 
 # Dandori, the impl plan

--- a/.claude/skills/dandori/SKILL.md
+++ b/.claude/skills/dandori/SKILL.md
@@ -11,7 +11,7 @@ Dandori is the implementation plan, not the mission-shape walk. By the time it r
 
 **Pairs with:** [`designs/ai/swarm-architecture.md`](../../../designs/ai/swarm-architecture.md) (the full ten-stage lifecycle; dandori is stage 4), [`designs/process/dandori.md`](../../../designs/process/dandori.md) (human-readable), and [`dispatch.md`](../dispatch/SKILL.md) (the seven-step flow that runs after confirm).
 
-## The four steps
+## The five steps
 
 1. **Crew.** Per work unit:
    - Impl writer. Often folds in test authoring when the work itself is test code.
@@ -25,7 +25,9 @@ Dandori is the implementation plan, not the mission-shape walk. By the time it r
 
 3. **Scope-expansion guard.** For any goal that could sprawl (CI gate, audit, doc rewrite, contract change), name the cap. Broader work files as follow-up issues after the mission, never inside it.
 
-4. **Confirm.** List the crew, the recon-grounded slices, and the scope caps. Wait for go before dispatching.
+4. **Split shape.** Decide how many PRs the feature becomes, governed by [`feedback_feature_pr_decomposition`]: the fewest PRs such that each one is independently shippable on trunk (compiles, suite green, no half-wired feature). Default is one feature, one branch, one PR (units fold serially onto it). When units can be made genuinely independent by landing a shared contract first, a parallel split into independent PRs is preferred, but only up to **3 PRs**; past 3 the contract churn dominates, so go serial. The **+1000 added-line** cap is a hard ceiling per PR: when the accumulated diff crosses it, PR the largest independently-shippable prefix and move the remainder to a follow-up off main (a forced 1->2 split is fine). Never cut a unit in half for the line count. A feature that genuinely cannot be sliced into independently-shippable sub-1000-line PRs is a planning smell to flag here, not at fold time.
+
+5. **Confirm.** List the crew, the recon-grounded slices, the scope caps, and the split shape. Wait for go before dispatching.
 
 ## What this skill replaces
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -11,6 +11,8 @@ Gru's executor flow, stage 5 of the swarm lifecycle. Use after dandori has confi
 
 Hold few coordination threads open at once. Drive one to done, or cleanly park it, before pulling the next; a half-open item is a cost on the clock and a residue tax on the next decision. Done means merged, or the mission closed, not the challenge opened: an open PR awaiting the maintainer's merge is still a thread on the count, so do not report it closed until it merges. This is not single-threading: parallelism is the worker layer's job, so fan out minions and reviewers with clean briefs and let them run at once. A low-WIP dispatcher is what keeps each fan-out brief sharp. Evidence and citations in [`designs/ai/dispatcher-focus-and-wip.md`](../../../designs/ai/dispatcher-focus-and-wip.md).
 
+How many PRs a feature becomes is the dandori split-shape decision, not one-PR-per-ticket by default. A multi-unit feature is usually one branch, one PR (units fold serially); it splits into multiple independent PRs only when a shared contract makes the units genuinely independent and the split stays at 3 PRs or fewer, and any single PR caps at +1000 added lines. The governing rule is [`feedback_feature_pr_decomposition`]; the walk is step 4 of [`dandori`](../dandori/SKILL.md).
+
 ## Gru works on a worktree too
 
 The default tree at `/home/josh/gamedev/volley` is Josh's; Gru does not edit it. Repo-touching Gru work (writing skills, restructuring docs, sweeping references) goes on a sibling worktree under `/home/josh/gamedev/volley/.claude/worktrees/<slug>` on a feature branch, same as a minion. Memory files at `~/.claude/projects/.../memory/` live outside the repo and don't need a worktree. If a session lands on the default tree by accident, stash and migrate before continuing.

--- a/designs/process/dandori.md
+++ b/designs/process/dandori.md
@@ -2,7 +2,7 @@
 
 Dandori is stage 4 of the swarm lifecycle: the implementation plan, run after the mission is filed and before any minion dispatches. Interrogating the work, picking a codename, and filing the milestone happen earlier, as stages 1 to 3, owned by [`swarm-architecture.md`](../ai/swarm-architecture.md). By the time dandori runs, the milestone exists on the right project, the Ride exists if the mission needs one, and the issues are attached.
 
-Dandori narrows to four questions, per work unit: who works it, what it touches, how it is capped, and a confirm before go.
+Dandori narrows to five questions, per work unit: who works it, what it touches, how it is capped, how it splits into PRs, and a confirm before go.
 
 Pairs with [`missions-and-projects.md`](missions-and-projects.md) (the nouns), [`flow-shapes.md`](flow-shapes.md) (the shapes work takes inside a mission), and the operational checklist in [`.claude/skills/dandori/SKILL.md`](../../.claude/skills/dandori/SKILL.md).
 

--- a/designs/process/dandori.md
+++ b/designs/process/dandori.md
@@ -25,9 +25,13 @@ Before confirm, a read-only minion maps each work unit's fix surface and the fil
 
 For any goal that could naturally sprawl (CI gate, audit, doc rewrite, contract change), name the cap. Broader work files as follow-up tickets after the mission, not inside it.
 
-## 4. Confirm before dispatch
+## 4. Split shape
 
-List the crew, the recon-grounded slices, and the scope caps. Wait for go. Don't dispatch until they are confirmed.
+Decide how many PRs the feature becomes: the fewest such that each PR is independently shippable on trunk (compiles, suite green, no half-wired feature). The default is one feature, one branch, one PR, with units folding serially. A parallel split into multiple independent PRs is preferred only when a shared contract makes the units genuinely independent and the split stays at three PRs or fewer; past three, contract churn dominates and the work goes serial. A single PR caps at +1000 added lines; crossing it splits off the remainder as a follow-up, cut at a clean boundary so each side still stands alone. A feature that cannot be sliced this way is a planning smell to flag here.
+
+## 5. Confirm before dispatch
+
+List the crew, the recon-grounded slices, the scope caps, and the split shape. Wait for go. Don't dispatch until they are confirmed.
 
 ## Worked example
 


### PR DESCRIPTION
Feature decomposition into PRs is a dandori-time decision, not one-PR-per-ticket by default.

Adds a **split shape** step to the dandori walk (skill + process doc) and a dispatcher-side pointer in the dispatch skill. The rule: split a feature into the fewest independently-shippable PRs (each compiles, suite green, no half-wired feature on trunk). One-PR default with serial folding; a shared-contract parallel split only at 3 PRs or fewer; the +1000 added-line cap forces a clean-boundary follow-up.

Surfaced while running SH-437 as five units on one branch: the skills agents read at dispatch had no notion of when a feature legitimately becomes more than one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)