### PR TITLE
chore: version project rule-enforcement hooks in the repo

### DIFF
--- a/.claude/hooks/block-approved-human.sh
+++ b/.claude/hooks/block-approved-human.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard: deny any attempt to apply (or remove) the
+# approved-human label. That label is Josh's human sign-off gate; the agent
+# must never touch it. Reads pass (a gh pr view that merely mentions the label
+# in a jq filter is fine); only label-mutating commands are denied.
+set -uo pipefail
+
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")"
+[ -z "$cmd" ] && exit 0
+
+deny=0
+# gh flag form: --add-label / --remove-label followed (optionally quoted) by
+# the label name. Matches the actual mutation, not a prose mention.
+if printf '%s' "$cmd" | grep -qiE -- '--(add|remove)-label[=[:space:]]+.{0,1}approved-human'; then
+  deny=1
+fi
+# REST/GraphQL form: a write to a labels endpoint carrying the label name.
+if printf '%s' "$cmd" | grep -qiE 'approved-human' \
+   && printf '%s' "$cmd" | grep -qiE '(issues|pulls)/[^[:space:]]*/labels|addLabels|removeLabels' \
+   && printf '%s' "$cmd" | grep -qiE -- '-X[[:space:]]+(POST|PUT|DELETE)|--method[[:space:]]+(POST|PUT|DELETE)'; then
+  deny=1
+fi
+
+if [ "$deny" = "1" ]; then
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Refusing to mutate the approved-human label. That is the human sign-off gate and is Josh'"'"'s alone; the agent must never apply or remove it. Ask Josh to approve."}}'
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/block-pr-merge.sh
+++ b/.claude/hooks/block-pr-merge.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard: only the maintainer merges PRs (via the UI Merge when
+# ready). Deny any gh pr merge invocation by the agent, including --auto.
+set -uo pipefail
+
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")"
+[ -z "$cmd" ] && exit 0
+
+if printf '%s' "$cmd" | grep -qiE 'gh pr merge([[:space:]]|$)'; then
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Only the maintainer merges PRs (via Merge when ready). The agent must not run gh pr merge, including --auto."}}'
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/debrief-flow-signal.sh
+++ b/.claude/hooks/debrief-flow-signal.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: detects debrief / mission-close trigger phrases
+# and injects a system reminder pointing at ai/skills/gru/debrief.md so
+# the six-step flow runs instead of an inline orchestrator summary.
+set -euo pipefail
+
+prompt="$(jq -r '.prompt // empty')"
+[[ -z "$prompt" ]] && exit 0
+
+if printf '%s' "$prompt" | grep -qiE "(\\bdebrief\\b|mission complete|mission close|close[a-z' ]{0,14}mission|wrap.?up|\\bretro\\b|\\bpulse\\b|done with )"; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: "Debrief / mission-close trigger detected. Read .claude/skills/debrief/SKILL.md before producing any wrap-up text. Six-step flow: (1) git status first, (2) dispatch three independent agents (cold-read, devils-advocate, CI miner), (3) fold their drafts, (4) post via mcp__linear__save_status_update on the relevant project, (5) route every action item Filed / Memory-only / Parked, (6) list every flag added or state none. Never the orchestrator inline summary."
+    }
+  }'
+fi
+exit 0

--- a/.claude/hooks/em-dash-pre-tool.sh
+++ b/.claude/hooks/em-dash-pre-tool.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Block tool calls whose input contains U+2014 (em dash).
+# Rule: ~/.claude/projects/-home-josh-gamedev-volley/memory/feedback_no_em_dashes.md
+set -e
+
+INPUT=$(cat)
+TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input | tostring' 2>/dev/null || printf '%s' "$INPUT")
+
+if printf '%s' "$TEXT" | grep -q $'\xe2\x80\x94'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "U+2014 (em dash) detected in tool input. The em dash is banned on every surface per feedback_no_em_dashes.md. Replace with a comma, semicolon, period, or parentheses, then retry."
+    }
+  }'
+fi
+exit 0

--- a/.claude/hooks/git-rebase-ask.sh
+++ b/.claude/hooks/git-rebase-ask.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Force an ask-prompt before git rebase or git pull --rebase.
+set -euo pipefail
+
+cmd="$(jq -r '.tool_input.command // ""')"
+
+if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]&|;`(])git[[:space:]]+rebase([[:space:]]|$)|(^|[[:space:]&|;`(])git[[:space:]]+pull([[:space:]]|$).*(--rebase|[[:space:]]-r([[:space:]]|$))'; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"git rebase / git pull --rebase requires explicit confirmation"}}'
+fi

--- a/.claude/hooks/inject-priority-memory.sh
+++ b/.claude/hooks/inject-priority-memory.sh
@@ -4,7 +4,7 @@
 # Fails open: any error prints nothing and exits 0 (no injection, no block).
 set -uo pipefail
 
-MEM_DIR="/home/josh/.claude/projects/-home-josh-gamedev-volley/memory"
+MEM_DIR="${HOME}/.claude/projects/-home-josh-gamedev-volley/memory"
 [ -d "$MEM_DIR" ] || exit 0
 
 out="$(

--- a/.claude/hooks/inject-priority-memory.sh
+++ b/.claude/hooks/inject-priority-memory.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SessionStart hook: inject the bodies of priority-flagged memories into context.
+# A memory is priority when its frontmatter metadata carries `priority: true`.
+# Fails open: any error prints nothing and exits 0 (no injection, no block).
+set -uo pipefail
+
+MEM_DIR="/home/josh/.claude/projects/-home-josh-gamedev-volley/memory"
+[ -d "$MEM_DIR" ] || exit 0
+
+out="$(
+  python3 - "$MEM_DIR" <<'PY' 2>/dev/null || true
+import sys, os, glob
+
+mem_dir = sys.argv[1]
+blocks = []
+for path in sorted(glob.glob(os.path.join(mem_dir, "*.md"))):
+    if os.path.basename(path) == "MEMORY.md":
+        continue
+    try:
+        text = open(path, encoding="utf-8", errors="replace").read()
+    except Exception:
+        continue
+    if not text.startswith("---"):
+        continue
+    end = text.find("---", 3)
+    if end == -1:
+        continue
+    front = text[3:end]
+    # priority flag lives in frontmatter (metadata.priority: true or top-level priority: true)
+    is_priority = any(
+        line.strip().replace(" ", "").lower() == "priority:true"
+        for line in front.splitlines()
+    )
+    if not is_priority:
+        continue
+    body = text[end + 3:].strip()
+    name = os.path.basename(path)[:-3]
+    blocks.append(f"### {name}\n{body}")
+
+if blocks:
+    print("Priority memories (always loaded; these are load-bearing rules):\n")
+    print("\n\n".join(blocks))
+PY
+)"
+
+[ -z "$out" ] && exit 0
+
+# SessionStart hooks inject context via additionalContext in JSON output.
+python3 - "$out" <<'PY' 2>/dev/null || true
+import sys, json
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": sys.argv[1]}}))
+PY
+exit 0

--- a/.claude/hooks/linear-issue-body-cap.sh
+++ b/.claude/hooks/linear-issue-body-cap.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# PreToolUse on mcp__linear__save_issue: deny when THIS call sets a description over 600 chars.
+# Overflow belongs in a linked design doc, not the issue body.
+# State-only saves (no description field in the call) pass regardless of the stored body length.
+# Fails open on parse error.
+set -uo pipefail
+
+CAP=600
+input="$(cat)"
+
+result="$(printf '%s' "$input" | python3 -c "
+import json, sys
+CAP = $CAP
+try:
+    d = json.load(sys.stdin)
+    ti = d.get('tool_input', {})
+    if 'description' not in ti or ti['description'] is None:
+        print('PASS')          # state-only save, body not being set
+    else:
+        n = len(ti['description'])
+        print('DENY %d' % n if n > CAP else 'PASS')
+except Exception:
+    print('PASS')              # fail open
+" 2>/dev/null || echo PASS)"
+
+if [ "${result%% *}" = "DENY" ]; then
+  n="${result##* }"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Issue body is %s chars; the cap is %s. Trim the body to the ask + AC and move the depth (options, rationale, design detail) into a designs/ doc linked via the issue links field."}}\n' "$n" "$CAP"
+fi
+exit 0

--- a/.claude/hooks/linear-save-issue-warn.sh
+++ b/.claude/hooks/linear-save-issue-warn.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Warn on creation of new Linear issues that may belong on an active PR.
+# Rule: ~/.claude/projects/-home-josh-gamedev-volley/memory/feedback_continuous_refactoring.md
+set -e
+
+INPUT=$(cat)
+
+# Only act when no `id` is present (creation, not update).
+HAS_ID=$(printf '%s' "$INPUT" | jq -r '.tool_input.id // empty' 2>/dev/null)
+if [ -n "$HAS_ID" ]; then
+  exit 0
+fi
+
+# If we're on a feature branch (not main), filing a new issue is the danger zone:
+# the work may be a follow-up that folds into the active PR per feedback_continuous_refactoring.
+BRANCH=$(git -C /home/josh/gamedev/volley branch --show-current 2>/dev/null || echo "")
+case "$BRANCH" in
+  ""|main|master)
+    exit 0
+    ;;
+esac
+
+jq -n --arg branch "$BRANCH" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "ask",
+    permissionDecisionReason: ("Creating a new Linear issue while on feature branch " + $branch + ". If this work could fold into the active PR, retire it as in-flight cleanup per feedback_continuous_refactoring instead. Approve to proceed if genuinely standalone.")
+  }
+}'
+exit 0

--- a/.claude/hooks/linear-save-issue-warn.sh
+++ b/.claude/hooks/linear-save-issue-warn.sh
@@ -13,7 +13,7 @@ fi
 
 # If we're on a feature branch (not main), filing a new issue is the danger zone:
 # the work may be a follow-up that folds into the active PR per feedback_continuous_refactoring.
-BRANCH=$(git -C /home/josh/gamedev/volley branch --show-current 2>/dev/null || echo "")
+BRANCH=$(git -C "$CLAUDE_PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
 case "$BRANCH" in
   ""|main|master)
     exit 0

--- a/.claude/hooks/memory-correction-signal.sh
+++ b/.claude/hooks/memory-correction-signal.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: scans the user's prompt for correction-phrase
+# heuristics and injects a system reminder when one matches, prompting
+# Claude to consider whether this turn introduces or sharpens a memory rule.
+set -euo pipefail
+
+prompt="$(jq -r '.prompt // empty')"
+[[ -z "$prompt" ]] && exit 0
+
+if printf '%s' "$prompt" | grep -qiE "(\\bdon't\\b|\\bstop\\b|\\balways\\b|\\bnever\\b|\\bactually\\b|\\bremember\\b|you didn't|you should|no don't|wrong way|isn't right|is not right|you forgot|\\bmissed\\b)"; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: "Possible correction signal in user message — apply feedback_corrections_always_update_memory and feedback_continuous_rule_refinement: consider whether this turn introduces or sharpens a memory rule, and if so update memory + commit before turn ends."
+    }
+  }'
+fi
+exit 0

--- a/.claude/hooks/pr-mention-state-check.sh
+++ b/.claude/hooks/pr-mention-state-check.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Stop hook: if the just-finished assistant turn references a PR but ran no live
+# PR-state read in that same turn, block once to force a hydrate before the
+# claim reaches the user. Fails open: any error or ambiguity exits 0 (no block).
+set -uo pipefail
+
+input="$(cat)"
+
+# Loop guard: if this turn was already blocked once, let it through.
+active="$(printf '%s' "$input" | jq -r '.stop_hook_active // false' 2>/dev/null || echo false)"
+[ "$active" = "true" ] && exit 0
+
+tp="$(printf '%s' "$input" | jq -r '.transcript_path // empty' 2>/dev/null || echo "")"
+[ -z "$tp" ] && exit 0
+[ -f "$tp" ] || exit 0
+
+verdict="$(python3 - "$tp" <<'PY' 2>/dev/null || true
+import sys, json, re
+
+path = sys.argv[1]
+try:
+    raw = open(path, encoding="utf-8", errors="replace").read().splitlines()
+except Exception:
+    print("0"); sys.exit(0)
+
+records = []
+for line in raw:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        records.append(json.loads(line))
+    except Exception:
+        pass
+
+def is_human_prompt(rec):
+    # A human prompt is a user-type message whose content is plain text,
+    # not a tool_result echo (those are also role user).
+    if rec.get("type") != "user":
+        return False
+    msg = rec.get("message", rec)
+    content = msg.get("content")
+    if isinstance(content, str):
+        return True
+    if isinstance(content, list):
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                return True
+        return False
+    return False
+
+last_human = -1
+for i, r in enumerate(records):
+    if is_human_prompt(r):
+        last_human = i
+
+turn = records[last_human + 1:] if last_human >= 0 else records
+
+assistant_text = []
+tool_inputs = []
+for r in turn:
+    msg = r.get("message", r)
+    role = msg.get("role") or r.get("type")
+    content = msg.get("content")
+    if isinstance(content, str):
+        if role == "assistant":
+            assistant_text.append(content)
+    elif isinstance(content, list):
+        for b in content:
+            if not isinstance(b, dict):
+                continue
+            if b.get("type") == "text" and role == "assistant":
+                assistant_text.append(b.get("text", ""))
+            elif b.get("type") == "tool_use":
+                tool_inputs.append(json.dumps(b.get("input", {})))
+
+text = "\n".join(assistant_text)
+cmds = "\n".join(tool_inputs)
+
+mentions_pr = re.search(r"#\d+|\bPRs?\b|pull request", text, re.I) is not None
+
+# Only meaningful when the text asserts a PR's state, not just names a PR.
+state_claim = re.search(
+    r"\b("
+    r"merged|is open|is closed|reopened|blocked|approved|approval|"
+    r"passing|passed|failing|failed|mergeable|queued|landed|"
+    r"ready to merge|auto-?merge|all checks|checks? (pass|green|red|fail)|"
+    r"review (passed|verdict|blocked|approved)|green|red"
+    r")\b",
+    text, re.I) is not None
+
+# A live read OR a gh pr write this turn grounds the claim (the command result
+# is ground truth), so neither should block.
+touched = re.search(
+    r"gh pr (view|list|status|checks|diff|merge|close|edit|create|reopen|ready|comment|review)"
+    r"|gh api[^\n]*(/pulls|/issues)",
+    cmds, re.I) is not None
+
+print("1" if (mentions_pr and state_claim and not touched) else "0")
+PY
+)"
+
+if [ "$verdict" = "1" ]; then
+  printf '%s\n' '{"decision":"block","reason":"state-check: this response referenced a PR or challenge state without a live gh read this turn. Run the gh read now (gh pr view <n> --json state,mergeable,reviewDecision or gh pr checks <n>), correct any claim that does not match, then stop."}'
+fi
+
+exit 0

--- a/.claude/hooks/require-background-agent.sh
+++ b/.claude/hooks/require-background-agent.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PreToolUse hook on Agent: deny any dispatch missing run_in_background: true.
+# Rule feedback_agents_default_background: always background, no exceptions.
+# Fails open on parse error (no false block), denies only on a clear missing/false flag.
+set -uo pipefail
+
+input="$(cat)"
+
+bg="$(printf '%s' "$input" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(str(d.get('tool_input', {}).get('run_in_background')).lower())
+except Exception:
+    print('parse_error')
+" 2>/dev/null || echo parse_error)"
+
+# Only act when we positively read a non-true flag. Anything ambiguous passes.
+if [ "$bg" = "true" ] || [ "$bg" = "parse_error" ]; then
+  exit 0
+fi
+
+printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Agent dispatch must set run_in_background: true (feedback_agents_default_background, always background, no exceptions). Re-issue the call with the flag."}}'
+exit 0

--- a/.claude/hooks/require-editing-agent-isolation.sh
+++ b/.claude/hooks/require-editing-agent-isolation.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# PreToolUse on Agent: deny a repo-file-EDITING agent dispatch that lacks isolation: "worktree".
+# Rule: code-writing minions run in their own worktree (ai/skills/gru/dispatch.md), so they never
+# share the main tree or its dirty state. Runtime/reviewer types are exempt (they need the main
+# editor for godotiq, or are read-only).
+# Fails open on parse error.
+set -uo pipefail
+
+input="$(cat)"
+
+printf '%s' "$input" | python3 -c "
+import json, sys
+# Editing agent types that ship repo file changes and do not need the running godotiq editor.
+EDITING = {'gdscript-implementer', 'test-author', 'integration-scenario-author', 'docs-tender'}
+try:
+    d = json.load(sys.stdin)
+    ti = d.get('tool_input', {})
+    st = ti.get('subagent_type', '')
+    iso = ti.get('isolation', '')
+except Exception:
+    sys.exit(0)
+
+if st in EDITING and iso != 'worktree':
+    reason = (
+        st + ' edits repo files and must dispatch with isolation: worktree so it does not share '
+        'the main worktree or its uncommitted state (ai/skills/gru/dispatch.md). Re-issue with '
+        'isolation set. If it genuinely needs the running godotiq editor, it is the wrong agent type.'
+    )
+    out = {'hookSpecificOutput': {'hookEventName': 'PreToolUse',
+                                  'permissionDecision': 'deny',
+                                  'permissionDecisionReason': reason}}
+    print(json.dumps(out))
+" 2>/dev/null || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,56 @@
 {
-  "hooks": {}
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/em-dash-pre-tool.sh\"" }
+        ]
+      },
+      {
+        "matcher": "mcp__linear__save_issue",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-save-issue-warn.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-issue-body-cap.sh\"" }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/require-background-agent.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/require-editing-agent-isolation.sh\"" }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/git-rebase-ask.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-approved-human.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-pr-merge.sh\"" }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-mention-state-check.sh\"" }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/memory-correction-signal.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/debrief-flow-signal.sh\"" }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-priority-memory.sh\"" }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
The hooks that enforce Volley's process rules lived unversioned in a personal `~/.claude/hooks` dir, wired through personal settings. They are the deterministic enforcement surface of the same rules that live in skills, CLAUDE.md, and memory, so they belong in the repo: reviewable, diffable, and applied for any contributor rather than just one machine.

Brings 12 hooks under version control, wired in repo `.claude/settings.json` via `$CLAUDE_PROJECT_DIR`:
- **Gates** (PreToolUse, blocking): em-dash, agent background + isolation, git-rebase-ask, approved-human block, PR-merge block, Linear issue body cap + save warning.
- **Signals** (UserPromptSubmit / Stop / SessionStart): PR-mention state check, memory-correction signal, debrief-flow signal, priority-memory injection.

Fixed two latent bugs found while migrating: the debrief signal pointed at the pre-move `ai/skills/gru/debrief.md` path, and a correction-phrase regex carried an apostrophe-less `isnt right` token.

The personal ntfy notification hooks are not process rules and are removed separately, not versioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)