### PR TITLE
docs: code-style process doc for comment conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ Reference the issue in the PR body with a bare `#123` (the number on its own). G
 
 **Tone.** Plain descriptive prose, positive framing. Lead with what a thing is and does. Applies to PR descriptions, commit messages, and code comments.
 
+**Code style.** Inline comments explain why; `##` doc-comments describe the public API. The conventions live in [`designs/process/code-style.md`](designs/process/code-style.md).
+
 **What a reviewer looks at:**
 
 - Acceptance criteria from the ticket are met.

--- a/designs/process/INDEX.md
+++ b/designs/process/INDEX.md
@@ -10,6 +10,7 @@ How the team writes, files, dispatches, and runs the work.
 | [Dandori](dandori.md) | The implementation plan, after filing, before dispatch. |
 | [Flow Shapes](flow-shapes.md) | Bug / spike / feature flow shapes inside a mission. |
 | [Refactoring](refactoring.md) | Refactor as you go: cleaning the shape your change touches. |
+| [Code Style](code-style.md) | Inline comments explain why; `##` doc-comments describe the public API. |
 | [Project Management](project-management.md) | How projects get sized, split, and retired. |
 | [Rituals Calendar](rituals-calendar.md) | The recurring beats: cycles, debriefs, rides. |
 | [Shuck Month](shuck-month.md) | The cycle and month rhythm. |

--- a/designs/process/code-style.md
+++ b/designs/process/code-style.md
@@ -1,0 +1,34 @@
+# Code style
+
+Two kinds of comment do two different jobs in the codebase, and it helps to keep them apart.
+
+## Inline comments explain why
+
+An inline `#` comment says why the code is the way it is: the reason behind a choice that the code itself cannot show. Keep it to one line, and do not narrate what the line does; the code already says that. A comment that restates the statement below it is noise, and reviewers will ask for it to go.
+
+```gdscript
+# Peak entry still fires the legacy max-speed event Cadence latches on.
+func _on_ball_peak_changed(in_peak: bool) -> void:
+```
+
+## Doc-comments describe the public API
+
+A Godot `##` doc-comment documents the surface other code calls: the class, its public methods, its signals, its exported and public variables. These render as tooltips in the Godot editor and feed the generated class reference, so they describe what a thing is for the caller, not how it works inside.
+
+```gdscript
+## Spawns floating soul labels on each per-hit award.
+class_name SoulFloatLayer
+extends CanvasLayer
+
+## Carries the screen anchor where the float should appear.
+signal soul_earned(amount: int, anchor: Vector2)
+
+## Vertical offset applied on top of the signal anchor.
+@export var anchor_offset: Vector2 = Vector2(0.0, -40.0)
+```
+
+The tags worth reaching for: `@deprecated`, `@experimental`, `@tutorial`, and the `[member x]`, `[method x]`, `[signal x]` cross-references that link one symbol to another.
+
+## Document as you go
+
+New code gets `##` on its public surface, and edited code gains it on the parts you touch. There is no expectation to retrofit the whole tree at once; the coverage grows with the work.


### PR DESCRIPTION
Adds `designs/process/code-style.md` so contributors know the two comment conventions: inline `#` comments explain why (one line, no narration); `##` doc-comments describe the public API (class, methods, signals, exported vars) and drive editor tooltips. CONTRIBUTING references it rather than inlining the detail; the process INDEX lists it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)