### PR TITLE
docs: ticket titles name the subject, not the artifact

### DIFF
--- a/designs/process/ticket-writing.md
+++ b/designs/process/ticket-writing.md
@@ -36,7 +36,7 @@ Applies to every ticket, every discipline.
 
 **Leave room for conversation, but publish the conversation.** Borrowed from Ron Jeffries' Three Cs (card, conversation, confirmation): the ticket is a promise of a conversation. For a contributor, the conversation has to happen in the ticket thread or the linked design doc; verbal context does not reach them. Over-specifying still kills iteration, so leave room, and document decisions in comments as they happen.
 
-**Titles are short and punchy.** Aim for 50 characters or fewer. Symptoms, qualifiers, file paths, and context belong in the body. "Timeout and Equip" reads better than "Implement the timeout system so the main character can equip items".
+**Titles are short and punchy.** Aim for 50 characters or fewer. Symptoms, qualifiers, file paths, and context belong in the body. "Timeout and Equip" reads better than "Implement the timeout system so the main character can equip items". Name the subject of the work in plain words, not the method or the artifact you imagine producing: "Play Animation Exploration", not "Animatic concept for animation dynamics". Craft jargon in a title (animatic, easing, on-twos) narrows the work before it has started.
 
 **INVEST as a sanity check.** Independent, Negotiable, Valuable, Estimable, Small, Testable (Bill Wake, 2003). Use it to spot tickets that should be split, merged, or rewritten. Independence matters extra for open-source: a contributor should be able to ship the ticket without a long chain of dependencies pulling them into unrelated systems.
 


### PR DESCRIPTION
The ticket-writing guide tells you to keep titles short, but not to keep them about the right thing. A title that names the artifact you imagine producing (an animatic, a tween, a shader) decides the shape of the work before anyone has explored it. The clearer title names the subject in plain words and leaves the method open. This adds that one clause to the titles principle.

Agent-Role: dispatcher