### PR TITLE
chore: gitignore concepts art pending an asset strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ addons/signal_lens/
 # the text docs reference external works in ways we keep internal.
 designs/art/mood-boards/
 
+# Concept art, local only until a binary-asset strategy is chosen (see the asset-management spike).
+concepts/
+
 # Private design docs: internal-only, synced to Notion rather than the public repo.
 designs/private/
 


### PR DESCRIPTION
Concept art (around 94MB of PNGs and PSD masters) sits in a root concepts/ directory. It stays local until the binary-asset version-control strategy is decided, so a stray add cannot drop 94MB of binaries into git history. The mood-board exclusion already sets this pattern for local-only media.

Agent-Role: dispatcher