### PR TITLE
fix: ship the no-threads web build to itch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
           relative_project_path: ./
           cache: true
           export_debug: true
-          presets_to_export: WebThreaded
+          presets_to_export: WebNoThreads
 
       - name: Download Butler
         run: |
@@ -119,6 +119,6 @@ jobs:
           chmod +x butler
 
       - name: Push to Itch.io Preview
-        run: ./butler push "${{ steps.export.outputs.build_directory }}/WebThreaded" ${{ env.ITCH_PROJECT }}:html5-preview
+        run: ./butler push "${{ steps.export.outputs.build_directory }}/WebNoThreads" ${{ env.ITCH_PROJECT }}:html5-preview
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}


### PR DESCRIPTION
The itch web player shows a SharedArrayBuffer / cross-origin-isolation error and never starts. The publish workflow exports and pushes the WebThreaded build, which needs the COOP and COEP headers that enable SharedArrayBuffer, and itch does not send them. The WebNoThreads preset runs without those headers, and a 2D game does not need web threading, so the preview push now ships that build. The WebThreaded preset stays in place for a future self-hosted web deploy where the headers can be set.

Agent-Role: dispatcher