### PR TITLE
chore: surface latest handoff at session start via hook

### DIFF
--- a/.claude/hooks/inject-latest-handoff.sh
+++ b/.claude/hooks/inject-latest-handoff.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SessionStart hook: point at the most-recent handoff by mtime so the session
+# reads it before acting. Deliberately a POINTER, not the body: handoffs are
+# point-in-time and a parallel sibling's file may be newer, so the rule is
+# read-then-hydrate, not trust-on-inject (see reference_session_handoff_file).
+# Fails open: any error prints nothing and exits 0 (no injection, no block).
+set -uo pipefail
+
+HANDOFF_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/ai/scratchpads"
+[ -d "$HANDOFF_DIR" ] || exit 0
+
+# Most recent handoff-*.md by mtime.
+latest="$(ls -t "$HANDOFF_DIR"/handoff-*.md 2>/dev/null | head -n1)"
+[ -z "$latest" ] && exit 0
+
+rel="ai/scratchpads/$(basename "$latest")"
+mtime="$(date -r "$latest" '+%Y-%m-%d %H:%M' 2>/dev/null || echo 'unknown time')"
+
+read -r -d '' note <<EOF || true
+Latest session handoff: ${rel} (modified ${mtime})
+
+Read it before acting on in-flight work. It is point-in-time: confirm its
+mission/branch matches THIS session, and hydrate any PR/branch/Linear claim
+with a live gh/git read before trusting it. A newer sibling may belong to a
+parallel session, so check the branch matches before you act on it.
+EOF
+
+python3 - "$note" <<'PY' 2>/dev/null || true
+import sys, json
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": sys.argv[1]}}))
+PY
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,7 +49,8 @@
     "SessionStart": [
       {
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-priority-memory.sh\"" }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-priority-memory.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-latest-handoff.sh\"" }
         ]
       }
     ]


### PR DESCRIPTION
Sessions that pick up mid-mission work depend on the latest handoff in `ai/scratchpads/`, but nothing guaranteed it got read. A memory would not fix this reliably (memories recall by relevance, not on a schedule), so this is a hook the harness runs.

A new `SessionStart` hook finds the most-recent `handoff-*.md` by mtime and injects a pointer to it, alongside the existing priority-memory injector.

It surfaces a pointer, not the file body, on purpose. Handoffs are point-in-time, and a parallel session's file may be newer, so the standing rule is read-then-hydrate rather than trust-on-inject. Injecting the body as fact would fight that rule; the pointer nudges toward opening the file and verifying branch and PR state with a live `gh`/`git` read first.

The hook fails open: any error prints nothing and exits 0, so a missing scratchpad dir or a bad read never blocks a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)