### PR TITLE
docs: surface physics ownership spike for SH-425

### DIFF
--- a/designs/01-prototype/20-ball-speed-tiers.md
+++ b/designs/01-prototype/20-ball-speed-tiers.md
@@ -106,9 +106,9 @@ New: unchanged. Wrist Brace compresses every tier's hits-to-climb and trades pad
 
 ## Court width
 
-The court's crossing distance sets the fun ceiling, so court width is a tunable rather than a baked scene layout. `CourtConfig` gains `court_half_width` (default 300, matching today's spawns); `Court` positions the player and partner spawns, miss zones, and right wall from it at startup instead of trusting authored marker positions. The markers stay in the scene for editor preview; runtime truth comes from config.
+The court's crossing distance sets the fun ceiling, so court width is a tunable on `CourtConfig` rather than a baked scene layout. The field is `court_width`, the full paddle-to-paddle span; tech/2026-06-03-surface-physics-ownership-spike covers why it is stored full rather than halved. It has one consumer, the world-max derivation. Spawns, miss zones, and walls are authored marker positions in the scene, not derived from it.
 
-`BALL_WORLD_MAX_SPEED` and the tier bounds derive from it: `crossing = 2 * court_half_width`, `world_max = crossing / fair_crossing_seconds` (about 0.8s). At the default 300 this reproduces the 720 ceiling. Widen the court and the fair ceiling rises with the crossing; past about 860px/s the collider-face dial (above) is what keeps it tunnel-safe.
+`BALL_WORLD_MAX_SPEED` and the tier bounds derive from it: `world_max = court_width / fair_crossing_seconds` (about 0.8s). At the default 600 this reproduces the 720 ceiling. Widen the court and the fair ceiling rises with the crossing; past about 860px/s the collider-face dial (above) is what keeps it tunnel-safe.
 
 ## Migration notes
 

--- a/designs/01-prototype/INDEX.md
+++ b/designs/01-prototype/INDEX.md
@@ -41,5 +41,6 @@ The public demo on itch.io. Core loop, first-pass assets, playable by strangers.
 | 20 | [Ball Speed Tiers and Physics Ceiling](20-ball-speed-tiers.md) |
 | 20a | [Ball Speed Tier Progression](20a-ball-speed-tier-progression.md) |
 | 21 | [Ball Lifecycle](tech/02-ball-lifecycle.md) |
+|    | - [Surface Physics Ownership (spike)](tech/2026-06-03-surface-physics-ownership-spike.md) |
 | 22 | [Levitation Progression](design/levitation-progression.md) |
 | 23 | [Soul](design/soul.md) |

--- a/designs/01-prototype/tech/2026-06-03-surface-physics-ownership-spike.md
+++ b/designs/01-prototype/tech/2026-06-03-surface-physics-ownership-spike.md
@@ -10,15 +10,15 @@ This finishes the cleanup #724 began. That fix pulled the apex bound out of `Cou
 
 The current code asserts the opposite. `Ball.enter_out_rest` overrides the state config's damping from `court_config.rest_roll_damping`, with a comment calling damping "a court-tunable, not a ball-state-tunable." That assumption is wrong: the venue rolls and rests balls too, so resting is not exclusive to the court. A value scoped to the court leaves the venue case homeless.
 
-Decide a ball-behaviour value's owner by where the behaviour happens. Resting happens in both court and venue, so damping belongs to the thing that travels with the ball across both: its rest state. `out_rest.tres` already drives the rest state's other physics flags (gravity, collision, material); damping joins them, and the `CourtConfig` field plus its override disappear.
+Decide a ball-behaviour value's owner by where the behaviour happens. Resting happens in both court and venue, so damping belongs to the thing that travels with the ball across both: its rest state. `out_rest.tres` already holds the rest state's other physics flags (gravity, collision, material); damping joins them, and the `CourtConfig` field plus its override disappear.
 
-## Why the surface material is not ball-only
+## Why the surface material is a contact property
 
-A bounce is an interaction between two bodies. Godot 2D combines the materials of both contacts; with the engine defaults, an absent material on one side reads as bounce 0, and the combined restitution collapses toward zero. So `play.tres` (bounce 1) on the court walls is load-bearing: the ball's own material supplies one half of the bounce, the wall supplies the other. Removing the wall's material to make the ball "own" the surface would kill the bounce.
+A bounce is an interaction between two bodies. Godot 2D combines the materials of both contacts; with the engine defaults, an absent material on one side reads as bounce 0, and the combined restitution collapses toward zero ([PhysicsMaterial](https://docs.godotengine.org/en/stable/classes/class_physicsmaterial.html)). So `play.tres` (bounce 1) on the court walls is load-bearing: the ball's own material supplies one half of the bounce, the wall supplies the other. Removing the wall's material to make the ball "own" the surface would kill the bounce.
 
 This combine reasoning follows Godot's documented material defaults and is not verified in a running scene here; confirming the exact restitution under combine is implementation-ride work, not part of this spike. The decision does not depend on the precise figure: removing a material can only reduce a bounce, never raise it, so the conclusion (keep the wall material) holds either way.
 
-The kernel worth keeping from the original SurfaceConfig idea is real but lives on the world side, not the ball: a surface has a character (friction, bounce, and a roll damping the ball adopts while resting on it) that today has no single named source. That is a venue-surface concern, surfacing only once venues need to differ. It is out of scope here and files as its own work when a venue demands a distinct surface.
+The kernel worth keeping from the original SurfaceConfig idea is real but lives on the world side, not the ball: a surface has a character (friction, bounce, and a roll damping the ball adopts while resting on it) that today has no single named source. That is a venue-surface concern, emerging only once venues need to differ. It is out of scope here and files as its own work when a venue demands a distinct surface.
 
 ## Why width is stored full, not half
 
@@ -37,7 +37,7 @@ After the change, `CourtConfig` holds only the geometry row (with `court_half_wi
 
 ## Collision-layer constants: deferred
 
-Two layers carry the game: world and items. The integer references spread across 14 sites in three artifact kinds (four imperative script callsites, three ball-state resources, seven baked scene nodes). A GDScript constants module can only reach the four script callsites; resources and scenes store raw integers and cannot reference a const. The hardest-to-audit sites, the scenes, stay raw either way. The layer names already live in `project.godot` (layer 1 world, layer 2 items), which is the engine's own legibility mechanism. A constants module is a partial win whose cost exceeds its benefit at two layers and stable semantics. Revisit if a third layer lands with real script consumers.
+Two layers carry the game: world and items. The integer references spread across 14 sites in three artifact kinds (four imperative script callsites, three ball-state resources, seven baked scene nodes). A GDScript constants module can only reach the four script callsites; resources and scenes store raw integers and cannot reference a const. The hardest-to-audit sites, the scenes, stay raw either way. The layer names already live in `project.godot` (layer 1 world, layer 2 items), which is the engine's own legibility mechanism. With only two layers and semantics that have held stable, a constants module is a partial win whose cost exceeds its benefit. Revisit if a third layer lands with real script consumers.
 
 ## Out of scope
 

--- a/designs/01-prototype/tech/2026-06-03-surface-physics-ownership-spike.md
+++ b/designs/01-prototype/tech/2026-06-03-surface-physics-ownership-spike.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-Rest-roll damping is a property of the ball's rest state, not the court. It moves from `CourtConfig.rest_roll_damping` onto `BallStateConfig` (authored in `out_rest.tres`), and the imperative override in `Ball.enter_out_rest` retires. The surface bounce materials (`play.tres`, `rest.tres`) stay where they are: they are contact properties shared between the ball and the world body it strikes, not ball-only state. Collision-layer constants stay as they are; a named module is deferred.
+Rest-roll damping is a property of the ball's rest state, not the court. It moves from `CourtConfig.rest_roll_damping` onto `BallStateConfig` (authored in `out_rest.tres`), and the imperative override in `Ball.enter_out_rest` retires. The surface bounce materials (`play.tres`, `rest.tres`) stay where they are: they are contact properties shared between the ball and the world body it strikes, not ball-only state. Collision-layer constants stay as they are; a named module is deferred. `CourtConfig.court_half_width` becomes `court_width`: width is width, stored full, with no derived role beyond the one consumer that reads it.
 
 This finishes the cleanup #724 began. That fix pulled the apex bound out of `CourtConfig` (onto the `SoulBound` marker) while separating the court's collision floor from the apex wall. The remainder is the damping field and the question of who owns the surface materials.
 
@@ -20,6 +20,10 @@ This combine reasoning follows Godot's documented material defaults and is not v
 
 The kernel worth keeping from the original SurfaceConfig idea is real but lives on the world side, not the ball: a surface has a character (friction, bounce, and a roll damping the ball adopts while resting on it) that today has no single named source. That is a venue-surface concern, surfacing only once venues need to differ. It is out of scope here and files as its own work when a venue demands a distinct surface.
 
+## Why width is stored full, not half
+
+`CourtConfig` stores `court_half_width`, but its only consumer is `world_max_speed`, which immediately doubles it to recover the full crossing span. The docstring claims the half-value seeds spawns and miss zones, but nothing reads it for that: the spawns are literal positions in `court.tscn`, not derived from the field. So the half is a number nobody halves around, read once and doubled. The field becomes `court_width`, holding the full paddle-to-paddle span; `world_max_speed` reads it directly and the doubling drops. Width is width, with no derived role.
+
 ## Surfaces today
 
 | Value | Lives in | Applied where |
@@ -27,9 +31,9 @@ The kernel worth keeping from the original SurfaceConfig idea is real but lives 
 | Bounce material (friction 0, bounce 1) | `resources/ball/play.tres` | `ball.tscn` default; ball `play_active` state; court walls and floor in `court.tscn` |
 | Rest material (friction 1, bounce 0) | `resources/ball/rest.tres` | ball `out_rest` state (`out_rest.tres`) |
 | Rest-roll damping | `CourtConfig.rest_roll_damping` | overridden onto the ball's `linear_damp` in `Ball.enter_out_rest` |
-| Court geometry (half width, crossing seconds, relock ramp) | `CourtConfig` | ball speed and relock logic |
+| Court geometry (`court_half_width`, crossing seconds, relock ramp) | `CourtConfig` | ball speed and relock logic |
 
-After the change, `CourtConfig` holds only the geometry row, and rest damping joins the rest material in `out_rest.tres`.
+After the change, `CourtConfig` holds only the geometry row (with `court_half_width` reshaped to a full `court_width`), and rest damping joins the rest material in `out_rest.tres`.
 
 ## Collision-layer constants: deferred
 

--- a/designs/01-prototype/tech/2026-06-03-surface-physics-ownership-spike.md
+++ b/designs/01-prototype/tech/2026-06-03-surface-physics-ownership-spike.md
@@ -1,0 +1,42 @@
+# Surface Physics Ownership Spike
+
+## Decision
+
+Rest-roll damping is a property of the ball's rest state, not the court. It moves from `CourtConfig.rest_roll_damping` onto `BallStateConfig` (authored in `out_rest.tres`), and the imperative override in `Ball.enter_out_rest` retires. The surface bounce materials (`play.tres`, `rest.tres`) stay where they are: they are contact properties shared between the ball and the world body it strikes, not ball-only state. Collision-layer constants stay as they are; a named module is deferred.
+
+This finishes the cleanup #724 began. That fix pulled the apex bound out of `CourtConfig` (onto the `SoulBound` marker) while separating the court's collision floor from the apex wall. The remainder is the damping field and the question of who owns the surface materials.
+
+## Why rest damping is ball state, not court
+
+The current code asserts the opposite. `Ball.enter_out_rest` overrides the state config's damping from `court_config.rest_roll_damping`, with a comment calling damping "a court-tunable, not a ball-state-tunable." That assumption is wrong: the venue rolls and rests balls too, so resting is not exclusive to the court. A value scoped to the court leaves the venue case homeless.
+
+Decide a ball-behaviour value's owner by where the behaviour happens. Resting happens in both court and venue, so damping belongs to the thing that travels with the ball across both: its rest state. `out_rest.tres` already drives the rest state's other physics flags (gravity, collision, material); damping joins them, and the `CourtConfig` field plus its override disappear.
+
+## Why the surface material is not ball-only
+
+A bounce is an interaction between two bodies. Godot 2D combines the materials of both contacts; with the engine defaults, an absent material on one side reads as bounce 0, and the combined restitution collapses toward zero. So `play.tres` (bounce 1) on the court walls is load-bearing: the ball's own material supplies one half of the bounce, the wall supplies the other. Removing the wall's material to make the ball "own" the surface would kill the bounce.
+
+This combine reasoning follows Godot's documented material defaults and is not verified in a running scene here; confirming the exact restitution under combine is implementation-ride work, not part of this spike. The decision does not depend on the precise figure: removing a material can only reduce a bounce, never raise it, so the conclusion (keep the wall material) holds either way.
+
+The kernel worth keeping from the original SurfaceConfig idea is real but lives on the world side, not the ball: a surface has a character (friction, bounce, and a roll damping the ball adopts while resting on it) that today has no single named source. That is a venue-surface concern, surfacing only once venues need to differ. It is out of scope here and files as its own work when a venue demands a distinct surface.
+
+## Surfaces today
+
+| Value | Lives in | Applied where |
+|---|---|---|
+| Bounce material (friction 0, bounce 1) | `resources/ball/play.tres` | `ball.tscn` default; ball `play_active` state; court walls and floor in `court.tscn` |
+| Rest material (friction 1, bounce 0) | `resources/ball/rest.tres` | ball `out_rest` state (`out_rest.tres`) |
+| Rest-roll damping | `CourtConfig.rest_roll_damping` | overridden onto the ball's `linear_damp` in `Ball.enter_out_rest` |
+| Court geometry (half width, crossing seconds, relock ramp) | `CourtConfig` | ball speed and relock logic |
+
+After the change, `CourtConfig` holds only the geometry row, and rest damping joins the rest material in `out_rest.tres`.
+
+## Collision-layer constants: deferred
+
+Two layers carry the game: world and items. The integer references spread across 14 sites in three artifact kinds (four imperative script callsites, three ball-state resources, seven baked scene nodes). A GDScript constants module can only reach the four script callsites; resources and scenes store raw integers and cannot reference a const. The hardest-to-audit sites, the scenes, stay raw either way. The layer names already live in `project.godot` (layer 1 world, layer 2 items), which is the engine's own legibility mechanism. A constants module is a partial win whose cost exceeds its benefit at two layers and stable semantics. Revisit if a third layer lands with real script consumers.
+
+## Out of scope
+
+- The single-source surface-character question (a venue's friction, bounce, and rest damping in one named resource). Files as its own work when venues need to differ.
+- The collision-layer constants module. Deferred per above.
+- Layer 4 on the venue side-bounds, used by no script. A venue-collision audit concern, not this.


### PR DESCRIPTION
SH-425 asks for the physics-config grab-bag to be consolidated into named, single-source resources. Before changing any code, this records the decision the spike reached, so the reasoning lives in the tree rather than in a commit message or someone's head (which is how the contradicted comment in `Ball.enter_out_rest` came to exist).

The spike found three things. Rest-roll damping belongs to the ball's rest state, not the court: the venue rolls and rests balls too, so a court-scoped value leaves the venue case homeless. The bounce material cannot move onto the ball alone, because a bounce is a contact between two bodies and the wall supplies half of it; stripping the wall's material would collapse the restitution. And the collision-layer constants module is deferred, because it would only reach the four script callsites while the resources and baked scenes keep raw integers, and the layer names already live in `project.godot`.

The code change that follows (absorbing `rest_roll_damping` into `BallStateConfig`) lands as a separate PR off main once this merges.

The combine-mode reasoning behind "the wall material is load-bearing" follows Godot's documented material defaults and is not verified in a running scene; that confirmation is implementation-ride work. The decision does not depend on the exact figure, since removing a material can only reduce a bounce.