### PR TITLE
refactor: move rest-roll damping to BallStateConfig, rename court_half_width

### DIFF
--- a/resources/ball/states/out_rest.tres
+++ b/resources/ball/states/out_rest.tres
@@ -9,3 +9,4 @@ collision_layer = 2
 collision_mask = 3
 gravity_scale = 1.0
 physics_material_override = ExtResource("2")
+linear_damp = 1.5

--- a/resources/court_config.tres
+++ b/resources/court_config.tres
@@ -4,4 +4,4 @@
 
 [resource]
 script = ExtResource("1_courtcfg")
-court_half_width = 300.0
+court_width = 600.0

--- a/scripts/core/court_config.gd
+++ b/scripts/core/court_config.gd
@@ -1,19 +1,16 @@
 class_name CourtConfig
 extends Resource
 
-## Per-court tunables: court width, soul-bound height, ramp duration, rest-roll damping.
+## Per-court tunables: court width, soul-bound height, ramp duration.
 
-## Half the court's paddle-to-paddle span in pixels; spawns, miss zones, and the world speed max derive from it.
-@export var court_half_width: float = 300.0
+## Full paddle-to-paddle court span in pixels; the world speed max derives from it.
+@export var court_width: float = 600.0
 ## Seconds a fair crossing must outlast so the receiver can move and react; sets the world speed max against the crossing.
 @export var fair_crossing_seconds: float = 0.833333
 ## Speed-relock ramp duration in seconds; 0.0 snaps the speed to the tracked entry value instantly.
 @export var relock_ramp_seconds: float = 0.12
-## Linear damping applied while the missed ball rolls to rest on the venue floor.
-# TODO(SH-394): move into a SurfaceConfig that also owns the floor PhysicsMaterial.
-@export var rest_roll_damping: float = 1.5
 
 
-## Top speed any ball may reach, derived from the court crossing: 2 * half_width / fair_crossing_seconds.
+## Top speed any ball may reach, derived from the court crossing: court_width / fair_crossing_seconds.
 func world_max_speed() -> float:
-	return (2.0 * court_half_width) / fair_crossing_seconds
+	return court_width / fair_crossing_seconds

--- a/scripts/core/court_config.gd
+++ b/scripts/core/court_config.gd
@@ -1,7 +1,7 @@
 class_name CourtConfig
 extends Resource
 
-## Per-court tunables: court width, soul-bound height, ramp duration.
+## Per-court tunables: court width, fair-crossing time, and the speed-relock ramp.
 
 ## Full paddle-to-paddle court span in pixels; the world speed max derives from it.
 @export var court_width: float = 600.0

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -250,8 +250,6 @@ func enter_play() -> void:
 func enter_out_rest() -> void:
 	_suppress_miss_detection = false
 	OUT_REST_CONFIG.apply(self)
-	# Damping is a court-tunable, not a ball-state-tunable; override the .tres default with the court value.
-	linear_damp = court_config.rest_roll_damping
 	current_tier = 0
 	in_final = false
 	speed = tier_floor

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -250,6 +250,7 @@ func enter_play() -> void:
 func enter_out_rest() -> void:
 	_suppress_miss_detection = false
 	OUT_REST_CONFIG.apply(self)
+
 	current_tier = 0
 	in_final = false
 	speed = tier_floor

--- a/scripts/entities/ball/ball_state_config.gd
+++ b/scripts/entities/ball/ball_state_config.gd
@@ -12,6 +12,8 @@ extends Resource
 @export var gravity_scale: float = 0.0
 ## Friction / bounce profile for collisions. Null disables material-driven response.
 @export var physics_material_override: PhysicsMaterial
+## Linear damping coefficient applied to the body; 0 leaves velocity unchanged per frame.
+@export var linear_damp: float = 0.0
 
 
 func apply(body: RigidBody2D) -> void:
@@ -20,3 +22,4 @@ func apply(body: RigidBody2D) -> void:
 	body.collision_mask = collision_mask
 	body.gravity_scale = gravity_scale
 	body.physics_material_override = physics_material_override
+	body.linear_damp = linear_damp

--- a/tests/unit/ball/test_ball_side_miss.gd
+++ b/tests/unit/ball/test_ball_side_miss.gd
@@ -17,7 +17,6 @@ func before_each() -> void:
 	add_child_autofree(_manager)
 
 	_config = load("res://scripts/core/court_config.gd").new()
-	_config.rest_roll_damping = REST_DAMPING
 
 	_ball = load("res://scripts/entities/ball/ball.gd").new()
 	_ball._item_manager = _manager

--- a/tests/unit/ball/test_ball_side_miss.gd
+++ b/tests/unit/ball/test_ball_side_miss.gd
@@ -1,7 +1,7 @@
 ## Side-miss transition: PLAY -> OUT_REST keeps velocity, engages gravity and damping.
 extends GutTest
 
-const REST_DAMPING := 1.5
+const OUT_REST_CONFIG: BallStateConfig = preload("res://resources/ball/states/out_rest.tres")
 
 var _ball: Ball
 var _config: CourtConfig
@@ -43,7 +43,7 @@ func test_miss_engages_gravity_and_damping() -> void:
 	_ball.linear_damp = 0.0
 	_ball.missed.emit(_ball)
 	assert_almost_eq(_ball.gravity_scale, 1.0, 0.001)
-	assert_almost_eq(_ball.linear_damp, REST_DAMPING, 0.001)
+	assert_almost_eq(_ball.linear_damp, OUT_REST_CONFIG.linear_damp, 0.001)
 
 
 func test_miss_resets_speed_scalar_for_next_rally() -> void:

--- a/tests/unit/ball/test_ball_state_transitions.gd
+++ b/tests/unit/ball/test_ball_state_transitions.gd
@@ -20,7 +20,6 @@ func before_each() -> void:
 	add_child_autofree(_manager)
 
 	_config = load("res://scripts/core/court_config.gd").new()
-	_config.rest_roll_damping = REST_DAMPING
 
 	_ball = load("res://scripts/entities/ball/ball.gd").new()
 	_ball._item_manager = _manager

--- a/tests/unit/ball/test_ball_state_transitions.gd
+++ b/tests/unit/ball/test_ball_state_transitions.gd
@@ -1,7 +1,6 @@
 ## State-transition surface: enter_stored / enter_play / enter_out_rest / enter_out_held property values.
 extends GutTest
 
-const REST_DAMPING := 1.5
 const BOUND_Y := -351.6
 const PLAY_ACTIVE_CONFIG: BallStateConfig = preload("res://resources/ball/states/play_active.tres")
 const OUT_REST_CONFIG: BallStateConfig = preload("res://resources/ball/states/out_rest.tres")
@@ -94,7 +93,7 @@ func test_enter_out_rest_sets_property_values() -> void:
 	assert_eq(_ball.play_state, Ball.PlayState.OUT_REST)
 	assert_false(_ball.freeze)
 	assert_almost_eq(_ball.gravity_scale, 1.0, 0.001)
-	assert_almost_eq(_ball.linear_damp, REST_DAMPING, 0.001)
+	assert_almost_eq(_ball.linear_damp, OUT_REST_CONFIG.linear_damp, 0.001)
 	assert_eq(_ball.collision_layer, OUT_REST_CONFIG.collision_layer)
 	assert_eq(_ball.collision_mask, OUT_REST_CONFIG.collision_mask)
 


### PR DESCRIPTION
Damping (1.5) moves out of `CourtConfig` into `out_rest.tres` and is applied by `BallStateConfig.apply()`; the manual override in `Ball.enter_out_rest()` and `CourtConfig.rest_roll_damping` are deleted. `court_half_width` (300.0) is renamed `court_width` (600.0) and `world_max_speed()` drops the 2× factor, yielding the same ~720 px/s result.

Agent-Role: gdscript-implementer