### PR TITLE
test: behavioural test-suite refactor

### DIFF
--- a/.claude/skills/commits/SKILL.md
+++ b/.claude/skills/commits/SKILL.md
@@ -33,9 +33,15 @@ For breaking changes (save wipes, API renames, workflow-input shifts), use `feat
 
 ## Issue references
 
-**GitHub issue IDs (`#N`) are the primary surface.** The repo is open source; readers of commits and PRs follow GitHub links, not Linear. Reference the GitHub issue with a bare `#123` (just the number, no leading verb) in the commit body or PR body: GitHub backlinks them, and the branch name (not the body) is what advances the Linear issue on merge. Linear IDs (`SH-N`) are private and never appear in commit messages or PR bodies. The branch name carries the Linear context for internal tooling; that is enough.
+**GitHub IDs (`#N`) are the only ID on every open surface, branch names included.** The repo is open source; readers follow GitHub links, not Linear. The branch is `feature/<gh-number>-<slug>` (the GitHub issue number, no `sh-` prefix, no `gh-` prefix). Reference the GitHub issue with a bare `#123` (just the number, no leading verb) in the commit body or PR body. Linear IDs (`SH-N`) are private and appear on no open surface: not the branch, not the title, not the body, not commits, not comments. When a branch covers two issues, chain the numbers: `feature/691-692-slug`.
 
-The bare reference is the one to reach for. A leading GitHub action-verb on the issue number fires GitHub's own issue-close on merge, which overshoots the Linear issue two states past where the branch-name integration leaves it. See [`designs/ai/lane-semantics.md`](../../../designs/ai/lane-semantics.md).
+The bare `#N` is the reference to reach for. A leading GitHub action-verb (`closes #N`) fires GitHub's own issue-close on merge; we do not want that. See [`designs/ai/lane-semantics.md`](../../../designs/ai/lane-semantics.md).
+
+**Linear transitions: the Shuck team PR automations move the issue on PR state** (draft open to Dispatched, marked-ready to Challenged, no action on merge so Completed is manual). BUT those automations only fire on a PR that Linear has *linked* to the issue, and Linear forms that link by finding a Linear ID (`SH-N`) in the branch name, PR title, or PR body. A fully GitHub-facing PR with no `SH-N` anywhere is unlinked, so it drives no transition.
+
+The reconciliation, while branches stay GitHub-facing: create the link once, by hand, via the Linear issue's "Link GitHub PR" (or paste the PR URL into the issue). Once the attachment exists the state automations follow the PR. Do not put `SH-N` on an open surface to get the link. Confirm the link landed with a Linear read; do not assume the PR moved the issue.
+
+**Multi-PR caveat.** A Linear issue can link several PRs, but the automation is an AND: the status only moves when the *final* linked PR reaches the state. So a stale link to a closed-without-merge PR can stall the transition (it never reaches merge). If you replace a PR (close one, open another for the same issue), unlink the dead PR from the issue so the live PR is the only linked target. A closed PR does not auto-unlink and a replacement does not auto-link; both are manual.
 
 ## Branch discipline
 

--- a/.claude/skills/commits/SKILL.md
+++ b/.claude/skills/commits/SKILL.md
@@ -39,9 +39,16 @@ The bare `#N` is the reference to reach for. A leading GitHub action-verb (`clos
 
 **Linear transitions: the Shuck team PR automations move the issue on PR state** (draft open to Dispatched, marked-ready to Challenged, no action on merge so Completed is manual). BUT those automations only fire on a PR that Linear has *linked* to the issue, and Linear forms that link by finding a Linear ID (`SH-N`) in the branch name, PR title, or PR body. A fully GitHub-facing PR with no `SH-N` anywhere is unlinked, so it drives no transition.
 
-The reconciliation, while branches stay GitHub-facing: create the link once, by hand, via the Linear issue's "Link GitHub PR" (or paste the PR URL into the issue). Once the attachment exists the state automations follow the PR. Do not put `SH-N` on an open surface to get the link. Confirm the link landed with a Linear read; do not assume the PR moved the issue.
+The reconciliation, while branches stay GitHub-facing: link the PR yourself. The MCP Linear tools do not expose attachment linking, but the raw GraphQL API does. Script it with `$LINEAR_API_KEY` against `https://api.linear.app/graphql` using `attachmentLinkGitHubPR` with `issueId`, `url`, and a `linkKind` (the `GitLinkKind` enum). `attachmentDelete` drops a link. Do not put `SH-N` on an open surface to get the link. Confirm the link landed with a Linear read; do not assume the PR moved the issue.
 
-**Multi-PR caveat.** A Linear issue can link several PRs, but the automation is an AND: the status only moves when the *final* linked PR reaches the state. So a stale link to a closed-without-merge PR can stall the transition (it never reaches merge). If you replace a PR (close one, open another for the same issue), unlink the dead PR from the issue so the live PR is the only linked target. A closed PR does not auto-unlink and a replacement does not auto-link; both are manual.
+**`linkKind` is the relationship, and it is what handles multi-PR.** The enum (matching the UI picker):
+- `closes` ("Resolves"), the PR resolves the issue on merge. Use for a single-PR issue.
+- `contributes` ("Contributes to"), one of several PRs; moves the issue but does not solo-resolve. **Use this for every PR on a multi-PR issue.**
+- `links` ("Related to"), reference only, no status automation.
+
+The merge automation is an AND across linked PRs: the issue only reaches the terminal state when the *final* contributing PR merges. So linking each PR as `contributes` (not `closes`) is what stops one early merge from completing the issue; you do not need to delete attachments to manage it. A closed or replaced PR does not auto-unlink, so set it to `links` or `attachmentDelete` it if its stale `closes` / `contributes` would skew the AND.
+
+Note for the Shuck team specifically: merge is set to no-action, so no `linkKind` completes an issue on merge today (Completed is always manual). The `closes` / `contributes` distinction still matters if that mapping is ever turned on, and `links` vs the others still controls whether the open / ready automations fire at all.
 
 ## Branch discipline
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -35,7 +35,7 @@ Worktree isolation is a per-dispatch choice, not a forced rule (the gate hook wa
 
 Tier 2 work (runtime / `run(play)`) is exclusive: only one minion at a time runs at Tier 2. Constraint is one-at-a-time, not Josh sign-off.
 
-When dispatching a minion onto a Linear issue, brief the agent to create the worktree on a properly named feature branch: `feature/sh-XXX-short-description`. The Agent tool's `isolation: "worktree"` defaults the branch name to the worktree slug (`worktree-agent-aXXXXXX`); that's an internal name, not a feature branch. SH-288 / PR #506 shipped on the slug name because the dispatch brief never named the branch. Future dispatches: include the branch name in the brief.
+When dispatching a minion onto a Linear issue, brief the agent to create the worktree on a properly named feature branch: `feature/<gh-number>-<short-description>`, using the GitHub issue number (from the Linear issue's GitHub mirror attachment), not the Linear `SH-N`. All branches are GitHub-facing, internal worktree branches included. The Agent tool's `isolation: "worktree"` defaults the branch name to the worktree slug (`worktree-agent-aXXXXXX`); that's an internal name, not a feature branch. SH-288 / PR #506 shipped on the slug name because the dispatch brief never named the branch. Future dispatches: include the branch name in the brief, with the resolved GitHub number.
 
 ## Background by default
 
@@ -61,7 +61,7 @@ Every implementer brief opens with: read `.claude/skills/code-comments/SKILL.md`
 
 Every code-writing minion runs this sequence once dispatched. Brief them on it in the dispatch prompt, or point them at this section.
 
-1. **Claim the ticket.** Every branch carries its Linear ticket ID. For chore or infra work with no SH-N, file first via `./scripts/dev/new-ticket.sh "<title>"` (Backlog, Feature, Josh-assigned, estimate 0, auto-slotted into the active cycle). Branch name is `feature/sh-<N>-<slug>`. Commit the claim on the branch, never on `main`.
+1. **Claim the ticket.** Resolve the issue's GitHub mirror number (`#N`); the branch carries that, not the Linear `SH-N`. For chore or infra work with no ticket, file first via `./scripts/dev/new-ticket.sh "<title>"` (Backlog, Feature, Josh-assigned, estimate 0, auto-slotted into the active cycle). Branch name is `feature/<gh-number>-<slug>` (no `sh-`/`gh-` prefix). Commit the claim on the branch, never on `main`. The branch carries no Linear ID; link the PR to the issue after it opens (see `.claude/skills/commits/SKILL.md`, "Issue references").
 2. **Cycle placement.** If the claimed ticket has no cycle, move it into the active one: `mcp__linear__list_cycles(teamId, type: "current")` then `mcp__linear__save_issue(id, cycleId)`. Skip if no active cycle.
 3. **Log progress in Linear.** Significant moments (claim, blocker, ready-for-review) post as a Linear comment on the ticket, not into a shared file. The git log carries the rest.
 4. **Sync before opening and before every later push.** `git fetch origin main && git merge origin/main`, resolve, re-run `./scripts/ci/run_gut.sh`, push. Repeat any time work resumes or before asking Josh to merge. `git rev-list --count HEAD..origin/main` reads "behind by N".
@@ -73,7 +73,7 @@ Every code-writing minion runs this sequence once dispatched. Brief them on it i
 
 - **Backlog shape is Josh's, end to end.** Minions do not create, draft, or pre-format Linear issues. They surface observations in prose ("the equip path also writes to X without a placement update"); they do not write candidate titles, acceptance criteria, or "follow-up tickets we should file" lists. Whether something is a ticket, what its title is, what its AC reads, is Josh's call. The rule applies when the ticket AC says "file tickets", when a spike's output is a migration plan, when a bug shows up mid-task, and when the minion has Linear write tools available.
 - **One ticket, one minion, one branch, one worktree.** Never two minions in the same file. Check what's in flight (see below) before claiming. Sub-agents modifying the repo dispatch with `isolation: "worktree"`.
-- **Worktree cleanup on merge.** After a challenge merges: `git worktree remove ../volley-sh-N && git branch -D sh-N-...`. The owning agent is responsible; otherwise periodic `git worktree list && git worktree prune`.
+- **Worktree cleanup on merge.** After a challenge merges: `git worktree remove ../volley-<gh-number> && git branch -D feature/<gh-number>-...`. The owning agent is responsible; otherwise periodic `git worktree list && git worktree prune`.
 - **Engineer challenges to merge in any order.** Each challenge stands alone against current `main`. Combine related changes that share a file rather than splitting them. Avoid "depends on #X".
 - **Verify, don't assume.** Every change needs evidence: tool output or tests, not "looks correct".
 - **Merge queue serialises `main`.** "Merge when ready" pulls the challenge into a `merge_group` ref, re-runs lint and tests against `main + challenge`, then fast-forwards `main`. The pre-challenge `git merge origin/main` still matters: the queue catches mechanical staleness, not semantic conflicts.

--- a/designs/ai/lane-semantics.md
+++ b/designs/ai/lane-semantics.md
@@ -14,9 +14,11 @@ Two states sit off to the side. Triage holds incoming external work before it jo
 
 The order alone is not enough; each transition has a concrete trigger, and getting the trigger right is what matters.
 
-**Vault** is the backlog: work to be done someday. **Ready** is work planned for a cycle, promoted by Josh, who owns cycle membership. **Dispatched** means an agent is actively working the issue; it flips the moment the work is dispatched, not when the issue is merely picked up. **Challenged** means the pull request is open and the work is up for review; it moves the instant the PR opens, not at merge.
+**Vault** is the backlog: work to be done someday. **Ready** is work planned for a cycle, promoted by Josh, who owns cycle membership. **Dispatched** means an agent is actively working the issue. **Challenged** means the pull request is open and the work is up for review.
 
-**Completed means the work merged.** That is the whole meaning. Linear's branch-name integration sets it automatically when the PR merges, so no manual move and no close trailer are needed. Verification does not live here.
+These two transitions are driven by the Shuck team's PR automations: a draft PR opening moves the issue to Dispatched, marking it ready-for-review moves it to Challenged. The automations only fire on a PR that Linear has linked to the issue, and because branches are GitHub-facing (no `SH-N`), that link is made by hand once the PR is up (see `.claude/skills/commits/SKILL.md`, "Issue references"). Link the PR, then the state follows it.
+
+**Completed means the work merged.** That is the whole meaning. Merge is deliberately set to no-action in the team automations, so reaching Completed is a manual move (never a close trailer, which overshoots). Verification does not live here.
 
 **Closed means the work was released to production** through the cycle release carnival. The carnival is itself the regression test, the gate that confirms nothing else broke before shipping. The release pipeline sets Closed; it is never a hand-move and never something a PR merge should reach.
 
@@ -26,6 +28,6 @@ Verification lives in the Ride, not on the issue. A Ride is Josh playtesting the
 
 **Forward only.** Once an issue advances, it never moves to an earlier state, even when a rework cycle tempts a move back to Dispatched. The state records the most-advanced step the work has reached. The one genuine exception is regression: when a Ride or post-merge playtest catches an already-Completed fix breaking again, the issue reopens forward to Ready because the work is genuinely re-opened, not because a state was overshot.
 
-**Reference an issue with a bare number.** A PR that links an issue does so with the number on its own (`#123`), nothing in front of it. The branch-name integration already moves the issue to Completed on merge, so the body only needs to backlink, and the bare reference is exactly that. Putting a GitHub action-verb ahead of the number is the trap: that fires GitHub's own issue-close on merge, which drags the linked Linear issue past Completed all the way to Closed, two states too far, and falsely reads as released.
+**Reference an issue with a bare number.** A PR that links an issue does so with the number on its own (`#123`), nothing in front of it. Completed is a manual move on merge (the team merge automation is no-action), so the body only needs to backlink, and the bare reference is exactly that. Putting a GitHub action-verb ahead of the number is the trap: that fires GitHub's own issue-close on merge, which drags the linked Linear issue all the way to Closed, falsely reading as released.
 
 This is the rule that drifts. Roughly one in four PRs has historically tripped it, and the cleanup is manual every time. The branch name, not the PR body, is what should drive Linear movement; the body's job is the bare backlink.

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -27,7 +27,7 @@ func before_each() -> void:
 
 ### Only stub what you can't instantiate
 
-The only stub is `hud_stub.gd` because the real HUD requires a wired-up Label node. If a dependency can be instantiated with minimal setup, use the real thing.
+Reach for a stub in `tests/stubs/` only when the real dependency cannot be instantiated with minimal setup: a node that needs a wired-up scene, an autoload, or a partner that records calls. Current stubs are `paddle_stub`, `ball_stub`, `autoplay_controller_stub`, `recording_partner_paddle_stub`, plus the `item_factory` and `progression_manager_factory` builders. If a dependency instantiates cleanly, use the real thing.
 
 ### Test observable outcomes, not internal state
 
@@ -39,11 +39,11 @@ Don't access private variables (`_streak`, `_volley_count`). Test what the playe
 | `_game._volley_count == 0` | `hud.last_count == 0` |
 | `_ball._hit_cooldown > 0` | Second hit doesn't change pitch |
 
-### Don't call private methods
+### Drive time deterministically; route through public seams
 
-Don't call `_physics_process()` directly to advance time. Use `await get_tree().create_timer(0.25).timeout` so the engine runs real physics frames.
+Advance a system under test by calling its `_physics_process(virtual_delta)` directly with a chosen delta rather than awaiting real frames. This is the project's standing practice for a fast suite (see Test budget below) and it is what unit tests here do. `_physics_process` is the engine's per-frame entry point, so driving it is simulating a frame, not poking private state.
 
-Don't call `_on_paddle_hit()` for routing checks; emit the signal instead: `_paddle.paddle_hit.emit()`.
+For routing and wiring, go through the public seam: emit the signal (`_paddle.paddle_hit.emit()`) rather than calling a private handler like `_on_paddle_hit()`. Assert on public state or emitted signals, never on private fields (see the table above).
 
 ### Step tweens deterministically instead of awaiting real time
 
@@ -67,6 +67,58 @@ This pattern lives in `tests/unit/paddle/test_timeout_controller.gd`.
 
 - **Unit tests** test one component's public methods or verify signal routing by emitting signals directly (`_paddle.paddle_hit.emit()`).
 - **Integration tests** drive the system through its entry points (`_paddle.on_ball_hit()`) and verify the full chain.
+
+## GUT feature reference
+
+GUT 9.x is a third-party Asset Library plugin (`addons/gut/`); Godot 4 ships no built-in test framework. A test file `extends GutTest`; a test is any `func test_*` method. There are no custom display names, the function name is the title, so name it as the behaviour sentence.
+
+### Lifecycle
+
+`before_all` / `before_each` / `after_each` / `after_all`. An inner `class X extends GutTest` is collected as its own group with its own lifecycle hooks; this is the only grouping GUT offers and it is one level deep (no nested-class nesting). Test order within a class is not guaranteed.
+
+### Assertions (the families we use)
+
+| Family | Methods |
+|---|---|
+| Equality | `assert_eq`, `assert_ne`, `assert_almost_eq`, `assert_almost_ne`, `assert_same`, `assert_eq_deep` |
+| Ordering | `assert_gt`, `assert_gte`, `assert_lt`, `assert_lte`, `assert_between` |
+| Truth / null | `assert_true`, `assert_false`, `assert_null`, `assert_not_null` |
+| Type | `assert_is`, `assert_typeof`, `assert_has_method` |
+| Signals | `assert_signal_emitted`, `assert_signal_emitted_with_parameters`, `assert_signal_emit_count`, `assert_has_signal` (call `watch_signals(obj)` first) |
+| Collections | `assert_has`, `assert_does_not_have` |
+| Lifecycle / leaks | `assert_freed`, `assert_not_freed`, `assert_no_new_orphans` |
+| Engine output | `assert_engine_error`, `assert_push_warning` (and their `_count` forms) |
+
+Prefer the signal asserts for behaviour that other systems hear; prefer public-state equality for the rest. The accessor/property assert helpers (`assert_accessors`, `assert_property`, `assert_exports`) pin a getter/setter pair by name, which is implementation, so avoid them unless the accessor contract itself is the player-facing surface.
+
+### Parameterized tests
+
+For a behaviour that is one rule over a table of inputs, use `use_parameters` instead of N near-identical functions. One function runs once per row:
+
+```gdscript
+func test_fill_ratio(p = use_parameters([
+    # [current, min, max, expected_ratio]
+    [400.0, 400.0, 700.0, 0.0],
+    [550.0, 400.0, 700.0, 0.5],
+    [700.0, 400.0, 700.0, 1.0],
+])):
+    _bar.update_speed(p[0], p[0], p[1], p[2])
+    assert_almost_eq(_fill_ratio(), p[3], 0.01)
+```
+
+This is the GUT-native answer to fragmented input-table suites; collapse those rather than copy a function per input.
+
+### Driving and waiting
+
+`simulate(obj, times, delta)` calls `_process`/`_physics_process` a number of times with a fixed delta. For real-frame waits there are `wait_frames`, `wait_physics_frames`, `wait_seconds`, `wait_for_signal`, `wait_until`/`wait_while`, but prefer deterministic stepping (see Test budget) over real-time waits.
+
+### Doubling and stubbing
+
+`double()` / `partial_double()` / `stub()` exist, but this project avoids them: `double()` has a headless-CI cache bug ([#491](https://github.com/bitwes/Gut/issues/491)) and does not simulate physics nodes. Use real instances with `add_child_autofree()`; reach for a hand-written stub in `tests/stubs/` only when a dependency cannot be instantiated cheaply.
+
+### How the suite runs
+
+`.gutconfig.json` drives it: all of `res://tests/`, subdirs included, exit on failure, with `tests/hooks/pre_run_hook.gd` and `post_run_hook.gd` around the run. Filter a run with `-gdir` plus `-gprefix`, e.g. `-gdir=res://tests/unit/ball -gprefix=test_ball_apex`.
 
 ## Real-input rule for player-facing acceptance criteria
 

--- a/tests/unit/ball/test_ball_apex_arc.gd
+++ b/tests/unit/ball/test_ball_apex_arc.gd
@@ -1,4 +1,4 @@
-## Ball state-machine, entry-value register, parabolic arc invariants, and relock-ramp tests.
+## Ball NORMAL <-> ARC transitions across the soul bound.
 extends GutTest
 
 const BOUND_Y := -100.0
@@ -30,203 +30,19 @@ func before_each() -> void:
 	)
 
 
-# --- state machine: starts in PLAY_NORMAL with locked physics ---
-
-
-func test_ball_starts_in_play_normal() -> void:
-	assert_eq(_ball.play_state, Ball.PlayState.PLAY_NORMAL)
-	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)
-	assert_almost_eq(_ball.linear_damp, 0.0, 0.001)
+# --- state machine: NORMAL <-> ARC transitions across the soul bound ---
 
 
 func test_normal_to_arc_on_upward_cross() -> void:
 	watch_signals(_ball)
 	_ball.global_position = Vector2(0.0, BOUND_Y - 10.0)
 	_ball._physics_process(0.016)
-	assert_eq(_ball.play_state, Ball.PlayState.PLAY_ARC)
-	assert_almost_eq(_ball.gravity_scale, 1.0, 0.001)
 	assert_signal_emitted_with_parameters(_ball, "play_state_changed", [Ball.PlayState.PLAY_ARC])
 
 
 func test_arc_to_normal_on_downward_cross() -> void:
-	_ball.global_position = Vector2(0.0, BOUND_Y - 10.0)
-	_ball._physics_process(0.016)
-	assert_eq(_ball.play_state, Ball.PlayState.PLAY_ARC, "precondition: ball entered ARC")
+	watch_signals(_ball)
+	_ball.set_play_state(Ball.PlayState.PLAY_ARC)
 	_ball.global_position = Vector2(0.0, BOUND_Y + 10.0)
 	_ball._physics_process(0.016)
-	assert_eq(_ball.play_state, Ball.PlayState.PLAY_NORMAL)
-	assert_almost_eq(_ball.gravity_scale, 0.0, 0.001)
-	assert_almost_eq(_ball.linear_damp, 0.0, 0.001)
-
-
-# --- entry-value register: persistent, set on first cross, updated by speed events in ARC ---
-
-
-func test_entry_speed_set_on_first_upward_cross() -> void:
-	var entry: float = _ball.min_speed * 1.3
-	_ball.speed = entry
-	_ball.effect_processor.sync_base_speed()
-	_ball.linear_velocity = Vector2(0.0, -entry)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	assert_almost_eq(_ball.entry_speed, entry, 0.5)
-
-
-func test_entry_speed_not_reset_on_subsequent_cross() -> void:
-	var first: float = _ball.min_speed * 1.3
-	var second: float = _ball.min_speed * 1.7
-	_ball.speed = first
-	_ball.effect_processor.sync_base_speed()
-	_ball.linear_velocity = Vector2(0.0, -first)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	_ball.global_position = Vector2(0.0, BOUND_Y + 5.0)
-	_ball._physics_process(0.016)
-	_ball.speed = second
-	_ball.linear_velocity = Vector2(0.0, -second)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	assert_almost_eq(
-		_ball.entry_speed, first, 0.5, "register persists across crosses; first value remains."
-	)
-
-
-func test_speed_change_in_arc_updates_entry_value() -> void:
-	var entry: float = _ball.min_speed * 1.1
-	_ball.speed = entry
-	_ball.effect_processor.sync_base_speed()
-	_ball.linear_velocity = Vector2(0.0, -entry)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	assert_almost_eq(_ball.entry_speed, entry, 0.5)
-	_ball.increase_speed()
-	assert_almost_eq(
-		_ball.entry_speed,
-		_ball.speed,
-		0.5,
-		"in-ARC speed-change events update the tracked entry value"
-	)
-
-
-# --- parabolic arc invariants: ball.gd does not bend velocity or hold magnitude in ARC ---
-
-
-func test_arc_does_not_renormalise_velocity_to_entry_speed() -> void:
-	var entry: float = _ball.min_speed * 1.1
-	var drifted: float = entry * 0.4
-	_ball.speed = entry
-	_ball.effect_processor.sync_base_speed()
-	# Enter ARC at the entry speed.
-	_ball.linear_velocity = Vector2(0.0, -entry)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	assert_eq(_ball.play_state, Ball.PlayState.PLAY_ARC)
-	# Mid-arc the engine would shed vertical speed to gravity. Simulate that drift, then tick.
-	# If the dropped centripetal-reprojection were still in place this would snap back to entry.
-	_ball.linear_velocity = Vector2(0.0, -drifted)
-	_ball._physics_process(0.016)
-	assert_almost_eq(
-		_ball.linear_velocity.length(),
-		drifted,
-		0.5,
-		"in-ARC velocity is left to engine gravity; ball.gd no longer renormalises"
-	)
-
-
-func test_arc_does_not_bend_purely_vertical_velocity() -> void:
-	# Off-centre, purely vertical motion: under the old centripetal rule this gained an x-component.
-	var entry: float = _ball.min_speed * 1.1
-	_ball.speed = entry
-	_ball.effect_processor.sync_base_speed()
-	_ball.global_position = Vector2(200.0, BOUND_Y - 50.0)
-	_ball.linear_velocity = Vector2(0.0, -entry)
-	_ball._physics_process(0.016)
-	_ball._physics_process(0.016)
-	assert_almost_eq(_ball.linear_velocity.x, 0.0, 0.001, "no centripetal bend toward centre")
-
-
-# --- relock ramp: speed ramps to entry_speed on ARC -> NORMAL cross ---
-
-
-func test_relock_ramp_lands_at_entry_speed() -> void:
-	var entry: float = _ball.min_speed * 1.5
-	var drifted: float = entry * 0.3
-	_ball.speed = entry
-	_ball.effect_processor.sync_base_speed()
-	_ball.linear_velocity = Vector2(0.0, -entry)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	assert_almost_eq(_ball.entry_speed, entry, 0.5)
-	_ball.linear_velocity = Vector2(0.0, drifted)
-	_ball.global_position = Vector2(0.0, BOUND_Y + 5.0)
-	_ball._physics_process(0.016)
-	assert_eq(_ball.play_state, Ball.PlayState.PLAY_NORMAL)
-	for _i in 12:
-		_ball._physics_process(0.016)
-	assert_almost_eq(
-		_ball.linear_velocity.length(),
-		entry,
-		1.0,
-		"post-ramp magnitude matches the tracked entry value"
-	)
-	assert_almost_eq(_ball.speed, entry, 0.5)
-
-
-func test_relock_ramp_intermediate_magnitude_between_endpoints() -> void:
-	var entry: float = _ball.min_speed * 1.5
-	var drifted: float = entry * 0.3
-	_ball.speed = entry
-	_ball.effect_processor.sync_base_speed()
-	_ball.linear_velocity = Vector2(0.0, -entry)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	_ball.linear_velocity = Vector2(0.0, drifted)
-	_ball.global_position = Vector2(0.0, BOUND_Y + 5.0)
-	_ball._physics_process(0.016)
-	_ball._physics_process(0.02)
-	var mid: float = _ball.linear_velocity.length()
-	assert_gt(mid, drifted)
-	assert_lt(mid, entry)
-
-
-# --- in-ARC speed events: every entry-value mutation is tracked ---
-
-
-func test_set_speed_for_streak_in_arc_updates_entry_value() -> void:
-	# Tier 2 band spans 500; keeps the per-frame clamp from pulling the entry speed down.
-	_ball.current_tier = 2
-	_ball.speed = 500.0
-	_ball.effect_processor.sync_base_speed()
-	_ball.linear_velocity = Vector2(0.0, -500.0)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	assert_almost_eq(_ball.entry_speed, 500.0, 0.5)
-	_ball.set_speed_for_streak(3)
-	assert_almost_eq(
-		_ball.entry_speed,
-		_ball.speed,
-		0.5,
-		"streak speed-set in ARC updates the tracked entry value"
-	)
-
-
-# --- snap path on ARC -> NORMAL when relock_ramp_seconds == 0.0 ---
-
-
-func test_relock_ramp_zero_snaps_to_entry_speed() -> void:
-	var entry: float = _ball.min_speed * 1.5
-	var drifted: float = entry * 0.3
-	_config.relock_ramp_seconds = 0.0
-	_ball.speed = entry
-	_ball.effect_processor.sync_base_speed()
-	_ball.linear_velocity = Vector2(0.0, -entry)
-	_ball.global_position = Vector2(0.0, BOUND_Y - 5.0)
-	_ball._physics_process(0.016)
-	_ball.linear_velocity = Vector2(0.0, drifted)
-	_ball.global_position = Vector2(0.0, BOUND_Y + 5.0)
-	_ball._physics_process(0.016)
-	assert_eq(_ball.play_state, Ball.PlayState.PLAY_NORMAL)
-	assert_almost_eq(_ball.speed, entry, 0.5, "snap path lands speed at entry_speed")
-	assert_almost_eq(
-		_ball.linear_velocity.length(), entry, 1.0, "snap path lands magnitude at entry_speed"
-	)
+	assert_signal_emitted_with_parameters(_ball, "play_state_changed", [Ball.PlayState.PLAY_NORMAL])

--- a/tests/unit/ball/test_ball_apex_arc.gd
+++ b/tests/unit/ball/test_ball_apex_arc.gd
@@ -4,33 +4,13 @@ extends GutTest
 const BOUND_Y := -100.0
 
 var _ball: Ball
-var _config: CourtConfig
-var _manager: Node
 
 
 func before_each() -> void:
-	_manager = load("res://scripts/items/item_manager.gd").new()
-	_manager.state = ItemState.new()
-	_manager.economy = EconomyState.new()
-	_manager._effect_manager = EffectManager.new()
-	_manager.items.assign([preload("res://resources/items/training_ball.tres")])
-	add_child_autofree(_manager)
-
-	_config = load("res://scripts/core/court_config.gd").new()
-	_config.relock_ramp_seconds = 0.1
-
 	_ball = load("res://scripts/entities/ball/ball.gd").new()
-	_ball._item_manager = _manager
-	_ball.court_config = _config
 	_ball.bound_y = BOUND_Y
 	add_child_autofree(_ball)
-	_ball.global_position = Vector2(0.0, 0.0)
-	_ball.linear_velocity = Vector2(
-		Stats.resolve(GameRules.base.ball_speed_min, &"ball_speed_min", _manager), 0.0
-	)
-
-
-# --- state machine: NORMAL <-> ARC transitions across the soul bound ---
+	_ball.linear_velocity = Vector2(_ball.min_speed, 0.0)
 
 
 func test_normal_to_arc_on_upward_cross() -> void:


### PR DESCRIPTION
Refactors the GUT unit suite so a green run means player-visible behaviour holds, not that the code shape was pinned. We are walking the suite test by test against one bar: a test survives only if it asserts a player verb and what the player sees (public state or an emitted signal). Constructor-default checks, private-field pokes, banned velocity-magnitude scalars, and re-assertions of a production constant are cut. Where a cut would drop a behaviour that is genuinely player-real and uncovered, it is logged as a gap rather than dropped silently.

This is an in-progress draft. It opens with the first surface done and the testing docs reconciled; further files land as the walk continues.

## What is in this draft

**`test_ball_apex_arc.gd`: 12 cases to 2.** Kept the two NORMAL/ARC transitions across the soul bound, simplified to the `play_state_changed` signal (the contract other systems hear). Cut: a constructor-default spawn-state check; three `entry_speed` bookkeeping tests (the felt round-trip, enter-at-X exit-at-X, is owned by `test_ball_relock_state.gd`); two parabolic-arc tests asserting `linear_velocity` components; four relock-ramp tests that re-ran `BallRelockState` through ball physics when the pure-RefCounted unit already covers the curve. Trimmed `before_each` to what the survivors need.

**`TESTING.md`: reconciled an internal contradiction and added a GUT reference.** The doc both banned calling `_physics_process` directly and prescribed it for a fast suite; reframed to drive-time-directly, route-through-public-seams. Added a GUT feature reference (assertion families, lifecycle, `use_parameters`, the doubling caveat, the runner) so the toolkit is documented. Fixed a stale `hud_stub` claim.

## Notes for review

- A prod-vs-expectation finding: speed is **not** constant through the arc. It is captured on entry, gravity changes it freely mid-arc, relock restores it on exit. The felt rule is enter-at-X exit-at-X.
- Phase 2 (after the deletes) will aggregate fragmented input-table suites with `use_parameters`, which the project currently uses nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #730.

