### PR TITLE
docs: GitHub-facing branches, manual Linear PR-link convention

### DIFF
--- a/.claude/skills/commits/SKILL.md
+++ b/.claude/skills/commits/SKILL.md
@@ -33,9 +33,15 @@ For breaking changes (save wipes, API renames, workflow-input shifts), use `feat
 
 ## Issue references
 
-**GitHub issue IDs (`#N`) are the primary surface.** The repo is open source; readers of commits and PRs follow GitHub links, not Linear. Reference the GitHub issue with a bare `#123` (just the number, no leading verb) in the commit body or PR body: GitHub backlinks them, and the branch name (not the body) is what advances the Linear issue on merge. Linear IDs (`SH-N`) are private and never appear in commit messages or PR bodies. The branch name carries the Linear context for internal tooling; that is enough.
+**GitHub IDs (`#N`) are the only ID on every open surface, branch names included.** The repo is open source; readers follow GitHub links, not Linear. The branch is `feature/<gh-number>-<slug>` (the GitHub issue number, no `sh-` prefix, no `gh-` prefix). Reference the GitHub issue with a bare `#123` (just the number, no leading verb) in the commit body or PR body. Linear IDs (`SH-N`) are private and appear on no open surface: not the branch, not the title, not the body, not commits, not comments. When a branch covers two issues, chain the numbers: `feature/691-692-slug`.
 
-The bare reference is the one to reach for. A leading GitHub action-verb on the issue number fires GitHub's own issue-close on merge, which overshoots the Linear issue two states past where the branch-name integration leaves it. See [`designs/ai/lane-semantics.md`](../../../designs/ai/lane-semantics.md).
+The bare `#N` is the reference to reach for. A leading GitHub action-verb (`closes #N`) fires GitHub's own issue-close on merge; we do not want that. See [`designs/ai/lane-semantics.md`](../../../designs/ai/lane-semantics.md).
+
+**Linear transitions: the Shuck team PR automations move the issue on PR state** (draft open to Dispatched, marked-ready to Challenged, no action on merge so Completed is manual). BUT those automations only fire on a PR that Linear has *linked* to the issue, and Linear forms that link by finding a Linear ID (`SH-N`) in the branch name, PR title, or PR body. A fully GitHub-facing PR with no `SH-N` anywhere is unlinked, so it drives no transition.
+
+The reconciliation, while branches stay GitHub-facing: create the link once, by hand, via the Linear issue's "Link GitHub PR" (or paste the PR URL into the issue). Once the attachment exists the state automations follow the PR. Do not put `SH-N` on an open surface to get the link. Confirm the link landed with a Linear read; do not assume the PR moved the issue.
+
+**Multi-PR caveat.** A Linear issue can link several PRs, but the automation is an AND: the status only moves when the *final* linked PR reaches the state. So a stale link to a closed-without-merge PR can stall the transition (it never reaches merge). If you replace a PR (close one, open another for the same issue), unlink the dead PR from the issue so the live PR is the only linked target. A closed PR does not auto-unlink and a replacement does not auto-link; both are manual.
 
 ## Branch discipline
 

--- a/.claude/skills/commits/SKILL.md
+++ b/.claude/skills/commits/SKILL.md
@@ -39,9 +39,16 @@ The bare `#N` is the reference to reach for. A leading GitHub action-verb (`clos
 
 **Linear transitions: the Shuck team PR automations move the issue on PR state** (draft open to Dispatched, marked-ready to Challenged, no action on merge so Completed is manual). BUT those automations only fire on a PR that Linear has *linked* to the issue, and Linear forms that link by finding a Linear ID (`SH-N`) in the branch name, PR title, or PR body. A fully GitHub-facing PR with no `SH-N` anywhere is unlinked, so it drives no transition.
 
-The reconciliation, while branches stay GitHub-facing: create the link once, by hand, via the Linear issue's "Link GitHub PR" (or paste the PR URL into the issue). Once the attachment exists the state automations follow the PR. Do not put `SH-N` on an open surface to get the link. Confirm the link landed with a Linear read; do not assume the PR moved the issue.
+The reconciliation, while branches stay GitHub-facing: link the PR yourself. The MCP Linear tools do not expose attachment linking, but the raw GraphQL API does. Script it with `$LINEAR_API_KEY` against `https://api.linear.app/graphql` using `attachmentLinkGitHubPR` with `issueId`, `url`, and a `linkKind` (the `GitLinkKind` enum). `attachmentDelete` drops a link. Do not put `SH-N` on an open surface to get the link. Confirm the link landed with a Linear read; do not assume the PR moved the issue.
 
-**Multi-PR caveat.** A Linear issue can link several PRs, but the automation is an AND: the status only moves when the *final* linked PR reaches the state. So a stale link to a closed-without-merge PR can stall the transition (it never reaches merge). If you replace a PR (close one, open another for the same issue), unlink the dead PR from the issue so the live PR is the only linked target. A closed PR does not auto-unlink and a replacement does not auto-link; both are manual.
+**`linkKind` is the relationship, and it is what handles multi-PR.** The enum (matching the UI picker):
+- `closes` ("Resolves"), the PR resolves the issue on merge. Use for a single-PR issue.
+- `contributes` ("Contributes to"), one of several PRs; moves the issue but does not solo-resolve. **Use this for every PR on a multi-PR issue.**
+- `links` ("Related to"), reference only, no status automation.
+
+The merge automation is an AND across linked PRs: the issue only reaches the terminal state when the *final* contributing PR merges. So linking each PR as `contributes` (not `closes`) is what stops one early merge from completing the issue; you do not need to delete attachments to manage it. A closed or replaced PR does not auto-unlink, so set it to `links` or `attachmentDelete` it if its stale `closes` / `contributes` would skew the AND.
+
+Note for the Shuck team specifically: merge is set to no-action, so no `linkKind` completes an issue on merge today (Completed is always manual). The `closes` / `contributes` distinction still matters if that mapping is ever turned on, and `links` vs the others still controls whether the open / ready automations fire at all.
 
 ## Branch discipline
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -35,7 +35,7 @@ Worktree isolation is a per-dispatch choice, not a forced rule (the gate hook wa
 
 Tier 2 work (runtime / `run(play)`) is exclusive: only one minion at a time runs at Tier 2. Constraint is one-at-a-time, not Josh sign-off.
 
-When dispatching a minion onto a Linear issue, brief the agent to create the worktree on a properly named feature branch: `feature/sh-XXX-short-description`. The Agent tool's `isolation: "worktree"` defaults the branch name to the worktree slug (`worktree-agent-aXXXXXX`); that's an internal name, not a feature branch. SH-288 / PR #506 shipped on the slug name because the dispatch brief never named the branch. Future dispatches: include the branch name in the brief.
+When dispatching a minion onto a Linear issue, brief the agent to create the worktree on a properly named feature branch: `feature/<gh-number>-<short-description>`, using the GitHub issue number (from the Linear issue's GitHub mirror attachment), not the Linear `SH-N`. All branches are GitHub-facing, internal worktree branches included. The Agent tool's `isolation: "worktree"` defaults the branch name to the worktree slug (`worktree-agent-aXXXXXX`); that's an internal name, not a feature branch. SH-288 / PR #506 shipped on the slug name because the dispatch brief never named the branch. Future dispatches: include the branch name in the brief, with the resolved GitHub number.
 
 ## Background by default
 
@@ -61,7 +61,7 @@ Every implementer brief opens with: read `.claude/skills/code-comments/SKILL.md`
 
 Every code-writing minion runs this sequence once dispatched. Brief them on it in the dispatch prompt, or point them at this section.
 
-1. **Claim the ticket.** Every branch carries its Linear ticket ID. For chore or infra work with no SH-N, file first via `./scripts/dev/new-ticket.sh "<title>"` (Backlog, Feature, Josh-assigned, estimate 0, auto-slotted into the active cycle). Branch name is `feature/sh-<N>-<slug>`. Commit the claim on the branch, never on `main`.
+1. **Claim the ticket.** Resolve the issue's GitHub mirror number (`#N`); the branch carries that, not the Linear `SH-N`. For chore or infra work with no ticket, file first via `./scripts/dev/new-ticket.sh "<title>"` (Backlog, Feature, Josh-assigned, estimate 0, auto-slotted into the active cycle). Branch name is `feature/<gh-number>-<slug>` (no `sh-`/`gh-` prefix). Commit the claim on the branch, never on `main`. The branch carries no Linear ID; link the PR to the issue after it opens (see `.claude/skills/commits/SKILL.md`, "Issue references").
 2. **Cycle placement.** If the claimed ticket has no cycle, move it into the active one: `mcp__linear__list_cycles(teamId, type: "current")` then `mcp__linear__save_issue(id, cycleId)`. Skip if no active cycle.
 3. **Log progress in Linear.** Significant moments (claim, blocker, ready-for-review) post as a Linear comment on the ticket, not into a shared file. The git log carries the rest.
 4. **Sync before opening and before every later push.** `git fetch origin main && git merge origin/main`, resolve, re-run `./scripts/ci/run_gut.sh`, push. Repeat any time work resumes or before asking Josh to merge. `git rev-list --count HEAD..origin/main` reads "behind by N".
@@ -73,7 +73,7 @@ Every code-writing minion runs this sequence once dispatched. Brief them on it i
 
 - **Backlog shape is Josh's, end to end.** Minions do not create, draft, or pre-format Linear issues. They surface observations in prose ("the equip path also writes to X without a placement update"); they do not write candidate titles, acceptance criteria, or "follow-up tickets we should file" lists. Whether something is a ticket, what its title is, what its AC reads, is Josh's call. The rule applies when the ticket AC says "file tickets", when a spike's output is a migration plan, when a bug shows up mid-task, and when the minion has Linear write tools available.
 - **One ticket, one minion, one branch, one worktree.** Never two minions in the same file. Check what's in flight (see below) before claiming. Sub-agents modifying the repo dispatch with `isolation: "worktree"`.
-- **Worktree cleanup on merge.** After a challenge merges: `git worktree remove ../volley-sh-N && git branch -D sh-N-...`. The owning agent is responsible; otherwise periodic `git worktree list && git worktree prune`.
+- **Worktree cleanup on merge.** After a challenge merges: `git worktree remove ../volley-<gh-number> && git branch -D feature/<gh-number>-...`. The owning agent is responsible; otherwise periodic `git worktree list && git worktree prune`.
 - **Engineer challenges to merge in any order.** Each challenge stands alone against current `main`. Combine related changes that share a file rather than splitting them. Avoid "depends on #X".
 - **Verify, don't assume.** Every change needs evidence: tool output or tests, not "looks correct".
 - **Merge queue serialises `main`.** "Merge when ready" pulls the challenge into a `merge_group` ref, re-runs lint and tests against `main + challenge`, then fast-forwards `main`. The pre-challenge `git merge origin/main` still matters: the queue catches mechanical staleness, not semantic conflicts.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ logs/
 .vscode/
 .mcp.json
 .cursorrules
+coverage.json
 .windsurfrules
 .github/copilot-instructions.md
 

--- a/designs/ai/lane-semantics.md
+++ b/designs/ai/lane-semantics.md
@@ -14,9 +14,11 @@ Two states sit off to the side. Triage holds incoming external work before it jo
 
 The order alone is not enough; each transition has a concrete trigger, and getting the trigger right is what matters.
 
-**Vault** is the backlog: work to be done someday. **Ready** is work planned for a cycle, promoted by Josh, who owns cycle membership. **Dispatched** means an agent is actively working the issue; it flips the moment the work is dispatched, not when the issue is merely picked up. **Challenged** means the pull request is open and the work is up for review; it moves the instant the PR opens, not at merge.
+**Vault** is the backlog: work to be done someday. **Ready** is work planned for a cycle, promoted by Josh, who owns cycle membership. **Dispatched** means an agent is actively working the issue. **Challenged** means the pull request is open and the work is up for review.
 
-**Completed means the work merged.** That is the whole meaning. Linear's branch-name integration sets it automatically when the PR merges, so no manual move and no close trailer are needed. Verification does not live here.
+These two transitions are driven by the Shuck team's PR automations: a draft PR opening moves the issue to Dispatched, marking it ready-for-review moves it to Challenged. The automations only fire on a PR that Linear has linked to the issue, and because branches are GitHub-facing (no `SH-N`), that link is made by hand once the PR is up (see `.claude/skills/commits/SKILL.md`, "Issue references"). Link the PR, then the state follows it.
+
+**Completed means the work merged.** That is the whole meaning. Merge is deliberately set to no-action in the team automations, so reaching Completed is a manual move (never a close trailer, which overshoots). Verification does not live here.
 
 **Closed means the work was released to production** through the cycle release carnival. The carnival is itself the regression test, the gate that confirms nothing else broke before shipping. The release pipeline sets Closed; it is never a hand-move and never something a PR merge should reach.
 
@@ -26,6 +28,6 @@ Verification lives in the Ride, not on the issue. A Ride is Josh playtesting the
 
 **Forward only.** Once an issue advances, it never moves to an earlier state, even when a rework cycle tempts a move back to Dispatched. The state records the most-advanced step the work has reached. The one genuine exception is regression: when a Ride or post-merge playtest catches an already-Completed fix breaking again, the issue reopens forward to Ready because the work is genuinely re-opened, not because a state was overshot.
 
-**Reference an issue with a bare number.** A PR that links an issue does so with the number on its own (`#123`), nothing in front of it. The branch-name integration already moves the issue to Completed on merge, so the body only needs to backlink, and the bare reference is exactly that. Putting a GitHub action-verb ahead of the number is the trap: that fires GitHub's own issue-close on merge, which drags the linked Linear issue past Completed all the way to Closed, two states too far, and falsely reads as released.
+**Reference an issue with a bare number.** A PR that links an issue does so with the number on its own (`#123`), nothing in front of it. Completed is a manual move on merge (the team merge automation is no-action), so the body only needs to backlink, and the bare reference is exactly that. Putting a GitHub action-verb ahead of the number is the trap: that fires GitHub's own issue-close on merge, which drags the linked Linear issue all the way to Closed, falsely reading as released.
 
 This is the rule that drifts. Roughly one in four PRs has historically tripped it, and the cleanup is manual every time. The branch name, not the PR body, is what should drive Linear movement; the body's job is the bare backlink.


### PR DESCRIPTION
Reconciles the branch-naming and Linear-transition rules across the process surfaces after a decision to make every open surface GitHub-facing.

The rule, now consistent across the commits skill, the dispatch skill, and the lane-semantics design doc: branches are `feature/<gh-number>-<slug>` using the GitHub issue number (no `sh-` or `gh-` prefix), and no Linear ID appears on any open surface. Linear transitions come from the team's PR automations on a manually-linked PR (draft open moves the issue to Dispatched, marking it ready moves it to Challenged), and because merge is set to no-action, reaching Completed is a manual move. Linking a PR to its issue is scripted via the GraphQL `attachmentLinkGitHubPR` with a `linkKind` (`closes` / `contributes` / `links`), where `contributes` is the multi-PR case.

The matching memory rules were reconciled in the same pass; this PR carries the in-repo surfaces (two skills and one design doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)