### PR TITLE
test: audit test_ball.gd to behavioural, remove dead methods

### DIFF
--- a/designs/01-prototype/20-ball-speed-tiers.md
+++ b/designs/01-prototype/20-ball-speed-tiers.md
@@ -61,13 +61,13 @@ Completing a non-top tier hands off to the next band. The top tier has nothing a
 
 ### Reset behaviour
 
-- **Miss** resets tier to 0 and speed to Tier 0 floor, matching today's `ball.reset_speed` semantics. A miss during the final consolidation window is a normal miss; the banked reward is already the player's (see 20a).
+- **Miss** resets tier to 0 and speed to Tier 0 floor; the miss path runs through `enter_out_rest`. A miss during the final consolidation window is a normal miss; the banked reward is already the player's (see 20a).
 - **Tier completion** sets tier to `tier + 1` and speed to the new tier's floor. Current speed does not carry across tiers; the drop is the reset beat.
 - **Half-streak items** (Cadence's existing `on_miss` / halve outcome) still halve `_volley_count` on miss. They now also set tier to `floor(current_tier / 2)` and speed to the floor of that tier, so halving is proportional across the new ladder.
 
 ### Tier-aware ball state
 
-`Ball` gains `current_tier: int` and `tier_floor` / `tier_ceiling` derived from `current_tier` against a `SpeedTierTable` resource. Each tier entry in the table carries `{ floor, ceiling, max_range, reward }`, where `max_range` is the per-tier promotion of the flat `ball_speed_max_range` stat from design/21-ball-dynamics.md. Tier 0's `max_range` holds the existing flat value from design/21-ball-dynamics.md's base-stats tuning surface, so that surface keeps its meaning and lives on the Tier 0 entry. `increase_speed` and `set_speed_for_streak` clamp against `tier_ceiling` instead of `max_speed`. Crossing `tier_ceiling` triggers `_advance_tier` which emits `tier_advanced(new_tier)` and `on_tier_completed` through `ItemManager.process_event`.
+`Ball` gains `current_tier: int` and `tier_floor` / `tier_ceiling` derived from `current_tier` against a `SpeedTierTable` resource. Each tier entry in the table carries `{ floor, ceiling, max_range, reward }`, where `max_range` is the per-tier promotion of the flat `ball_speed_max_range` stat from design/21-ball-dynamics.md. Tier 0's `max_range` holds the existing flat value from design/21-ball-dynamics.md's base-stats tuning surface, so that surface keeps its meaning and lives on the Tier 0 entry. `increase_speed` clamps against `tier_ceiling` instead of `max_speed`. Crossing `tier_ceiling` triggers `_advance_tier` which emits `tier_advanced(new_tier)` and `on_tier_completed` through `ItemManager.process_event`.
 
 `speed_changed` grows to carry tier floor and ceiling instead of global min and max, so the speed bar can render the current band. `at_max_speed_changed` is repurposed to fire only on final consolidation entry/exit. The Cadence "ceiling outcome" (which currently latches on `on_max_speed_reached`) is out of scope here: Cadence's interaction with the tier model lives in its own tickets (SH-449 names the lifted cap and on-whistle consolidate as L2/L3; SH-59 the L3 burst). This work only retires the dead `on_max_speed_reached` trigger.
 
@@ -115,7 +115,7 @@ The court's crossing distance sets the fun ceiling, so court width is a tunable 
 - `ball_speed_max_range` stays as a tuning surface; it is promoted into a per-tier `max_range` field on `SpeedTierTable` rather than deleted. The flat value from design/21-ball-dynamics.md rides on the Tier 0 entry so existing tuning and tests keep their meaning; the tiers above each declare their own `max_range` alongside `floor`, `ceiling`, and `reward`. The table is owned by `GameRules`. Existing callers that read `ball_speed_max_range` read `SpeedTierTable.get_tier(current_tier).max_range` (or `.get_tier(0).max_range` for the base-stats tuning surface).
 - Court Lines' `ball_speed_max_range` stat outcome is rewritten to a new `RaiseFloorSpeedOutcome`. Training Ball and Wrist Brace unchanged. Cadence is out of scope (SH-449 / SH-59).
 - Court's `_on_ball_at_max_speed_changed` splits into `_on_ball_tier_advanced` (fires per tier) and `_on_ball_final_consolidation_changed` (fires on final consolidation entry/exit). `on_max_speed_reached` as an event name is retired; `on_tier_completed` replaces it.
-- `ball.reset_speed` stays as miss behaviour. `ball.advance_tier` is new. `ball.set_speed_for_streak` clamps against `tier_ceiling` of the tier implied by streak count, which the tier table answers.
+- Miss behaviour runs through `enter_out_rest` (tier 0, floor speed). `ball.advance_tier` is new.
 - No save compat shim. Items in flight at migration time reload against the new data and pick up the new behaviour.
 
 ## Open questions

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -306,20 +306,6 @@ func advance_tier() -> void:
 	_item_manager.process_event(&"on_tier_completed")
 
 
-func reset_speed() -> void:
-	current_tier = 0
-	in_final = false
-	speed = tier_floor
-	_apply_speed()
-	_track_arc_speed_change()
-
-
-func set_speed_for_streak(count: int) -> void:
-	speed = minf(tier_floor + count * speed_increment, tier_ceiling)
-	_apply_speed()
-	_track_arc_speed_change()
-
-
 func _tier_fraction(field: String) -> float:
 	var tier: SpeedTier = GameRules.speed_tiers.get_tier(current_tier)
 	if tier == null:

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -126,6 +126,10 @@ This is the GUT-native answer to fragmented input-table suites; collapse those r
 
 `.gutconfig.json` drives it: all of `res://tests/`, subdirs included, exit on failure, with `tests/hooks/pre_run_hook.gd` and `post_run_hook.gd` around the run. Filter a run with `-gdir` plus `-gprefix`, e.g. `-gdir=res://tests/unit/ball -gprefix=test_ball_apex`.
 
+### A green GUT run is the authority for "does it compile", not `--check-only`
+
+`godot --headless --check-only --script <file>` reports "Compilation failed" on any script that references an autoload singleton (`ItemManager`, `GameRules`, `Stats`) or a global `class_name`, because the isolated check loads no autoloads. The script is fine; this is an open engine bug ([godotengine/godot#111515](https://github.com/godotengine/godot/issues/111515), `--debug` even crashes on it). Validate in project context instead: a GUT run loads every script with autoloads up, and the godotiq `validate`/`check_errors` tools do too. When an isolated check disagrees with a green suite, trust the suite.
+
 ## Real-input rule for player-facing acceptance criteria
 
 Every player-facing AC has at least one integration test that drives the player's real input handler end-to-end. The handler is whichever of `_input`, `_unhandled_input`, or `Area2D.input_event` the production code routes through. The test seam (helpers like `start_drag()`, `attempt_release(position)`, `grab_from_rack()`) is for tuning isolation only; it cannot be the sole verification of an AC.

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -39,6 +39,12 @@ Don't access private variables (`_streak`, `_volley_count`). Test what the playe
 | `_game._volley_count == 0` | `hud.last_count == 0` |
 | `_ball._hit_cooldown > 0` | Second hit doesn't change pitch |
 
+### Test behaviour the game can actually reach
+
+Before keeping a test, confirm the production code it drives is reachable: something in the game calls the method (directly, or via a signal, `Callable`, or resource-named dispatch). A test of a method with no production caller is testing dead code, and the honest finding is the dead code, not a passing test. When you hit one, cut the test and remove the unused method (and any stub override of it) in the same change; verify the behaviour you thought it covered is owned by the live path and tested there.
+
+Coverage tells the story: cutting a dead-method test drops coverage, and deleting the method brings it back, the net is the same reachable surface with less to maintain. (SH-430 found `Ball.reset_speed` and `set_speed_for_streak` this way; the real miss-reset runs through `enter_out_rest`, covered elsewhere.)
+
 ### Drive time deterministically; route through public seams
 
 Advance a system under test by calling its `_physics_process(virtual_delta)` directly with a chosen delta rather than awaiting real frames. This is the project's standing practice for a fast suite (see Test budget below) and it is what unit tests here do. `_physics_process` is the engine's per-frame entry point, so driving it is simulating a frame, not poking private state.

--- a/tests/stubs/ball_manager_stub.gd
+++ b/tests/stubs/ball_manager_stub.gd
@@ -1,9 +1,6 @@
 extends Node
 
-## Minimal stand-in for ItemManager, the slice a Ball touches when no item modifiers
-## are under test. Returns neutral values so the ball resolves its base stats off
-## GameRules alone. Use the real ItemManager (with items) when item-modified behaviour
-## is what the test asserts.
+## Neutral ItemManager stand-in: the slice a Ball calls, returning no modifiers.
 
 
 func get_modifier(_key: StringName) -> float:

--- a/tests/stubs/ball_manager_stub.gd
+++ b/tests/stubs/ball_manager_stub.gd
@@ -1,0 +1,18 @@
+extends Node
+
+## Minimal stand-in for ItemManager, the slice a Ball touches when no item modifiers
+## are under test. Returns neutral values so the ball resolves its base stats off
+## GameRules alone. Use the real ItemManager (with items) when item-modified behaviour
+## is what the test asserts.
+
+
+func get_modifier(_key: StringName) -> float:
+	return 0.0
+
+
+func get_percentage_offset(_key: StringName) -> float:
+	return 0.0
+
+
+func process_event(_event_type: StringName) -> Array[StringName]:
+	return []

--- a/tests/stubs/ball_manager_stub.gd
+++ b/tests/stubs/ball_manager_stub.gd
@@ -1,7 +1,5 @@
 extends Node
 
-## Neutral ItemManager stand-in: the slice a Ball calls, returning no modifiers.
-
 
 func get_modifier(_key: StringName) -> float:
 	return 0.0

--- a/tests/stubs/ball_stub.gd
+++ b/tests/stubs/ball_stub.gd
@@ -7,11 +7,3 @@ func _init() -> void:
 
 func increase_speed() -> void:
 	pass
-
-
-func reset_speed() -> void:
-	pass
-
-
-func set_speed_for_streak(_count: int) -> void:
-	pass

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -1,7 +1,6 @@
 extends GutTest
 
-# Ball speed-tier and miss-zone behaviour at base stats (no item modifiers under test),
-# so the ball runs off a neutral manager stub rather than the full ItemManager rig.
+# Ball speed-tier and miss-zone behaviour at base stats, off a neutral manager stub.
 
 const BallManagerStub: GDScript = preload("res://tests/stubs/ball_manager_stub.gd")
 

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -41,11 +41,16 @@ func test_increase_speed_advances_tier_at_ceiling() -> void:
 	assert_almost_eq(_ball.speed, _ball.tier_floor, 0.01, "speed drops to the new tier's floor")
 
 
-# --- miss zone registration ---
-func test_miss_zone_entry_emits_missed() -> void:
+# --- miss zone ---
+func _registered_zone() -> MissZone:
 	var zone := MissZone.new()
 	add_child_autofree(zone)
 	_ball.register_miss_zone(zone)
+	return zone
+
+
+func test_miss_zone_entry_emits_missed() -> void:
+	var zone := _registered_zone()
 	watch_signals(_ball)
 
 	zone.body_entered.emit(_ball)
@@ -54,9 +59,7 @@ func test_miss_zone_entry_emits_missed() -> void:
 
 
 func test_miss_zone_ignores_other_bodies() -> void:
-	var zone := MissZone.new()
-	add_child_autofree(zone)
-	_ball.register_miss_zone(zone)
+	var zone := _registered_zone()
 	watch_signals(_ball)
 
 	var other_body: Node2D = Node2D.new()
@@ -67,12 +70,12 @@ func test_miss_zone_ignores_other_bodies() -> void:
 
 
 func test_register_miss_zone_is_idempotent() -> void:
-	var zone := MissZone.new()
-	add_child_autofree(zone)
-	_ball.register_miss_zone(zone)
-	_ball.register_miss_zone(zone)
+	var zone := _registered_zone()
+	_ball.register_miss_zone(zone)  # second registration must not double-wire
 	watch_signals(_ball)
 
 	zone.body_entered.emit(_ball)
+
+	assert_signal_emit_count(_ball, "missed", 1)
 
 	assert_signal_emit_count(_ball, "missed", 1)

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -41,14 +41,6 @@ func test_increase_speed_advances_tier_at_ceiling() -> void:
 	assert_almost_eq(_ball.speed, _ball.tier_floor, 0.01, "speed drops to the new tier's floor")
 
 
-func test_increase_speed_never_exceeds_tier_ceiling() -> void:
-	_ball.current_tier = 0
-	var ceiling: float = _ball.tier_ceiling
-	_ball.speed = ceiling - 1.0
-	_ball.increase_speed()
-	assert_true(_ball.speed <= ceiling + 0.01, "speed stays within the band's ceiling")
-
-
 # --- reset_speed ---
 func test_reset_speed_returns_to_tier_zero_floor() -> void:
 	_ball.current_tier = 2

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -1,7 +1,5 @@
 extends GutTest
 
-# Ball speed-tier and miss-zone behaviour at base stats, off a neutral manager stub.
-
 const BallManagerStub: GDScript = preload("res://tests/stubs/ball_manager_stub.gd")
 
 var _ball: Ball
@@ -19,7 +17,6 @@ func before_each() -> void:
 	)
 
 
-# --- increase_speed ---
 func test_increase_speed_advances_tier_at_ceiling() -> void:
 	_ball.current_tier = 0
 	_ball.speed = _ball.tier_ceiling - 1.0
@@ -28,7 +25,6 @@ func test_increase_speed_advances_tier_at_ceiling() -> void:
 	assert_almost_eq(_ball.speed, _ball.tier_floor, 0.01, "speed drops to the new tier's floor")
 
 
-# --- miss zone ---
 func _registered_zone() -> MissZone:
 	var zone := MissZone.new()
 	add_child_autofree(zone)

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -41,28 +41,6 @@ func test_increase_speed_advances_tier_at_ceiling() -> void:
 	assert_almost_eq(_ball.speed, _ball.tier_floor, 0.01, "speed drops to the new tier's floor")
 
 
-# --- reset_speed ---
-func test_reset_speed_returns_to_tier_zero_floor() -> void:
-	_ball.current_tier = 2
-	_ball.speed = _ball.tier_ceiling
-	_ball.reset_speed()
-	assert_eq(_ball.current_tier, 0, "miss resets to Tier 0")
-	assert_almost_eq(_ball.speed, _ball.tier_floor, 0.01)
-
-
-# --- set_speed_for_streak ---
-func test_set_speed_for_streak_zero_equals_tier_floor() -> void:
-	_ball.current_tier = 0
-	_ball.set_speed_for_streak(0)
-	assert_almost_eq(_ball.speed, _ball.tier_floor, 0.01)
-
-
-func test_set_speed_for_streak_caps_at_tier_ceiling() -> void:
-	_ball.current_tier = 0
-	_ball.set_speed_for_streak(9999)
-	assert_almost_eq(_ball.speed, _ball.tier_ceiling, 0.01)
-
-
 # --- miss zone registration ---
 func test_miss_zone_entry_emits_missed() -> void:
 	var zone := MissZone.new()

--- a/tests/unit/ball/test_ball.gd
+++ b/tests/unit/ball/test_ball.gd
@@ -1,34 +1,22 @@
 extends GutTest
 
-# Tests for ball speed behaviour driven by item manager stat values.
-# Injects a real ItemManager with mock storage to avoid autoload dependency.
+# Ball speed-tier and miss-zone behaviour at base stats (no item modifiers under test),
+# so the ball runs off a neutral manager stub rather than the full ItemManager rig.
+
+const BallManagerStub: GDScript = preload("res://tests/stubs/ball_manager_stub.gd")
 
 var _ball: Ball
-var _manager: Node
 
 
 func before_each() -> void:
-	_manager = load("res://scripts/items/item_manager.gd").new()
-	_manager.state = ItemState.new()
-	_manager.economy = EconomyState.new()
-	_manager._effect_manager = EffectManager.new()
-	(
-		_manager
-		. items
-		. assign(
-			[
-				preload("res://resources/items/training_ball.tres"),
-				preload("res://resources/items/court_lines.tres"),
-			]
-		)
-	)
-	add_child_autofree(_manager)
+	var manager: Node = BallManagerStub.new()
+	add_child_autofree(manager)
 
 	_ball = load("res://scripts/entities/ball/ball.gd").new()
-	_ball._item_manager = _manager
+	_ball._item_manager = manager
 	add_child_autofree(_ball)
 	_ball.linear_velocity = Vector2(
-		Stats.resolve(GameRules.base.ball_speed_min, &"ball_speed_min", _manager), 0.0
+		Stats.resolve(GameRules.base.ball_speed_min, &"ball_speed_min", manager), 0.0
 	)
 
 


### PR DESCRIPTION
Second chunk of the SH-430 audit, the rest of the ball directory, holding tests to behaviour the game can reach. Trims test_ball.gd to four real tests (a tier-advance rule and the three miss-zone signal guards), removes the uncalled reset_speed and set_speed_for_streak from Ball, and stands base-ball tests up on a neutral manager stub instead of the full ItemManager rig. Refs #730.