### PR TITLE
docs: code-comments skill bars floating comments

### DIFF
--- a/.claude/skills/code-comments/SKILL.md
+++ b/.claude/skills/code-comments/SKILL.md
@@ -15,6 +15,8 @@ A comment earns its place only for a **WHY the code genuinely cannot hold**: a h
 
 Before the WHY test even runs, a comment has to be *attached* to the line or declaration it explains: a `##` directly above a declaration with no blank line between, or a `#` on or directly above the specific line it is about. A comment that floats on its own, narrating a block underneath a blank line, is out, however good the WHY. If the only honest home for it is floating above a span of code, the span wants a named function and the comment becomes its name. Floating block comments are not weighed and trimmed; they do not earn consideration in the first place.
 
+A comment also takes the code's spacing, not its own. It is part of the declaration it sits on, so no blank line separates it from that line, and no blank line pads it off from the code above as if it were its own paragraph. The comment lives inside the code's rhythm, spaced like the lines around it.
+
 ## The two comment kinds
 
 `##` is Godot's documentation comment; it attaches to the declaration directly below and surfaces in the editor. Same bar: one line naming a non-obvious WHY for that declaration, kept adjacent (a blank line breaks the attachment). One line per declaration; a WHY that needs a paragraph is a doc, not a docstring.

--- a/.claude/skills/code-comments/SKILL.md
+++ b/.claude/skills/code-comments/SKILL.md
@@ -11,11 +11,15 @@ Good code documents itself. The identifiers name what things are, the structure 
 
 A comment earns its place only for a **WHY the code genuinely cannot hold**: a hidden constraint, a workaround for a specific engine quirk, a choice that would look wrong to a careful reader who doesn't know the reason. If a reader of the well-named code could deduce it, or if it belongs in a design or tech doc, let one of those carry it instead.
 
+## A comment must be connected to something
+
+Before the WHY test even runs, a comment has to be *attached* to the line or declaration it explains: a `##` directly above a declaration with no blank line between, or a `#` on or directly above the specific line it is about. A comment that floats on its own, narrating a block underneath a blank line, is out, however good the WHY. If the only honest home for it is floating above a span of code, the span wants a named function and the comment becomes its name. Floating block comments are not weighed and trimmed; they do not earn consideration in the first place.
+
 ## The two comment kinds
 
 `##` is Godot's documentation comment; it attaches to the declaration directly below and surfaces in the editor. Same bar: one line naming a non-obvious WHY for that declaration, kept adjacent (a blank line breaks the attachment). One line per declaration; a WHY that needs a paragraph is a doc, not a docstring.
 
-`#` is an inline comment, same bar again: a single line, only for the WHY the code can't hold.
+`#` is an inline comment, same bar again: a single line, only for the WHY the code can't hold, on or directly above the line it explains.
 
 ## Test files document themselves
 


### PR DESCRIPTION
The code-comments skill said a `##` docstring breaks its attachment across a blank line, but never stated the general rule: a comment has to be connected to the line or declaration it explains. A comment floating above a block, narrating it across a blank line, is out before its why is even weighed; the usual fix is to make the block a named function so the name carries what the comment wanted to. This adds that as the first gate in the skill.

Surfaced while trimming the arc comments in #852, where the bar held by luck rather than by a rule that named it.

Agent-Role: dispatcher