### PR TITLE
docs: cap the synthesis verdict body at 300 chars

### DIFF
--- a/.claude/hooks/synthesis-body-cap.sh
+++ b/.claude/hooks/synthesis-body-cap.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PreToolUse on Bash, gated to bot-review.yml: deny when the synthesis verdict -f body exceeds 300 chars.
+# A clean re-verdict roll-call restates what the inline threads carry; the body is the verdict, not a report.
+# Non-bot-review commands and parse errors pass.
+set -uo pipefail
+
+CAP=300
+input="$(cat)"
+
+result="$(printf '%s' "$input" | python3 -c "
+import json, sys, re
+CAP = $CAP
+try:
+    d = json.load(sys.stdin)
+    cmd = d.get('tool_input', {}).get('command', '')
+    if 'bot-review.yml' not in cmd:
+        print('PASS')
+    else:
+        m = re.search(r'-f body=([\x27\"])(.*?)\1', cmd, re.S)
+        if not m:
+            print('PASS')
+        else:
+            n = len(m.group(2))
+            print('DENY %d' % n if n > CAP else 'PASS')
+except Exception:
+    print('PASS')
+" 2>/dev/null || echo PASS)"
+
+if [ "${result%% *}" = "DENY" ]; then
+  n="${result##* }"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Synthesis verdict body is %s chars; the cap is %s. Collapse to the resolved-findings clause and the verdict; the inline threads carry the detail."}}\n' "$n" "$CAP"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,7 +25,8 @@
         "hooks": [
           { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/git-rebase-ask.sh\"" },
           { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-approved-human.sh\"" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-pr-merge.sh\"" }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-pr-merge.sh\"" },
+          { "type": "command", "if": "Bash(*bot-review.yml*)", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/synthesis-body-cap.sh\"" }
         ]
       }
     ],

--- a/.claude/skills/reviewers/SKILL.md
+++ b/.claude/skills/reviewers/SKILL.md
@@ -68,6 +68,8 @@ Block: one line per reviewer that found something, led by codename and role:
 
 Rules: one line per finding, not per reviewer. Findings that landed inline say "findings posted inline" and are not restated. Off-diff findings (line absent from the diff, e.g. a stale summary the PR forgot) cannot anchor inline, so the body carries them in full. Same prose bar as a review comment: attributed, no AI tells, no em dashes, anchored to a line.
 
+The body has a hard cap of 300 characters. A roll-call of clean re-verdicts is the over-production tell; collapse to the resolved-findings clause and the verdict. Over the cap means the body is restating what the inline threads already carry.
+
 Re-review after a fix: `event=APPROVE`, body names the fix SHA and what it resolved in one line. `Re-review clean: <sha> <what changed>. Block resolved.`
 
 Your codename is in the dispatch prompt (Trillian, Zaphod, Ford, Marvin, Slartibartfast, etc.). The role name (code-quality, gdscript-conventions) is not the codename.


### PR DESCRIPTION
The synthesis verdict body had no length bar, and a clean re-battle produced a 685-char roll-call that just restated what the inline threads already carried. This caps the body at 300 characters, the same shape as the Linear issue-body cap, so the verdict collapses to the resolved-findings clause and the event rather than narrating each reviewer's re-verdict.

The cap lands two ways: as prose in the reviewers skill, and as a PreToolUse hook gated to `bot-review.yml` invocations that denies an over-cap body, mirroring the Linear issue-body-cap hook so the rule binds mechanically rather than relying on memory.

#730

Agent-Role: dispatcher