### PR TITLE
chore: scope the em-dash hook to prose-writing surfaces

### DIFF
--- a/.claude/hooks/em-dash-pre-tool.sh
+++ b/.claude/hooks/em-dash-pre-tool.sh
@@ -1,12 +1,35 @@
 #!/usr/bin/env bash
 # Block tool calls whose input contains U+2014 (em dash).
 # Rule: ~/.claude/projects/-home-josh-gamedev-volley/memory/feedback_no_em_dashes.md
+#
+# Bash is special: a command can legitimately CONTAIN an em dash as a search
+# pattern (grep/sed/rg matching for it) without writing one anywhere. So for
+# Bash, only scan commands that write prose to a permanent surface: a commit
+# message, a PR body/title, or a redirect/heredoc into a text file. Every
+# other tool (Edit, Write, the Linear and PR text tools) is scanned in full.
 set -e
 
 INPUT=$(cat)
-TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input | tostring' 2>/dev/null || printf '%s' "$INPUT")
+EM=$'\xe2\x80\x94'
 
-if printf '%s' "$TEXT" | grep -q $'\xe2\x80\x94'; then
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || printf '')
+
+if [ "$TOOL" = "Bash" ]; then
+  CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || printf '')
+  # Prose-writing surfaces: commit messages (literal git, the gcmsg alias, and
+  # the gc* conventional-commit function family in ~/.zshrc, each with a `!`
+  # variant), PR create/edit, redirects or heredocs into a text file. Anything
+  # else (grep/sed patterns, plain commands) is exempt even with an em dash.
+  if printf '%s' "$CMD" | grep -qE '(^|[;&|[:space:]])(git commit|gcmsg|gc(f|x|d|h|r|t|i|st|pf|bd|v)!?)([[:space:]]|$)|gh pr (create|edit)|>>?[[:space:]]*[^[:space:]]*\.(md|txt|gd|tres|tscn|cfg|json|yml|yaml|sh)|<<'; then
+    SCAN="$CMD"
+  else
+    exit 0
+  fi
+else
+  SCAN=$(printf '%s' "$INPUT" | jq -r '.tool_input | tostring' 2>/dev/null || printf '%s' "$INPUT")
+fi
+
+if printf '%s' "$SCAN" | grep -q "$EM"; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",


### PR DESCRIPTION
The em-dash hook scanned every tool input, so a Bash command that merely searched for an em-dash (grep, sed, ripgrep) was blocked even though it wrote one nowhere. That false-fire tripped repeatedly during normal work.

It now scans non-Bash tools (Edit, Write, the Linear and PR text tools) in full as before, and scans Bash only when the command writes prose to a permanent surface: git commit, the gc-family conventional-commit aliases and gcmsg (with their breaking-change variants), gh pr create/edit, or a redirect or heredoc into a text file. Search patterns and plain commands pass; commit and PR messages stay protected. Verified against the full alias family and against gcc/gcloud/grep so they no longer false-fire.

This matters because lefthook and CI do not check for em-dashes at all; this hook is the only enforcement, so the prose-writing paths had to stay covered while the search paths were freed.