### PR TITLE
docs: record the paddle animation and collision spike decision

### DIFF
--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -104,18 +104,25 @@ Player hitboxes are intentionally sized for feel, not pixel accuracy. For a fast
 ball, tunnelling is solved by continuous collision detection, not polygon detail, so
 a complex collider buys nothing the ball can use.
 
-### The collider extent is a gameplay input, so the angle denominator stays fixed
+### The collider is authored independently of the sprite, not derived from it
 
-The paddle collider is not only a presence test. `Paddle.get_half_height()`
-(`paddle.gd:82-83`) returns the collider's half vertical extent, and the ball's return
-angle uses it as the contact-offset denominator. So a per-state collider that is taller
-during swing would silently change the return angle on swing hits, a feel bug with no
-obvious cause ("edge hits feel off"). Decision: split the two concerns the single
-`RectangleShape2D` currently collapses. The per-state shape that varies is the physics
-extent (what the ball bounces off); the angle denominator stays a fixed reference
-height, not whichever collider is active. `get_half_height()` returns that fixed
-reference, not the live shape. A per-state swing collider may differ in physics extent
-without touching the return-angle math.
+Today the sprite and collider are coupled by derivation: `_apply_size()`
+(`paddle.gd:127`) scales `sprite.scale.y` to match the collider. That coupling is
+exactly what breaks once the sprite animates, the visual silhouette changes frame to
+frame, and anything derived from it drifts with it. The paddle collider is also a
+gameplay input, not only a presence test: `Paddle.get_half_height()`
+(`paddle.gd:82-83`) feeds the ball's return-angle contact-offset denominator, so a
+collider that tracked the sprite would make the bounce angle wobble with the art.
+
+Decision: decouple the collider from the sprite. The collider is its own authored
+shape, sized for gameplay feel, and the sprite is its own thing, sized for the art;
+neither is calculated from the other, and the `_apply_size` sprite-from-collider
+derivation retires. The sprite then varies freely across animation states and frames
+without ever touching collision or the return angle, because the collision shape was
+never derived from it. The contact reference for the bounce reads from the authored
+collider, which is stable. A per-state collider that differs (a wider swing shape) is
+then a deliberate authored choice, not a side effect of the sprite, and its effect on
+the return angle, if any, is intended rather than incidental.
 
 ### Toggle the collider in `_physics_process`, not on an animation callback
 

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -1,0 +1,138 @@
+# Paddle Animation and Collision Spike
+
+Resolves the two paddle spikes [#587](https://github.com/shuck-dev/volley/issues/587)
+(animation states) and [#865](https://github.com/shuck-dev/volley/issues/865)
+(sprite collisions) as one decision, because both rework the same Sprite/collider
+seam on `paddle.gd` and the collider question only has an answer once the animation
+states exist.
+
+## Decision
+
+Paddles render through an `AnimatedSprite2D` whose `SpriteFrames` resource holds
+named placeholder animations (idle, ready, swing, walk). A movement state machine
+owns the paddle's gameplay state and drives the animation downstream; the
+animation layer never holds gameplay state. Swing is a transient overlay action
+composed in code on top of the current movement state, not a movement state of its
+own. Collision uses a small set of per-state primitive shapes (a `CollisionShape2D`
+sized for idle/walk, a wider/taller one for swing), toggled in code on state
+change, never keyed off an `AnimationPlayer` track. No `AnimationTree`.
+
+Real character art lands later as a `SpriteFrames` swap with matching animation
+names; no GDScript changes. This satisfies [#587](https://github.com/shuck-dev/volley/issues/587)'s
+acceptance criterion.
+
+## Why AnimatedSprite2D, not AnimationPlayer or AnimationTree
+
+The three Godot 4 ways to drive sprite animation, and why this picks the first:
+
+| Approach | Fit | Verdict |
+|---|---|---|
+| AnimatedSprite2D + code state map | Self-contained; all frames in one `SpriteFrames`; swap art by swapping the resource | Chosen |
+| AnimationPlayer owns sprite + tracks | One lockstep timeline (sprite, collider, audio) | Rejected: tracks live in the node, so new art means re-keying per sheet, breaking the swap-with-no-code-change goal |
+| AnimationTree (state-machine mode) | Blended, composed locomotion | Rejected: no blending wanted; cannot natively drive AnimatedSprite2D ([proposal #567](https://github.com/godotengine/godot-proposals/issues/567)), so adopting it forces giving up the swap-friendly node for a feature we do not use |
+
+AnimatedSprite2D is the only option where dropping in real art is a resource swap.
+The official Godot tutorial introduces it as the primary tool for frame-based
+sprite animation; it carries less per-instance overhead than AnimationPlayer
+([2D sprite animation](https://docs.godotengine.org/en/stable/tutorials/2d/2d_sprite_animation.html)).
+
+## Why the movement FSM is the source of truth
+
+Gameplay state (idle / ready / walk, and the transient swing action) lives in a
+movement state machine on the paddle. The animation layer is a downstream consumer:
+the FSM decides the state, then tells the sprite which animation to play and which
+collider to activate. State must never live in the animation, or the ball physics
+(is the swing hitbox active) would depend on which sprite frame is showing, coupling
+collision to art.
+
+The paddle has no movement FSM today. State is implicit: `velocity.y != 0` reads as
+moving, `== 0` as idle, and the only explicit machine is `TimeoutController`'s
+walk-off/equip/walk-on enum, which sits outside the paddle and sets `drive_blocked`
+(`timeout_controller.gd:14`). Wiring named animation states is the occasion to make
+movement state explicit, with the FSM as the single owner the animation reads from.
+
+## Why swing is an overlay, not a state, and why no tree
+
+Swing is a transient action that can fire while the paddle is idle or walking, not a
+mode the paddle is wholly in. The hit is currently an instantaneous `paddle_hit`
+signal with no held pose (`paddle.gd:53`), which is the overlay shape: a brief action
+on top of a persistent movement state.
+
+Overlay composition does not require an `AnimationTree`. A tree earns its cost when
+the composition is blended and continuous (speed-graded locomotion, per-bone upper
+body over lower body). Ours is discrete and orthogonal: one channel picks the body
+animation, another toggles the swing collider and pose. Sprite frames cannot
+meaningfully blend (a frame is a discrete picture), so a tree here would be a state
+selector with extra ceremony, while also forcing the loss of AnimatedSprite2D.
+Discrete orthogonal composition is a few lines in the FSM. Revisit a tree only if
+blended locomotion or live multi-layer sprite compositing is ever wanted; both are
+additive over this.
+
+## Why per-state colliders, toggled in code
+
+A ball must not pass through the character as the silhouette changes across states.
+The options, with the shipped-game precedent that settles them:
+
+| Option | Cost | Verdict |
+|---|---|---|
+| Per-frame `CollisionPolygon2D` from sprite alpha | 16-32 unique shapes to validate; every write invalidates the physics-server shape; concave is the slowest shape type | Rejected: impractical outside fighting games; no engine support ([proposal #829](https://github.com/shuck-dev/volley/issues/829) open, unmilestoned) |
+| Per-state primitive shapes, toggled on state change | One shape per state, swap on transition | Chosen |
+| Single static capsule | Cheapest, least accurate | Rejected: a capsule covering the swing extent feels too large at idle |
+
+Shipped 2D action games near-universally avoid silhouette-tracking colliders.
+Celeste and TowerFall use integer axis-aligned bounding boxes for every actor and
+projectile ([Thorson](https://maddythorson.medium.com/celeste-and-towerfall-physics-d24bd2ae0fc5));
+even Smash, the one genre with per-frame hitboxes, uses authored capsules on bone
+positions, not pixel polygons ([Smash Wiki](https://www.ssbwiki.com/Hitbox)).
+Player hitboxes are intentionally sized for feel, not pixel accuracy. For a fast
+ball, tunnelling is solved by continuous collision detection, not polygon detail, so
+a complex collider buys nothing the ball can use.
+
+### Caveat: do not key the collider toggle from an AnimationPlayer
+
+The tempting pattern (an AnimationPlayer track keying `CollisionShape2D.disabled` per
+frame) has a cluster of known Godot bugs: a call-function track cannot reliably
+enable a CollisionShape2D ([#18824](https://github.com/godotengine/godot/issues/18824)),
+and the `disabled` property toggled via animation has reported inverted-state and
+re-enable-on-unpause behaviour ([#30383](https://github.com/godotengine/godot/issues/30383),
+[forum](https://forum.godotengine.org/t/unpause-animationplayer-re-enables-disabled-collisionshape2d/38723)).
+Drive the toggle from the FSM in code instead. The FSM already makes the state
+decision; it flips the active collider in the same transition, so sprite and collider
+cannot disagree.
+
+## Frame delivery: individual images
+
+Character art is authored as individual PNGs per frame, dropped into a `SpriteFrames`
+resource. The project has no sprite art convention to inherit (nine PNGs today, all
+single images, no spritesheets, no `SpriteFrames`), so this spike sets the
+convention. Individual images are the most swap-friendly and artist-friendly path for
+AnimatedSprite2D; a spritesheet would suit AnimationPlayer's region keying, which is
+not the chosen node.
+
+## The seam, today
+
+Three paddle scenes, all 2D `CharacterBody2D`, share `paddle.gd`:
+
+| Scene | Root | Visual node today |
+|---|---|---|
+| `scenes/player_paddle.tscn` | CharacterBody2D | child `Sprite2D` "Sprite", `PlaceholderTexture2D` |
+| `scenes/partner_paddle.tscn` | CharacterBody2D | child `Sprite2D` "Sprite", `PlaceholderTexture2D` |
+| `scenes/partners/martha_paddle.tscn` | CharacterBody2D | child `Sprite2D` "Sprite" + cosmetic "Bow" overlay |
+
+`sprite` is already `@export` (`paddle.gd:13`); its only logic is `_apply_size()`
+scaling `sprite.scale.y` to the collider (`paddle.gd:127`). The build swaps the
+`Sprite2D` export to `AnimatedSprite2D` across `paddle.gd` and the three scenes, moves
+the `_apply_size` scale to the new node, adds the per-state colliders, and wires the
+movement FSM to drive both. Whether to wrap the AnimatedSprite2D and colliders in a
+small reusable child node (instanced across the three scenes) or keep them as direct
+children driven by `paddle.gd` is a build-time structural taste call, not load-bearing
+here.
+
+## Out of scope
+
+- Real character art. Placeholder frames only; art swaps in later.
+- New gameplay states. `ready` and `swing` are defined animation hooks the FSM can
+  enter; the gameplay that triggers a held `ready` or a swing windup is separate work.
+- The movement FSM's full design beyond what animation needs to read.
+- Any `AnimationPlayer` or `AnimationTree` adoption. Both are additive later if
+  blended locomotion or frame-synced multi-track events are ever wanted.

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -51,21 +51,45 @@ walk-off/equip/walk-on enum, which sits outside the paddle and sets `drive_block
 (`timeout_controller.gd:14`). Wiring named animation states is the occasion to make
 movement state explicit, with the FSM as the single owner the animation reads from.
 
-### The FSM defers to TimeoutController, it does not replace it
+### Finding: TimeoutController is the wrong shape and should decompose first
 
-`TimeoutController` (`timeout_controller.gd:14`) already runs a six-state machine
-(IDLE, DESCENDING, WALKING_OFF, AT_EQUIP_POSE, WALKING_ON, ASCENDING) that drives the
-paddle during a timeout and holds `drive_blocked` for the whole non-IDLE span. The two
-most common non-idle paddle states (walk-off, walk-on) live there, so the new movement
-FSM cannot ignore it. The relationship: the movement FSM reads `drive_blocked` (or
-`TimeoutController.get_state()`) as its highest-priority input. While a timeout is
-active, the FSM is in a `timeout` state that maps the controller's phase to an
-animation (descending/ascending to a walk-cycle, at-equip to an idle-or-pose), and the
-collider follows that. TimeoutController stays the locomotion authority during a
-timeout; the FSM only translates its phase into animation-and-collider, the same
-downstream-consumer role it has for the velocity-driven states. The full FSM transition
-table is build-ticket work, but this priority (timeout phase outranks velocity) is the
-constraint the build inherits, not a blank slate.
+`TimeoutController` (`scripts/core/timeout_controller.gd`) welds three concerns into
+one class, and only one of them is what the animation FSM actually needs:
+
+1. **Scripted movement.** Driving the paddle to a target point through the venue
+   (`_start_horizontal_walk`, `_step_horizontal_walk`, `_step_descent`, `_step_ascent`).
+   Nothing here is timeout-specific; it is generic "move this paddle to there." This is
+   the concern reused when the player moves around the venue during a timeout, not just
+   the off-and-back errand.
+2. **Control handoff.** Suspending the paddle's own drive (`set_physics_process(false)`,
+   `drive_blocked = true`) and swapping the collision mask, then restoring both. Generic
+   to any context that scripts the paddle.
+3. **The timeout sequence.** The `IDLE, DESCENDING, WALKING_OFF, AT_EQUIP_POSE,
+   WALKING_ON, ASCENDING` orchestration to the equip pose and back, plus the lifecycle
+   signals. This is the only genuinely timeout-specific part, and it is a *consumer* of
+   movement, not the owner of it.
+
+Timeout is going to be more than this errand (player movement around the venue), so the
+movement concern must come out from under the timeout choreography. The decomposition:
+a **mover** (drive a paddle to venue targets), a **control-handoff** (suspend/restore
+drive and mask), and a thin **timeout orchestrator** that composes the two into the
+off-and-back sequence. Venue movement then reuses the mover and handoff directly.
+
+### The FSM defers to the movement concern, not the timeout orchestrator
+
+Given that decomposition, the animation FSM's relationship corrects: it is a downstream
+consumer of the **movement** concern (the mover), the same way it consumes the
+velocity-driven states. The timeout orchestrator is a *peer* consumer of movement, not
+the locomotion authority the FSM reports to. During a timeout the FSM still animates
+walk-off/walk-on, but it reads them from the active movement, not from a timeout phase
+enum it has to special-case. This is cleaner than the FSM hard-wiring to
+`TimeoutController.get_state()`: once movement is its own concern, both the FSM and the
+timeout sequence read from it, and neither owns the other.
+
+The decomposition is build-and-refactor work the spike does not execute; it is a
+sequenced refactor (plan via `impact_check` / `dependency_graph`) that lands before or
+alongside the animation rig. The constraint the build inherits: do not couple the FSM
+to the current `TimeoutController` class shape, because that class is splitting.
 
 ## Why swing is an overlay, not a state, and why no tree
 
@@ -166,14 +190,18 @@ Three paddle scenes, all 2D `CharacterBody2D`, share `paddle.gd`:
 | `scenes/partner_paddle.tscn` | CharacterBody2D | child `Sprite2D` "Sprite", `PlaceholderTexture2D` |
 | `scenes/partners/martha_paddle.tscn` | CharacterBody2D | child `Sprite2D` "Sprite" + cosmetic "Bow" overlay |
 
-`sprite` is already `@export` (`paddle.gd:13`); its only logic is `_apply_size()`
+`sprite` is already `@export` (`paddle.gd:13`); today its only logic is `_apply_size()`
 scaling `sprite.scale.y` to the collider (`paddle.gd:127`). The build swaps the
-`Sprite2D` export to `AnimatedSprite2D` across `paddle.gd` and the three scenes, moves
-the `_apply_size` scale to the new node, adds the per-state colliders, and wires the
-movement FSM to drive both. Whether to wrap the AnimatedSprite2D and colliders in a
-small reusable child node (instanced across the three scenes) or keep them as direct
-children driven by `paddle.gd` is a build-time structural taste call, not load-bearing
-here.
+`Sprite2D` export to `AnimatedSprite2D` across `paddle.gd` and the three scenes, retires
+the `_apply_size` sprite-from-collider derivation (the sprite and collider are authored
+independently, per the decouple decision above), adds the per-state colliders, and wires
+the movement FSM to drive both. Note `TimeoutController` also reads the collider via
+`_half_height()` to anchor the paddle's foot during in-pose resizes, and comments there
+reference `_apply_size`'s foot-anchoring; retiring `_apply_size` is a cross-effect the
+build must reconcile with that controller (another reason the decomposition above is
+entangled with this rig). Whether to wrap the AnimatedSprite2D and colliders in a small
+reusable child node (instanced across the three scenes) or keep them as direct children
+driven by `paddle.gd` is a build-time structural taste call, not load-bearing here.
 
 ## Out of scope
 
@@ -181,5 +209,10 @@ here.
 - New gameplay states. `ready` and `swing` are defined animation hooks the FSM can
   enter; the gameplay that triggers a held `ready` or a swing windup is separate work.
 - The movement FSM's full design beyond what animation needs to read.
+- Executing the `TimeoutController` decomposition. The spike surfaces it (the movement
+  concern must come out from under the timeout choreography, and the FSM defers to that
+  movement concern, not the orchestrator) and names it as a dependency the rig is
+  entangled with. The sequenced refactor itself, planned via `impact_check` /
+  `dependency_graph`, is its own work that lands before or alongside the build.
 - Any `AnimationPlayer` or `AnimationTree` adoption. Both are additive later if
   blended locomotion or frame-synced multi-track events are ever wanted.

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -51,43 +51,37 @@ walk-off/equip/walk-on enum, which sits outside the paddle and sets `drive_block
 (`timeout_controller.gd:14`). Wiring named animation states is the occasion to make
 movement state explicit, with the FSM as the single owner the animation reads from.
 
-### Finding: TimeoutController is the wrong shape and should decompose
+### Finding: extract an EquipController from TimeoutController
 
-`TimeoutController` (`scripts/core/timeout_controller.gd`) is a manager that reaches
-into the paddle and performs world interaction directly: every physics frame it drives
-`main_character.velocity` and calls `move_and_slide()` (`_step_descent`, `_step_ascent`,
-`_step_horizontal_walk`) to walk the paddle around the venue. Moving a body through the
-world is not a manager's place. A controller coordinates, it decides what should happen;
-the world interaction itself belongs on the thing that lives in the world.
+`TimeoutController` (`scripts/core/timeout_controller.gd`) bundles the scripted equip
+errand with its own machinery. The errand is specific: walk the main character off to a
+fixed equip pose, hold there, walk back (`_equip_pose_x`, the `AT_EQUIP_POSE` /
+`main_character_reached_equip_pose` sequence). The name `timeout` describes *when* this
+runs, not *what* it does; what it does is equip. So the first extraction is an
+`EquipController` that owns the equip sequence and its lifecycle signals.
 
-The decomposition follows from that rule, owner by where the behaviour happens:
+Two notes bound this, so the spike does not over-reach:
 
-1. **Movement is the paddle's.** Walking to a target, descending to the floor, ascending
-   to the lane: this is the paddle (a `CharacterBody2D`, the world body) moving itself.
-   It owns "move me to this venue target." This is also exactly what player movement
-   around the venue needs, the paddle can move itself regardless of why, so the
-   capability is reused, not duplicated.
-2. **Control mode is the paddle's.** Whether the paddle is player-driven or following a
-   scripted target (`drive_blocked`, `set_physics_process`, the collision-mask swap) is
-   the paddle managing its own control modes, not a flag imposed from outside.
-3. **The equip sequence is the coordinator's.** Go to the equip pose, be equipped,
-   return, plus the lifecycle signals. This is the genuinely errand-specific part and the
-   good first extraction: an `EquipController` that holds no `move_and_slide`, asks the
-   paddle to move to the equip pose, and reacts when it arrives.
+- **This movement is scripted, not player-controlled.** The walk/descend/ascend the
+  controller performs is the game driving the paddle to a fixed target, automated, no
+  player agency. It is the equip errand's mechanism, and it stays with the equip errand.
+- **Player-controlled venue movement during a timeout does not exist yet.** It is
+  anticipated (the player steering the paddle around the venue during the break is its own
+  future capability with player input), but it is not present in `TimeoutController` to
+  factor out, and it is a different thing from the scripted equip walk. The spike does not
+  design or pre-factor for it; the seam for it gets built when that feature arrives. The
+  only consequence for now: do not treat the current controller as "the locomotion
+  authority", because it only knows one scripted errand, not the movement modes coming
+  later.
 
-So a first cut is an `EquipController` (pure coordinator: equip sequence, signals,
-policy) sitting on a paddle that owns its own venue movement. Timeout becomes the broader
-mode under which equip is one errand; player venue-movement is another, both asking the
-same paddle to move. The manager never touches `move_and_slide`.
+### The FSM reads paddle movement state, not a controller phase
 
-### The FSM reads the paddle's own movement, not a controller
-
-Given that the paddle owns its movement, the animation FSM's relationship is simple: it
-reads the paddle's own movement state, the same single source whether the paddle is moving
-under player input, AI, or an equip errand. No special-casing a controller's phase enum,
-no FSM hard-wired to `TimeoutController.get_state()`. The equip coordinator and the FSM
-are both downstream of the paddle's movement; neither owns the other, and neither owns the
-movement.
+The animation FSM consumes the paddle's movement state directly (velocity-driven idle vs
+moving), not a controller's internal phase enum. During an equip errand the paddle is
+still moving, so the FSM animates that movement the same way; it does not need to be
+hard-wired to `TimeoutController.get_state()`. Whatever the `EquipController` extraction
+settles, the FSM's input is paddle movement, which keeps the FSM independent of how any
+one errand is orchestrated.
 
 The decomposition is build-and-refactor work the spike does not execute; it is a
 sequenced refactor (plan via `impact_check` / `dependency_graph`) that lands before or
@@ -212,11 +206,13 @@ driven by `paddle.gd` is a build-time structural taste call, not load-bearing he
 - New gameplay states. `ready` and `swing` are defined animation hooks the FSM can
   enter; the gameplay that triggers a held `ready` or a swing windup is separate work.
 - The movement FSM's full design beyond what animation needs to read.
-- Executing the `TimeoutController` decomposition. The spike surfaces it (world
-  interaction is not a manager's place: movement and control-mode belong on the paddle,
-  with an `EquipController` as a pure coordinator on top, and the FSM reads the paddle's
-  own movement) and names it as a dependency the rig is entangled with. The sequenced
-  refactor itself, planned via `impact_check` / `dependency_graph`, is its own work that
-  lands before or alongside the build.
+- Executing the `EquipController` extraction. The spike surfaces it (the scripted equip
+  errand should be its own coordinator, lifted out of `TimeoutController`) and names it as
+  a dependency the rig is entangled with. The sequenced refactor itself, planned via
+  `impact_check` / `dependency_graph`, is its own work that lands before or alongside the
+  build.
+- Player-controlled venue movement during a timeout. Anticipated but unbuilt; not
+  designed or pre-factored here. Named only to keep the equip extraction from baking in
+  "timeout is this one scripted errand."
 - Any `AnimationPlayer` or `AnimationTree` adoption. Both are additive later if
   blended locomotion or frame-synced multi-track events are ever wanted.

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -51,40 +51,43 @@ walk-off/equip/walk-on enum, which sits outside the paddle and sets `drive_block
 (`timeout_controller.gd:14`). Wiring named animation states is the occasion to make
 movement state explicit, with the FSM as the single owner the animation reads from.
 
-### Finding: TimeoutController is the wrong shape and should decompose first
+### Finding: TimeoutController is the wrong shape and should decompose
 
-`TimeoutController` (`scripts/core/timeout_controller.gd`) welds three concerns into
-one class, and only one of them is what the animation FSM actually needs:
+`TimeoutController` (`scripts/core/timeout_controller.gd`) is a manager that reaches
+into the paddle and performs world interaction directly: every physics frame it drives
+`main_character.velocity` and calls `move_and_slide()` (`_step_descent`, `_step_ascent`,
+`_step_horizontal_walk`) to walk the paddle around the venue. Moving a body through the
+world is not a manager's place. A controller coordinates, it decides what should happen;
+the world interaction itself belongs on the thing that lives in the world.
 
-1. **Scripted movement.** Driving the paddle to a target point through the venue
-   (`_start_horizontal_walk`, `_step_horizontal_walk`, `_step_descent`, `_step_ascent`).
-   Nothing here is timeout-specific; it is generic "move this paddle to there." This is
-   the concern reused when the player moves around the venue during a timeout, not just
-   the off-and-back errand.
-2. **Control handoff.** Suspending the paddle's own drive (`set_physics_process(false)`,
-   `drive_blocked = true`) and swapping the collision mask, then restoring both. Generic
-   to any context that scripts the paddle.
-3. **The timeout sequence.** The `IDLE, DESCENDING, WALKING_OFF, AT_EQUIP_POSE,
-   WALKING_ON, ASCENDING` orchestration to the equip pose and back, plus the lifecycle
-   signals. This is the only genuinely timeout-specific part, and it is a *consumer* of
-   movement, not the owner of it.
+The decomposition follows from that rule, owner by where the behaviour happens:
 
-Timeout is going to be more than this errand (player movement around the venue), so the
-movement concern must come out from under the timeout choreography. The decomposition:
-a **mover** (drive a paddle to venue targets), a **control-handoff** (suspend/restore
-drive and mask), and a thin **timeout orchestrator** that composes the two into the
-off-and-back sequence. Venue movement then reuses the mover and handoff directly.
+1. **Movement is the paddle's.** Walking to a target, descending to the floor, ascending
+   to the lane: this is the paddle (a `CharacterBody2D`, the world body) moving itself.
+   It owns "move me to this venue target." This is also exactly what player movement
+   around the venue needs, the paddle can move itself regardless of why, so the
+   capability is reused, not duplicated.
+2. **Control mode is the paddle's.** Whether the paddle is player-driven or following a
+   scripted target (`drive_blocked`, `set_physics_process`, the collision-mask swap) is
+   the paddle managing its own control modes, not a flag imposed from outside.
+3. **The equip sequence is the coordinator's.** Go to the equip pose, be equipped,
+   return, plus the lifecycle signals. This is the genuinely errand-specific part and the
+   good first extraction: an `EquipController` that holds no `move_and_slide`, asks the
+   paddle to move to the equip pose, and reacts when it arrives.
 
-### The FSM defers to the movement concern, not the timeout orchestrator
+So a first cut is an `EquipController` (pure coordinator: equip sequence, signals,
+policy) sitting on a paddle that owns its own venue movement. Timeout becomes the broader
+mode under which equip is one errand; player venue-movement is another, both asking the
+same paddle to move. The manager never touches `move_and_slide`.
 
-Given that decomposition, the animation FSM's relationship corrects: it is a downstream
-consumer of the **movement** concern (the mover), the same way it consumes the
-velocity-driven states. The timeout orchestrator is a *peer* consumer of movement, not
-the locomotion authority the FSM reports to. During a timeout the FSM still animates
-walk-off/walk-on, but it reads them from the active movement, not from a timeout phase
-enum it has to special-case. This is cleaner than the FSM hard-wiring to
-`TimeoutController.get_state()`: once movement is its own concern, both the FSM and the
-timeout sequence read from it, and neither owns the other.
+### The FSM reads the paddle's own movement, not a controller
+
+Given that the paddle owns its movement, the animation FSM's relationship is simple: it
+reads the paddle's own movement state, the same single source whether the paddle is moving
+under player input, AI, or an equip errand. No special-casing a controller's phase enum,
+no FSM hard-wired to `TimeoutController.get_state()`. The equip coordinator and the FSM
+are both downstream of the paddle's movement; neither owns the other, and neither owns the
+movement.
 
 The decomposition is build-and-refactor work the spike does not execute; it is a
 sequenced refactor (plan via `impact_check` / `dependency_graph`) that lands before or
@@ -209,10 +212,11 @@ driven by `paddle.gd` is a build-time structural taste call, not load-bearing he
 - New gameplay states. `ready` and `swing` are defined animation hooks the FSM can
   enter; the gameplay that triggers a held `ready` or a swing windup is separate work.
 - The movement FSM's full design beyond what animation needs to read.
-- Executing the `TimeoutController` decomposition. The spike surfaces it (the movement
-  concern must come out from under the timeout choreography, and the FSM defers to that
-  movement concern, not the orchestrator) and names it as a dependency the rig is
-  entangled with. The sequenced refactor itself, planned via `impact_check` /
-  `dependency_graph`, is its own work that lands before or alongside the build.
+- Executing the `TimeoutController` decomposition. The spike surfaces it (world
+  interaction is not a manager's place: movement and control-mode belong on the paddle,
+  with an `EquipController` as a pure coordinator on top, and the FSM reads the paddle's
+  own movement) and names it as a dependency the rig is entangled with. The sequenced
+  refactor itself, planned via `impact_check` / `dependency_graph`, is its own work that
+  lands before or alongside the build.
 - Any `AnimationPlayer` or `AnimationTree` adoption. Both are additive later if
   blended locomotion or frame-synced multi-track events are ever wanted.

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -39,10 +39,9 @@ sprite animation; it carries less per-instance overhead than AnimationPlayer
 
 Gameplay state (idle / ready / walk, and the transient swing action) lives in a
 movement state machine on the paddle. The animation layer is a downstream consumer:
-the FSM decides the state, then tells the sprite which animation to play and which
-collider to activate. State must never live in the animation, or the ball physics
-(is the swing hitbox active) would depend on which sprite frame is showing, coupling
-collision to art.
+the FSM decides the state, then tells the sprite which animation to play. State must
+never live in the animation, or the ball physics would depend on which sprite frame is
+showing, coupling collision to art.
 
 The paddle has no movement FSM today. State is implicit: `velocity.y != 0` reads as
 moving, `== 0` as idle, and the only explicit machine is `TimeoutController`'s
@@ -85,7 +84,8 @@ it is reactive animation, the paddle plays a swing because a hit happened, not a
 timed action that extends reach or alters the hitbox. The ball always strikes the
 same body. So there is no per-state silhouette to track, no per-frame collision
 shape, and nothing to toggle: the paddle has one authored collider, and the sprite
-animates freely over it.
+animates freely over it. (This argues `swing` specifically; if a future `ready` pose
+ever extends the paddle's reach, the collider question reopens for that state alone.)
 
 This also keeps the bounce stable. `Paddle.get_half_height()` (`paddle.gd`) feeds the
 ball's return-angle contact-offset denominator; because the collider is one fixed

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -51,42 +51,16 @@ walk-off/equip/walk-on enum, which sits outside the paddle and sets `drive_block
 (`timeout_controller.gd:14`). Wiring named animation states is the occasion to make
 movement state explicit, with the FSM as the single owner the animation reads from.
 
-### Finding: extract an EquipController from TimeoutController
-
-`TimeoutController` (`scripts/core/timeout_controller.gd`) bundles the scripted equip
-errand with its own machinery. The errand is specific: walk the main character off to a
-fixed equip pose, hold there, walk back (`_equip_pose_x`, the `AT_EQUIP_POSE` /
-`main_character_reached_equip_pose` sequence). The name `timeout` describes *when* this
-runs, not *what* it does; what it does is equip. So the first extraction is an
-`EquipController` that owns the equip sequence and its lifecycle signals.
-
-Two notes bound this, so the spike does not over-reach:
-
-- **This movement is scripted, not player-controlled.** The walk/descend/ascend the
-  controller performs is the game driving the paddle to a fixed target, automated, no
-  player agency. It is the equip errand's mechanism, and it stays with the equip errand.
-- **Player-controlled venue movement during a timeout does not exist yet.** It is
-  anticipated (the player steering the paddle around the venue during the break is its own
-  future capability with player input), but it is not present in `TimeoutController` to
-  factor out, and it is a different thing from the scripted equip walk. The spike does not
-  design or pre-factor for it; the seam for it gets built when that feature arrives. The
-  only consequence for now: do not treat the current controller as "the locomotion
-  authority", because it only knows one scripted errand, not the movement modes coming
-  later.
-
 ### The FSM reads paddle movement state, not a controller phase
 
 The animation FSM consumes the paddle's movement state directly (velocity-driven idle vs
-moving), not a controller's internal phase enum. During an equip errand the paddle is
-still moving, so the FSM animates that movement the same way; it does not need to be
-hard-wired to `TimeoutController.get_state()`. Whatever the `EquipController` extraction
-settles, the FSM's input is paddle movement, which keeps the FSM independent of how any
-one errand is orchestrated.
-
-The decomposition is build-and-refactor work the spike does not execute; it is a
-sequenced refactor (plan via `impact_check` / `dependency_graph`) that lands before or
-alongside the animation rig. The constraint the build inherits: do not couple the FSM
-to the current `TimeoutController` class shape, because that class is splitting.
+moving), not any controller's internal phase enum. During a timeout the paddle is still
+moving, so the FSM animates that movement the same way; it does not need to be hard-wired
+to `TimeoutController.get_state()`. The constraint the build inherits: do not couple the
+FSM to `TimeoutController`'s current class shape, because that shape is under separate
+review (the timeout/equip responsibilities are being re-homed by ownership in their own
+refactor). Keying the FSM to paddle movement keeps it independent of how any errand is
+orchestrated.
 
 ## Why swing is an overlay, not a state, and why no tree
 
@@ -195,10 +169,10 @@ independently, per the decouple decision above), adds the per-state colliders, a
 the movement FSM to drive both. Note `TimeoutController` also reads the collider via
 `_half_height()` to anchor the paddle's foot during in-pose resizes, and comments there
 reference `_apply_size`'s foot-anchoring; retiring `_apply_size` is a cross-effect the
-build must reconcile with that controller (another reason the decomposition above is
-entangled with this rig). Whether to wrap the AnimatedSprite2D and colliders in a small
-reusable child node (instanced across the three scenes) or keep them as direct children
-driven by `paddle.gd` is a build-time structural taste call, not load-bearing here.
+build must reconcile with that controller. Whether to wrap the AnimatedSprite2D and
+colliders in a small reusable child node (instanced across the three scenes) or keep them
+as direct children driven by `paddle.gd` is a build-time structural taste call, not
+load-bearing here.
 
 ## Out of scope
 
@@ -206,13 +180,8 @@ driven by `paddle.gd` is a build-time structural taste call, not load-bearing he
 - New gameplay states. `ready` and `swing` are defined animation hooks the FSM can
   enter; the gameplay that triggers a held `ready` or a swing windup is separate work.
 - The movement FSM's full design beyond what animation needs to read.
-- Executing the `EquipController` extraction. The spike surfaces it (the scripted equip
-  errand should be its own coordinator, lifted out of `TimeoutController`) and names it as
-  a dependency the rig is entangled with. The sequenced refactor itself, planned via
-  `impact_check` / `dependency_graph`, is its own work that lands before or alongside the
-  build.
-- Player-controlled venue movement during a timeout. Anticipated but unbuilt; not
-  designed or pre-factored here. Named only to keep the equip extraction from baking in
-  "timeout is this one scripted errand."
+- The `TimeoutController` reshape. Its timeout/equip responsibilities are being re-homed
+  by ownership under a separate refactor; the spike only constrains the FSM not to couple
+  to that controller's current shape, and does not decide or execute the reshape.
 - Any `AnimationPlayer` or `AnimationTree` adoption. Both are additive later if
   blended locomotion or frame-synced multi-track events are ever wanted.

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -11,11 +11,10 @@ states exist.
 Paddles render through an `AnimatedSprite2D` whose `SpriteFrames` resource holds
 named placeholder animations (idle, ready, swing, walk). A movement state machine
 owns the paddle's gameplay state and drives the animation downstream; the
-animation layer never holds gameplay state. Swing is a transient overlay action
-composed in code on top of the current movement state, not a movement state of its
-own. Collision uses a small set of per-state primitive shapes (a `CollisionShape2D`
-sized for idle/walk, a wider/taller one for swing), toggled in code on state
-change, never keyed off an `AnimationPlayer` track. No `AnimationTree`.
+animation layer never holds gameplay state. Swing is reactive animation (the paddle
+plays it because a hit happened, it is not a player input), so collision does not
+change with it: the paddle has one fixed authored collider and the sprite animates
+over it. No `AnimationTree`.
 
 Real character art lands later as a `SpriteFrames` swap with matching animation
 names; no GDScript changes. This satisfies [#587](https://github.com/shuck-dev/volley/issues/587)'s
@@ -47,8 +46,8 @@ collision to art.
 
 The paddle has no movement FSM today. State is implicit: `velocity.y != 0` reads as
 moving, `== 0` as idle, and the only explicit machine is `TimeoutController`'s
-walk-off/equip/walk-on enum, which sits outside the paddle and sets `drive_blocked`
-(`timeout_controller.gd:14`). Wiring named animation states is the occasion to make
+walk-off/equip/walk-on enum, which sits outside the paddle and sets the paddle's
+`drive_blocked` flag (declared on `paddle.gd`). Wiring named animation states is the occasion to make
 movement state explicit, with the FSM as the single owner the animation reads from.
 
 ### The FSM reads paddle movement state, not a controller phase
@@ -71,76 +70,41 @@ on top of a persistent movement state.
 
 Overlay composition does not require an `AnimationTree`. A tree earns its cost when
 the composition is blended and continuous (speed-graded locomotion, per-bone upper
-body over lower body). Ours is discrete and orthogonal: one channel picks the body
-animation, another toggles the swing collider and pose. Sprite frames cannot
+body over lower body). Ours is discrete: the movement state picks the body animation,
+and a swing plays its animation on top when a hit fires. Sprite frames cannot
 meaningfully blend (a frame is a discrete picture), so a tree here would be a state
 selector with extra ceremony, while also forcing the loss of AnimatedSprite2D.
-Discrete orthogonal composition is a few lines in the FSM. Revisit a tree only if
-blended locomotion or live multi-layer sprite compositing is ever wanted; both are
-additive over this.
+Discrete composition is a few lines in the FSM. Revisit a tree only if blended
+locomotion or live multi-layer sprite compositing is ever wanted; both are additive
+over this.
 
-## Why per-state colliders, toggled in code
+## One fixed collider, the sprite animates over it
 
-A ball must not pass through the character as the silhouette changes across states.
-The options, with the shipped-game precedent that settles them:
+The collider does not change across animation states. Swing is not a player input;
+it is reactive animation, the paddle plays a swing because a hit happened, not a
+timed action that extends reach or alters the hitbox. The ball always strikes the
+same body. So there is no per-state silhouette to track, no per-frame collision
+shape, and nothing to toggle: the paddle has one authored collider, and the sprite
+animates freely over it.
 
-| Option | Cost | Verdict |
-|---|---|---|
-| Per-frame `CollisionPolygon2D` from sprite alpha | 16-32 unique shapes to validate; every write invalidates the physics-server shape; concave is the slowest shape type | Rejected: impractical outside fighting games; no engine support ([proposal #829](https://github.com/shuck-dev/volley/issues/829) open, unmilestoned) |
-| Per-state primitive shapes, toggled on state change | One shape per state, swap on transition | Chosen |
-| Single static capsule | Cheapest, least accurate | Rejected: a capsule covering the swing extent feels too large at idle |
+This also keeps the bounce stable. `Paddle.get_half_height()` (`paddle.gd`) feeds the
+ball's return-angle contact-offset denominator; because the collider is one fixed
+shape, that reference never moves with the animation. The sprite varies; the angle
+does not.
 
-Shipped 2D action games near-universally avoid silhouette-tracking colliders.
-Celeste and TowerFall use integer axis-aligned bounding boxes for every actor and
-projectile ([Thorson](https://maddythorson.medium.com/celeste-and-towerfall-physics-d24bd2ae0fc5));
-even Smash, the one genre with per-frame hitboxes, uses authored capsules on bone
-positions, not pixel polygons ([Smash Wiki](https://www.ssbwiki.com/Hitbox)).
-Player hitboxes are intentionally sized for feel, not pixel accuracy. For a fast
-ball, tunnelling is solved by continuous collision detection, not polygon detail, so
-a complex collider buys nothing the ball can use.
+The collider's only legitimate size change is the stat-driven loadout resize in
+`_apply_size()` (item effects growing/shrinking the paddle), which is per-loadout, not
+per-frame, and is the existing foot-anchor path, untouched by this work.
 
-### The collider is authored independently of the sprite, not derived from it
+### Decouple the collider from the sprite
 
-Today the sprite and collider are coupled by derivation: `_apply_size()`
-(`paddle.gd:127`) scales `sprite.scale.y` to match the collider. That coupling is
-exactly what breaks once the sprite animates, the visual silhouette changes frame to
-frame, and anything derived from it drifts with it. The paddle collider is also a
-gameplay input, not only a presence test: `Paddle.get_half_height()`
-(`paddle.gd:82-83`) feeds the ball's return-angle contact-offset denominator, so a
-collider that tracked the sprite would make the bounce angle wobble with the art.
-
-Decision: decouple the collider from the sprite. The collider is its own authored
-shape, sized for gameplay feel, and the sprite is its own thing, sized for the art;
-neither is calculated from the other, and the `_apply_size` sprite-from-collider
-derivation retires. The sprite then varies freely across animation states and frames
-without ever touching collision or the return angle, because the collision shape was
-never derived from it. The contact reference for the bounce reads from the authored
-collider, which is stable. A per-state collider that differs (a wider swing shape) is
-then a deliberate authored choice, not a side effect of the sprite, and its effect on
-the return angle, if any, is intended rather than incidental.
-
-### Toggle the collider in `_physics_process`, not on an animation callback
-
-The FSM drives the collider toggle in code (the AnimationPlayer caveat below). One
-timing trap to honour: AnimatedSprite2D advances in `_process`, physics reads collider
-shape in `_physics_process`, different loops. If the FSM flips the active collider from
-a `_process`-side animation callback, a physics step can run before the next `_process`
-and read the stale collider, so a ball hit in that one-frame window gets the wrong shape
-and angle. Pin the toggle to `_physics_process` (drive the FSM there, or set the
-collider state on the same physics tick the state changes), so the shape the ball reads
-is never a frame behind the state.
-
-### Caveat: do not key the collider toggle from an AnimationPlayer
-
-The tempting pattern (an AnimationPlayer track keying `CollisionShape2D.disabled` per
-frame) has a cluster of known Godot bugs: a call-function track cannot reliably
-enable a CollisionShape2D ([#18824](https://github.com/godotengine/godot/issues/18824)),
-and the `disabled` property toggled via animation has reported inverted-state and
-re-enable-on-unpause behaviour ([#30383](https://github.com/godotengine/godot/issues/30383),
-[forum](https://forum.godotengine.org/t/unpause-animationplayer-re-enables-disabled-collisionshape2d/38723)).
-Drive the toggle from the FSM in code instead. The FSM already makes the state
-decision; it flips the active collider in the same transition, so sprite and collider
-cannot disagree.
+Today `_apply_size()` ends by scaling `sprite.scale.y` to match the collider, the one
+line that couples the visual to the physics shape. Once the sprite animates, that
+derivation drifts. The build removes that final sprite-scale line; the collider-resize
+and the `position.y` foot-anchor in `_apply_size` stay untouched, so
+`TimeoutController._half_height()` (which reads the collider, not the sprite) is
+unaffected. After that, the collider is authored on its own and the sprite is authored
+on its own; neither derives from the other.
 
 ## Frame delivery: individual images
 
@@ -161,18 +125,15 @@ Three paddle scenes, all 2D `CharacterBody2D`, share `paddle.gd`:
 | `scenes/partner_paddle.tscn` | CharacterBody2D | child `Sprite2D` "Sprite", `PlaceholderTexture2D` |
 | `scenes/partners/martha_paddle.tscn` | CharacterBody2D | child `Sprite2D` "Sprite" + cosmetic "Bow" overlay |
 
-`sprite` is already `@export` (`paddle.gd:13`); today its only logic is `_apply_size()`
-scaling `sprite.scale.y` to the collider (`paddle.gd:127`). The build swaps the
-`Sprite2D` export to `AnimatedSprite2D` across `paddle.gd` and the three scenes, retires
-the `_apply_size` sprite-from-collider derivation (the sprite and collider are authored
-independently, per the decouple decision above), adds the per-state colliders, and wires
-the movement FSM to drive both. Note `TimeoutController` also reads the collider via
-`_half_height()` to anchor the paddle's foot during in-pose resizes, and comments there
-reference `_apply_size`'s foot-anchoring; retiring `_apply_size` is a cross-effect the
-build must reconcile with that controller. Whether to wrap the AnimatedSprite2D and
-colliders in a small reusable child node (instanced across the three scenes) or keep them
-as direct children driven by `paddle.gd` is a build-time structural taste call, not
-load-bearing here.
+`sprite` is already `@export` (`paddle.gd`); today its only animation-relevant logic is
+`_apply_size()` ending by scaling `sprite.scale.y` to the collider. The build swaps the
+`Sprite2D` export to `AnimatedSprite2D` across `paddle.gd` and the three scenes, removes
+that final sprite-scale line from `_apply_size` (the collider-resize and `position.y`
+foot-anchor in `_apply_size` stay, so `TimeoutController._half_height()` is unaffected),
+and wires the movement FSM to drive the animation. The single collider is untouched.
+Whether to wrap the AnimatedSprite2D in a small reusable child node (instanced across the
+three scenes) or keep it a direct child driven by `paddle.gd` is a build-time structural
+taste call, not load-bearing here.
 
 ## Out of scope
 

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -51,6 +51,22 @@ walk-off/equip/walk-on enum, which sits outside the paddle and sets `drive_block
 (`timeout_controller.gd:14`). Wiring named animation states is the occasion to make
 movement state explicit, with the FSM as the single owner the animation reads from.
 
+### The FSM defers to TimeoutController, it does not replace it
+
+`TimeoutController` (`timeout_controller.gd:14`) already runs a six-state machine
+(IDLE, DESCENDING, WALKING_OFF, AT_EQUIP_POSE, WALKING_ON, ASCENDING) that drives the
+paddle during a timeout and holds `drive_blocked` for the whole non-IDLE span. The two
+most common non-idle paddle states (walk-off, walk-on) live there, so the new movement
+FSM cannot ignore it. The relationship: the movement FSM reads `drive_blocked` (or
+`TimeoutController.get_state()`) as its highest-priority input. While a timeout is
+active, the FSM is in a `timeout` state that maps the controller's phase to an
+animation (descending/ascending to a walk-cycle, at-equip to an idle-or-pose), and the
+collider follows that. TimeoutController stays the locomotion authority during a
+timeout; the FSM only translates its phase into animation-and-collider, the same
+downstream-consumer role it has for the velocity-driven states. The full FSM transition
+table is build-ticket work, but this priority (timeout phase outranks velocity) is the
+constraint the build inherits, not a blank slate.
+
 ## Why swing is an overlay, not a state, and why no tree
 
 Swing is a transient action that can fire while the paddle is idle or walking, not a
@@ -87,6 +103,30 @@ positions, not pixel polygons ([Smash Wiki](https://www.ssbwiki.com/Hitbox)).
 Player hitboxes are intentionally sized for feel, not pixel accuracy. For a fast
 ball, tunnelling is solved by continuous collision detection, not polygon detail, so
 a complex collider buys nothing the ball can use.
+
+### The collider extent is a gameplay input, so the angle denominator stays fixed
+
+The paddle collider is not only a presence test. `Paddle.get_half_height()`
+(`paddle.gd:82-83`) returns the collider's half vertical extent, and the ball's return
+angle uses it as the contact-offset denominator. So a per-state collider that is taller
+during swing would silently change the return angle on swing hits, a feel bug with no
+obvious cause ("edge hits feel off"). Decision: split the two concerns the single
+`RectangleShape2D` currently collapses. The per-state shape that varies is the physics
+extent (what the ball bounces off); the angle denominator stays a fixed reference
+height, not whichever collider is active. `get_half_height()` returns that fixed
+reference, not the live shape. A per-state swing collider may differ in physics extent
+without touching the return-angle math.
+
+### Toggle the collider in `_physics_process`, not on an animation callback
+
+The FSM drives the collider toggle in code (the AnimationPlayer caveat below). One
+timing trap to honour: AnimatedSprite2D advances in `_process`, physics reads collider
+shape in `_physics_process`, different loops. If the FSM flips the active collider from
+a `_process`-side animation callback, a physics step can run before the next `_process`
+and read the stale collider, so a ball hit in that one-frame window gets the wrong shape
+and angle. Pin the toggle to `_physics_process` (drive the FSM there, or set the
+collider state on the same physics tick the state changes), so the shape the ball reads
+is never a frame behind the state.
 
 ### Caveat: do not key the collider toggle from an AnimationPlayer
 


### PR DESCRIPTION
The two paddle spikes, #587 (animation states) and #865 (sprite collisions), are one decision: both rework the same Sprite/collider seam on `paddle.gd`, and the collider question has no answer until the animation states exist. This records that joint decision as a spike note under `designs/01-prototype/tech/`, in the same shape as the surface-physics ownership spike, for the build work to cite.

The note states the chosen architecture (AnimatedSprite2D with a swappable SpriteFrames, a movement FSM as the source of truth, swing as a code-composed overlay, per-state colliders toggled in code, no AnimationTree) and records each rejected alternative with its reason and the Godot engine caveats behind them. The research is cited inline. This PR is the spike's deliverable; the build work it unlocks files separately and cites the merged note.

#587
#865