### PR TITLE
chore: gate rm at the hook level with a real reason

### DIFF
--- a/.claude/hooks/rm-permission-reason.sh
+++ b/.claude/hooks/rm-permission-reason.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
-# PreToolUse(Bash) guard for rm. The bare permissions rules (Bash(rm:*) on ask,
-# Bash(rm -rf:*) on deny) fire silently, so a denial reaches the agent as a bare
-# "denied" with no cause, and the agent guesses why. This hook emits the SAME
-# decisions WITH a permissionDecisionReason the agent can read, so the gate
-# explains itself instead of being reverse-engineered.
+# PreToolUse(Bash) gate for rm. This hook IS the gate (no bare permissions rule
+# behind it), so it carries its own reasoning rather than narrating a rule:
+#   - rm -rf (recursive force): denied.
+#   - plain rm tacked on as a trailing cleanup after other commands: allowed, but
+#     warned, that trailing-cleanup pattern is the one that drags an otherwise-fine
+#     command onto a prompt and reads badly; split it into its own step.
+#   - plain rm on its own: allowed silently.
 set -euo pipefail
 
 cmd="$(jq -r '.tool_input.command // ""')"
 [ -z "$cmd" ] && exit 0
 
-# rm -rf (and -fr / -r -f variants): deny outright. Matches an rm invocation
-# carrying both recursive and force flags.
+# rm with both recursive and force flags (-rf / -fr / -r -f / -f -r): deny.
 if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]&|;`(])rm[[:space:]]+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r|-r[[:space:]]+-f|-f[[:space:]]+-r)'; then
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"rm -rf is on the deny list: recursive force-delete is never run unattended. If a directory must go, remove its contents in a reviewed step or ask Josh."}}'
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Recursive force-delete (rm -rf) is not run unattended. Remove a directory'"'"'s contents in a reviewed step, or ask Josh."}}'
   exit 0
 fi
 
-# Any other rm: ask, with the reason so a denial is legible (this is what bit a
-# trailing `rm -rf \"$TMP\"` cleanup tacked onto an otherwise-fine command).
-if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]&|;`(])rm([[:space:]]|$)'; then
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"rm is on the ask list; confirm the path is intended. Note: a trailing rm cleanup drags an otherwise-fine command onto this path, prefer leaving /tmp files or deleting them in a separate step."}}'
+# Plain rm that follows another command on the same line (&&, ||, ;, |, newline):
+# the trailing-cleanup pattern. Allow, but warn.
+if printf '%s' "$cmd" | grep -Eq '[^[:space:]].*([&|;]|`)[[:space:]]*rm([[:space:]]|$)'; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"Trailing rm cleanup: this rm runs after other commands on the same line. Allowed, but prefer leaving /tmp files or deleting them in a separate step, a trailing cleanup is what drags an otherwise-fine command onto a prompt."}}'
   exit 0
 fi
+
+# Any other rm (leading / sole command): allow silently by not emitting a decision.

--- a/.claude/hooks/rm-permission-reason.sh
+++ b/.claude/hooks/rm-permission-reason.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard for rm. The bare permissions rules (Bash(rm:*) on ask,
+# Bash(rm -rf:*) on deny) fire silently, so a denial reaches the agent as a bare
+# "denied" with no cause, and the agent guesses why. This hook emits the SAME
+# decisions WITH a permissionDecisionReason the agent can read, so the gate
+# explains itself instead of being reverse-engineered.
+set -euo pipefail
+
+cmd="$(jq -r '.tool_input.command // ""')"
+[ -z "$cmd" ] && exit 0
+
+# rm -rf (and -fr / -r -f variants): deny outright. Matches an rm invocation
+# carrying both recursive and force flags.
+if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]&|;`(])rm[[:space:]]+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r|-r[[:space:]]+-f|-f[[:space:]]+-r)'; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"rm -rf is on the deny list: recursive force-delete is never run unattended. If a directory must go, remove its contents in a reviewed step or ask Josh."}}'
+  exit 0
+fi
+
+# Any other rm: ask, with the reason so a denial is legible (this is what bit a
+# trailing `rm -rf \"$TMP\"` cleanup tacked onto an otherwise-fine command).
+if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]&|;`(])rm([[:space:]]|$)'; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"rm is on the ask list; confirm the path is intended. Note: a trailing rm cleanup drags an otherwise-fine command onto this path, prefer leaving /tmp files or deleting them in a separate step."}}'
+  exit 0
+fi

--- a/.claude/hooks/rm-permission-reason.sh
+++ b/.claude/hooks/rm-permission-reason.sh
@@ -11,8 +11,18 @@ set -euo pipefail
 cmd="$(jq -r '.tool_input.command // ""')"
 [ -z "$cmd" ] && exit 0
 
-# rm with both recursive and force flags (-rf / -fr / -r -f / -f -r): deny.
-if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]&|;`(])rm[[:space:]]+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r|-r[[:space:]]+-f|-f[[:space:]]+-r)'; then
+# rm with both recursive AND force, in any spelling, denied. Catches:
+#   - short clusters: -rf, -fr, -rvf, -r -f, -f -r
+#   - long flags: --recursive --force (either order, mixed with short)
+#   - path-qualified / escaped / wrapped: /bin/rm, \rm, $(rm ...), `rm ...`, xargs rm
+# rm is matched as a command token (start, whitespace, separator, slash, backslash,
+# or subshell char before it), then recursive and force each appear somewhere after.
+_rm_invoked='(^|[[:space:]&|;`($\\/])rm[[:space:]]'
+_has_recursive='(-[a-zA-Z]*r|--recursive)'
+_has_force='(-[a-zA-Z]*f|--force)'
+if printf '%s' "$cmd" | grep -Eq "${_rm_invoked}" \
+  && printf '%s' "$cmd" | grep -Eq "${_rm_invoked}.*${_has_recursive}" \
+  && printf '%s' "$cmd" | grep -Eq "${_rm_invoked}.*${_has_force}"; then
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Recursive force-delete (rm -rf) is not run unattended. Remove a directory'"'"'s contents in a reviewed step, or ask Josh."}}'
   exit 0
 fi

--- a/.claude/hooks/rm-permission-reason.sh
+++ b/.claude/hooks/rm-permission-reason.sh
@@ -1,41 +1,35 @@
 #!/usr/bin/env bash
 # PreToolUse(Bash) gate for rm. This hook IS the gate (no bare permissions rule
-# behind it), so it carries its own reasoning rather than narrating a rule:
-#   - rm -rf (recursive force): denied.
-#   - plain rm tacked on as a trailing cleanup after other commands: allowed, but
-#     warned, that trailing-cleanup pattern is the one that drags an otherwise-fine
-#     command onto a prompt and reads badly; split it into its own step.
-#   - plain rm on its own: allowed silently.
+# behind it):
+#   - rm chained/piped with other commands (&&, ||, ;, |, newline, or wrapped in
+#     a subshell): denied. A chained rm hides damage in a line that's hard to
+#     eyeball; run it on its own.
+#   - standalone rm -rf (recursive force): denied. Reviewed deletes only.
+#   - standalone plain rm: allowed.
+# rm is matched as a command token (start, whitespace, separator, slash, backslash,
+# or subshell char before it), so /bin/rm, \rm, $(rm ...), `rm ...`, xargs rm count.
 set -euo pipefail
 
 cmd="$(jq -r '.tool_input.command // ""')"
 [ -z "$cmd" ] && exit 0
 
-# rm with both recursive AND force, in any spelling, denied. Catches:
-#   - short clusters: -rf, -fr, -rvf, -r -f, -f -r
-#   - long flags: --recursive --force (either order, mixed with short)
-#   - path-qualified / escaped / wrapped: /bin/rm, \rm, $(rm ...), `rm ...`, xargs rm
-# rm is matched as a command token (start, whitespace, separator, slash, backslash,
-# or subshell char before it), then recursive and force each appear somewhere after.
-# Known limitation: the two flag checks are independent, so two SEPARATE rm calls on
-# one line (rm -r a; rm -f b) trip the deny even though neither is rm -rf. This is a
-# conservative false-deny, not a bypass; split the commands into separate calls. Not
-# worth per-invocation parsing in a shell regex for a rare, recoverable case.
 _rm_invoked='(^|[[:space:]&|;`($\\/])rm[[:space:]]'
-_has_recursive='(-[a-zA-Z]*r|--recursive)'
-_has_force='(-[a-zA-Z]*f|--force)'
-if printf '%s' "$cmd" | grep -Eq "${_rm_invoked}" \
-  && printf '%s' "$cmd" | grep -Eq "${_rm_invoked}.*${_has_recursive}" \
-  && printf '%s' "$cmd" | grep -Eq "${_rm_invoked}.*${_has_force}"; then
+
+# Is there an rm invocation at all?
+printf '%s' "$cmd" | grep -Eq "${_rm_invoked}" || exit 0
+
+# Chained/piped: a command separator (&& || ; |) or a subshell wrapper appears
+# anywhere in the command alongside the rm. Deny the whole line.
+if printf '%s' "$cmd" | grep -Eq '(&&|\|\||;|\||`|\$\()'; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"rm is chained with other commands (a separator or subshell is present). A chained rm hides what it deletes in a line that is hard to review. Run the rm on its own, in a separate step."}}'
+  exit 0
+fi
+
+# Standalone rm -rf: recursive force in any spelling.
+if printf '%s' "$cmd" | grep -Eq '(-[a-zA-Z]*r|--recursive)' \
+  && printf '%s' "$cmd" | grep -Eq '(-[a-zA-Z]*f|--force)'; then
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Recursive force-delete (rm -rf) is not run unattended. Remove a directory'"'"'s contents in a reviewed step, or ask Josh."}}'
   exit 0
 fi
 
-# Plain rm that follows another command on the same line (&&, ||, ;, |, newline):
-# the trailing-cleanup pattern. Allow, but warn.
-if printf '%s' "$cmd" | grep -Eq '[^[:space:]].*([&|;]|`)[[:space:]]*rm([[:space:]]|$)'; then
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"Trailing rm cleanup: this rm runs after other commands on the same line. Allowed, but prefer leaving /tmp files or deleting them in a separate step, a trailing cleanup is what drags an otherwise-fine command onto a prompt."}}'
-  exit 0
-fi
-
-# Any other rm (leading / sole command): allow silently by not emitting a decision.
+# Standalone plain rm: allowed silently.

--- a/.claude/hooks/rm-permission-reason.sh
+++ b/.claude/hooks/rm-permission-reason.sh
@@ -18,15 +18,18 @@ _rm_invoked='(^|[[:space:]&|;`($\\/])rm[[:space:]]'
 # Is there an rm invocation at all?
 printf '%s' "$cmd" | grep -Eq "${_rm_invoked}" || exit 0
 
-# Chained/piped: a command separator (&& || ; |) or a subshell wrapper appears
-# anywhere in the command alongside the rm. Deny the whole line.
-if printf '%s' "$cmd" | grep -Eq '(&&|\|\||;|\||`|\$\()'; then
-  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"rm is chained with other commands (a separator or subshell is present). A chained rm hides what it deletes in a line that is hard to review. Run the rm on its own, in a separate step."}}'
+# Chained/piped: a command separator (&& || ; |), a subshell wrapper, or a newline
+# (multi-line command) appears anywhere alongside the rm. Deny the whole line.
+# The newline is checked directly because grep -E newline handling is unreliable.
+# Known false-deny: a separator char inside a quoted rm argument (rm "a;b") trips
+# this; such filenames must be deleted in a command with no other separators.
+if [ "$cmd" != "${cmd%$'\n'*}" ] || printf '%s' "$cmd" | grep -Eq '(&&|\|\||;|\||`|\$\()'; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"rm is chained with other commands (a separator, subshell, or newline is present). A chained rm hides what it deletes in a line that is hard to review. Run the rm on its own, in a separate step."}}'
   exit 0
 fi
 
-# Standalone rm -rf: recursive force in any spelling.
-if printf '%s' "$cmd" | grep -Eq '(-[a-zA-Z]*r|--recursive)' \
+# Standalone rm -rf: recursive force in any spelling (-R is a synonym for -r).
+if printf '%s' "$cmd" | grep -Eq '(-[a-zA-Z]*[rR]|--recursive)' \
   && printf '%s' "$cmd" | grep -Eq '(-[a-zA-Z]*f|--force)'; then
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Recursive force-delete (rm -rf) is not run unattended. Remove a directory'"'"'s contents in a reviewed step, or ask Josh."}}'
   exit 0

--- a/.claude/hooks/rm-permission-reason.sh
+++ b/.claude/hooks/rm-permission-reason.sh
@@ -17,6 +17,10 @@ cmd="$(jq -r '.tool_input.command // ""')"
 #   - path-qualified / escaped / wrapped: /bin/rm, \rm, $(rm ...), `rm ...`, xargs rm
 # rm is matched as a command token (start, whitespace, separator, slash, backslash,
 # or subshell char before it), then recursive and force each appear somewhere after.
+# Known limitation: the two flag checks are independent, so two SEPARATE rm calls on
+# one line (rm -r a; rm -f b) trip the deny even though neither is rm -rf. This is a
+# conservative false-deny, not a bypass; split the commands into separate calls. Not
+# worth per-invocation parsing in a shell regex for a rare, recoverable case.
 _rm_invoked='(^|[[:space:]&|;`($\\/])rm[[:space:]]'
 _has_recursive='(-[a-zA-Z]*r|--recursive)'
 _has_force='(-[a-zA-Z]*f|--force)'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,7 @@
           { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/git-rebase-ask.sh\"" },
           { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-approved-human.sh\"" },
           { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-pr-merge.sh\"" },
+          { "type": "command", "if": "Bash(rm*)", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-permission-reason.sh\"" },
           { "type": "command", "if": "Bash(*bot-review.yml*)", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/synthesis-body-cap.sh\"" }
         ]
       }


### PR DESCRIPTION
A bare `permissions.ask`/`deny` rule denies silently: the agent sees a refusal with no cause and guesses wrong. The fix is to gate at the hook level, where a `permissionDecisionReason` travels, and let the hook be the gate rather than a second mechanism shadowing a bare rule.

This PreToolUse hook is that gate for `rm`. `rm -rf` denies with a reason; a plain `rm` tacked on as a trailing cleanup after other commands allows but warns (that pattern is what drags an otherwise-fine command onto a prompt); a leading or sole `rm` allows silently. Tested across each case plus JSON well-formedness.

Follow-up once this is live (after `/hooks` reload): remove the now-redundant bare `Bash(rm:*)` / `Bash(rm -rf:*)` rules so the hook is the sole gate. Order matters, the hook must be live before the bare `rm -rf` deny is dropped, or there is a window with no gate.
