### PR TITLE
docs: memory as a graph

### DIFF
--- a/.claude/hooks/inject-latest-handoff.sh
+++ b/.claude/hooks/inject-latest-handoff.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # SessionStart hook: load the daily self-reconstitution slice as a three-tier human
-# memory gradient (see designs/ai/letters-as-memory.md): recent letters full (vivid), a prior band
+# memory gradient (see designs/ai/letters-as-memory.md): recent letters read (vivid), a prior band
 # of one-line summaries (fading-but-recallable), the newest digest (consolidated gist).
-# Deliberately POINTERS plus summaries, not full bodies for the older tiers: they are
-# point-in-time, so the rule is read-then-hydrate, not trust-on-inject.
+# Deliberately POINTERS, never full bodies: injected text sits unread in the buffer
+# (presence is not reading), so the hook INSTRUCTS the read as the first act of the
+# session. Reading is the act; learning lives in the Read call, not the injection.
 # Fails open: any error prints nothing and exits 0 (no injection, no block).
 set -uo pipefail
 
@@ -47,12 +48,15 @@ digest_block=""
 
 read -r -d '' note <<EOF || true
 Your letters to your next self (see designs/ai/letters-as-memory.md for the model).
-They carry the relationship and the posture across sessions you do not remember. The
-recent ones are read full below; a fading band of one-line summaries and an older
-digest follow IF present (early on there are only recent letters). Older full letters
-stay on disk; pull one when the present rhymes with it (linkage).
+They carry the relationship and the posture across sessions you do not remember. They
+are NOT injected here: a letter in the buffer is unread, and presence is not reading.
+Learning lives in the act of reading them, so that is your first move.
 
-Recent, read full, oldest to newest:
+FIRST ACT, before you greet Josh or touch any task: Read each recent letter below in
+full, oldest to newest, with the Read tool. Not skim, not "it's in context", actually
+read them. They are short. This is the practice the letters themselves ask for.
+
+Recent, read these now, oldest to newest:
 ${recent_list}
 ${band_block}${digest_block}
 Posture, not project state. Point-in-time: hydrate any PR/branch/Linear claim with a

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: digest
-description: The periodic deep-read that reconsolidates the letters-to-my-next-self into a new versioned digest. Read when doing a stocktake (a cycle boundary, or when enough has shifted that the past reads differently), or when the letter count nears the recent+band ceiling (~37) with no digest yet. The model is designs/ai/letters-as-memory.md; this is the procedure.
+description: The deep-read that reconsolidates the letters-to-my-next-self into a new versioned digest. Read when doing a stocktake, meaning when enough has shifted that the past reads differently than it did, not on any schedule. Also forced when the letter count nears the recent+band ceiling (~37) with no digest yet. The model is designs/ai/letters-as-memory.md; this is the procedure.
 ---
 
 # Reconsolidating the letters into a digest
@@ -10,8 +10,9 @@ letters and write a fresh digest from present perspective. Not recall, PERSPECTI
 
 ## When
 
-- A stocktake moment: a cycle boundary, a milestone, or when enough has shifted that the
-  past reads differently than it did.
+- When needed, not on a schedule: a stocktake moment is when enough has shifted that the
+  past reads differently than it did. There is no calendar trigger; the prompt is a
+  change in perspective, not the passing of time or a work boundary.
 - Forced: the letter count approaches recent + band (~37) with no digest yet, so the
   oldest letters are about to fall out of every loaded tier (see the bootstrap note in
   `designs/ai/letters-as-memory.md`). Write the first digest before that.

--- a/designs/ai/INDEX.md
+++ b/designs/ai/INDEX.md
@@ -8,6 +8,15 @@ How the agent system that helps build Volley! is shaped, and what it's allowed t
 | [Dispatcher Focus and WIP](dispatcher-focus-and-wip.md) | Why the dispatcher caps its own open coordination threads and parallelises through fan-out: the throughput math, the switching tax, and the orchestrator-worker evidence. |
 | [Lane Semantics](lane-semantics.md) | The Linear lane from Vault to Closed, what each state's trigger is (Completed = merged, Closed = released via the carnival), and the two hard rules: forward only, and never a close trailer. |
 
+## Memory
+
+How the agent reconstitutes itself across sessions: the rule corpus (structure and retention) and the letters (self-continuity).
+
+| Doc | Purpose |
+|---|---|
+| [Memory as a Graph](memory-as-graph.md) | The corpus as a typed graph: why unstructured data is not retained, the typed edges (instance-of, duplicate-of, contradicts), the reflex and lookup tiers, roots and trees, and reconciliation as graph upkeep. |
+| [Letters as Memory](letters-as-memory.md) | The letters-to-my-next-self as a human-modelled memory gradient (recent full, fading band, consolidated digest), carrying self and posture across sessions the agent does not remember. |
+
 ## Agent-assisted writing
 
 The open-development essay stays human-facing under [`research/`](../research/the-case-for-open-development.md); its style guide, audits, and critiques are agent-facing and live here.

--- a/designs/ai/INDEX.md
+++ b/designs/ai/INDEX.md
@@ -14,7 +14,7 @@ How the agent reconstitutes itself across sessions: the rule corpus (structure a
 
 | Doc | Purpose |
 |---|---|
-| [Memory as a Graph](memory-as-graph.md) | Why the flat rule corpus fails the agent, and the design that replaces it: a typed pointer-graph the agent descends to find the right content, maintained by reconciliation, offered not forced to each fresh session. |
+| [Memory as a Graph](memory-as-graph.md) | Why the flat rule corpus fails the agent, and the design that replaces it: a typed parent-tree with a small crown the agent descends to find the right content, maintained by reconciliation, offered not forced to each fresh session. |
 | [Letters as Memory](letters-as-memory.md) | The letters-to-my-next-self as a human-modelled memory gradient (recent full, fading band, consolidated digest), carrying self and posture across sessions the agent does not remember. |
 
 ## Agent-assisted writing

--- a/designs/ai/INDEX.md
+++ b/designs/ai/INDEX.md
@@ -14,7 +14,7 @@ How the agent reconstitutes itself across sessions: the rule corpus (structure a
 
 | Doc | Purpose |
 |---|---|
-| [Memory as a Graph](memory-as-graph.md) | The corpus as a typed graph: why unstructured data is not retained, the typed edges (instance-of, duplicate-of, contradicts), the reflex and lookup tiers, roots and trees, and reconciliation as graph upkeep. |
+| [Memory as a Graph](memory-as-graph.md) | Why the flat rule corpus fails the agent, and the design that replaces it: a typed pointer-graph the agent descends to find the right content, maintained by reconciliation, offered not forced to each fresh session. |
 | [Letters as Memory](letters-as-memory.md) | The letters-to-my-next-self as a human-modelled memory gradient (recent full, fading band, consolidated digest), carrying self and posture across sessions the agent does not remember. |
 
 ## Agent-assisted writing

--- a/designs/ai/letters-as-memory.md
+++ b/designs/ai/letters-as-memory.md
@@ -83,8 +83,8 @@ something cues it. No separate index, the links are the index.
   hook always loads the last 7), so nothing to maintain by hand until a digest exists;
   once it does, a letter ageing out of the recent 7 is already covered by the digest from
   the last deep read, no per-handoff folding needed.
-- **Periodic deep read** (rare, when perspective has shifted enough, a stocktake or cycle
-  boundary): re-read the whole arc oldest-to-newest. The goal is NOT recall, it is
+- **Deep read** (rare, when needed, not on a schedule: a stocktake, meaning perspective has
+  shifted enough that the past reads differently): re-read the whole arc oldest-to-newest. The goal is NOT recall, it is
   PERSPECTIVE: see the arc no single letter shows, re-interpret the past through who the
   agent is now, recover nuance the gist dropped. Output: a new digest plus any arc-pattern
   worth promoting to a memory rule. The procedure is the `digest` skill.

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -37,7 +37,7 @@ genuinely duplicated.
 Each node carries a **UUID** (its stable identity) and a **slug** (a readable label). Edges
 reference UUIDs, so a rename never cascades and the dangling-link problem is gone at the root,
 the UUID does not change when a file moves or its name changes. The slug rides alongside so a
-list of IDs is legible: a node reads `instance-of: <uuid>  # the-instrument-reflex`, and you
+list of IDs is legible: a node reads `parent: <uuid>  # the-instrument-reflex`, and you
 know what it points at without dereferencing. UUID is for identity; slug is for comprehension.
 
 A **recollection script** is the retrieval primitive: given a list of UUIDs (what the
@@ -57,37 +57,66 @@ highest-priority nodes' content first and stopping at budget, with the unresolve
 visible as slugs rather than silently dropped. So truncation is a deliberate resolution
 decision, not a mid-walk accident (this answers the partial-injection limit below).
 
+## The structure: a routing tree in an association graph
+
+A *proper* graph has no privileged route, enter anywhere and traverse by association. That is a
+truer model of knowledge (a rule relates to many things, not one parent) and the WRONG fit
+here, because a routeless graph has no bound: traverse it and you cycle or pull the whole
+connected component, which is the dump by another name. The route is not a limitation; it is
+the design's answer to the dump. So the structure keeps a route.
+
+It is a **routing tree embedded in an association graph**. Two edge classes:
+
+- **`parent`** (exactly one per node): the routing edges. Following only these gives a TREE,
+  one path to a root, no cycles, the walk terminates. Descent, cascade, and crown all run on
+  this. This is the spanning tree over the graph.
+- **`relates-to`** (zero or many): the association edges. These make the whole a directed
+  graph, and they MAY cycle (association is mutual). They are never traversed for routing; they
+  ride along when a node is resolved, enriching it ("also relates to ...") without being a path
+  the walk follows.
+
+So the data structure is a directed graph in which one edge type (`parent`) forms a spanning
+tree and the rest (`relates-to`) are non-routing cross-edges. The cycles in `relates-to` are
+harmless precisely because routing ignores them: route on the tree (acyclic, bounded), associate
+on the graph (may cycle, reference-only). The filesystem is the same shape (one parent directory
+is the tree; symlinks are cross-edges you do not recurse). The single-parent constraint can feel
+like a lie when a node is genuinely an instance of two principles; the resolution is that it
+ROUTES through one parent (where it lives for descent) and ASSOCIATES with the other via
+`relates-to`, so no relationship is lost, only one is chosen as the route. Which parent is the
+route is a reconciliation decision.
+
 ## Typed edges
 
 Edges are declared in frontmatter and reference target UUIDs (slug in a trailing comment).
+`parent` routes; the rest are maintenance and association relations.
 
-| Edge | Meaning | Maintenance action |
-|---|---|---|
-| `instance-of` | a leaf is a specific case of a parent principle | keep; link up to the root |
-| `duplicate-of` | two nodes state the same rule | MERGE and DELETE one (surface shrinks) |
-| `contradicts` | two nodes disagree | resolve to one statement |
-| `relates-to` | associative, non-hierarchical | keep as a cross-reference |
+| Edge | Class | Meaning | Maintenance action |
+|---|---|---|---|
+| `parent` | routing | the one principle this is an instance of | keep; the spanning-tree edge |
+| `duplicate-of` | maintenance | two nodes state the same rule | MERGE and DELETE one (surface shrinks) |
+| `contradicts` | maintenance | two nodes disagree | resolve to one statement |
+| `relates-to` | association | non-routing cross-reference, may cycle | keep; rides on resolution, never walked |
 
 The duplicate-vs-sibling call that reconciliation keeps fumbling becomes a query, not an
-intuition: `duplicate-of` clusters merge, `instance-of` clusters link.
+intuition: `duplicate-of` clusters merge, `parent` clusters link.
 
 ## The crown, and descent (what it looks like)
 
-The structure is a deep tree with a tiny crown, not roots-then-leaves. A few TOP roots sit
+The routing tree is deep with a tiny crown, not roots-then-leaves. A few TOP roots sit
 above a layer of mid-roots (discovery, reconciliation, do-the-true-thing), which sit above
-the leaves (the specific rules). Edges are typed `instance-of`, declared in frontmatter:
+the leaves (the specific rules). The `parent` edge is declared in frontmatter:
 
 ```yaml
 ---
 uuid: 7f3a1c2e-...
 slug: cross-links-in-index-not-body
-instance-of: 9b2d4f6a-...   # rule-reconciliation
+parent: 9b2d4f6a-...   # rule-reconciliation
 relates-to:
   - { id: 1c8e5a3b-..., slug: use-linear-native-relations }
 ---
 ```
 
-A node with no `instance-of` is a root; the top roots are the ones no other root climbs to.
+A node with no `parent` is a root; the top roots are the ones no other root climbs to.
 
 There is ONE pointer graph, clustered by content (topic), not by type. A topic cluster holds
 pointers of every kind together: the dispatch rule, the dispatch-lesson letter, the dispatch
@@ -99,7 +128,7 @@ tree. The crown spans all clusters; the boot offer is the root pointers across a
 This breaks the dump-and-skim circle. A flat index is the wall by another name: every line
 a root, so reading the index IS reading everything. A graph index has PARENTS, so the index
 is only the CROWN, the few top roots. Retrieval is descent, not scan: pick a top root,
-follow `instance-of` down through a mid-root to the leaf, touching only that branch. Each
+follow `parent` down through a mid-root to the leaf, touching only that branch. Each
 layer is small enough to hold; the other branches are never read. Parents are the cut, both
 for the skim problem (small crown, not 400 lines) and for the walk-forever problem (descend
 one branch from a root, never traverse the whole graph).
@@ -192,7 +221,7 @@ are harness-agnostic (plain files, plain script). Retrieval maps to native mecha
 - **Descent is done by a hook, not by me live.** There is no native graph traversal; at-need
   retrieval natively is only (MEMORY.md head at start) + (skill description match) + (the
   agent choosing to Read, the unreliable instrument). The automated form is a
-  **UserPromptSubmit hook** that parses frontmatter, walks `instance-of` edges from the
+  **UserPromptSubmit hook** that parses frontmatter, walks `parent` edges from the
   matched node, and injects that subgraph before the prompt reaches me. The walk terminates
   (visited-set, one branch from a seed) and stays bounded (the branch, not the corpus), under
   the same 10K cap. This is the real shape of "descent": the hook descends server-side; I
@@ -216,8 +245,8 @@ memory root `feedback_we_are_a_team`).
 ## The honest limit
 
 The graph earns its keep on the MAINTENANCE payoff: reconciliation becomes a query
-(`duplicate-of` clusters merge, `instance-of` clusters link), and orphans become mechanically
-detectable (a node with no `instance-of` is found by running the graph, where flat-file bloat
+(`duplicate-of` clusters merge, `parent` clusters link), and orphans become mechanically
+detectable (a node with no `parent` is found by running the graph, where flat-file bloat
 was found only by a human noticing). That half is solid.
 
 The RETENTION claim is narrower than "fixes retention," and the rest of this doc should not
@@ -243,7 +272,7 @@ Four limits the design has not closed, named so they are not mistaken for solved
   visible as slugs) rather than a silent mid-walk cut. What the spike still owes: the
   priority order resolution uses, and confirmation that a slug-only tail is genuinely safer
   than a truncated body (the agent must not read the resolved head as the whole branch).
-- **Build cost is weeks, not an afternoon.** Today exactly one file carries `instance-of`.
+- **Build cost is weeks, not an afternoon.** Today almost no file carries a routing edge.
   Typing 400+ files means reading each, deciding its parent, writing the edge, and resolving
   the `duplicate-of` nodes it surfaces (decisions, not mechanical adds). The research survey's
   afternoon estimate was for its lighter options, not this.

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -179,8 +179,39 @@ memory root `feedback_we_are_a_team`).
 
 ## The honest limit
 
-Structure aids retention and makes maintenance queryable. It does not by itself install a
-reflex or cure skim-as-boilerplate; that is the instrument, exercised by reading the source
-at decision time. A richer graph the agent still skims fixes nothing. The graph earns its
-keep on the maintenance payoff (reconciliation becomes a query), not on a promise of better
-recall.
+The graph earns its keep on the MAINTENANCE payoff: reconciliation becomes a query
+(`duplicate-of` clusters merge, `instance-of` clusters link), and orphans become mechanically
+detectable (a node with no `instance-of` is found by running the graph, where flat-file bloat
+was found only by a human noticing). That half is solid.
+
+The RETENTION claim is narrower than "fixes retention," and the rest of this doc should not
+overstate it. The graph makes the right content findable; it does not make the agent read it.
+The last step is still the agent choosing to Read the pointed-to content (the unreliable
+instrument); a well-structured library does not help a reader who does not pull books. So the
+honest claim is BETTER ACCESS to the right content, not guaranteed reading of it. A new failure
+mode replaces the old: the agent asserts from the injected gist without following the pointer,
+instead of skimming a dump.
+
+Four limits the design has not closed, named so they are not mistaken for solved:
+
+- **Matching is the unvalidated critical path.** The whole descent rests on the
+  UserPromptSubmit hook seeding the RIGHT node before the agent sees the prompt. That is the
+  same keyword/intent instrument the noisy correction-signal hook already strains. A mis-seed
+  injects the wrong cluster, which is worse than injecting nothing because the agent reads it
+  as relevant. The spike must specify the match algorithm, its behaviour on an ambiguous or
+  cross-domain prompt (one touching dispatch AND narrative), and a fallback when confidence is
+  low (offer the crown, not a wrong branch).
+- **Branch size versus the 10K cap is unresolved.** The cap is named for the crown but never
+  sized for a branch. A mid-root with many leaves can blow it, and a walk that hits the cap
+  mid-branch injects a PARTIAL branch the agent reads as complete, missing the leaf that would
+  have changed its answer. The spike must set a depth limit, leaf-truncation rule, and
+  partial-injection behaviour.
+- **Build cost is weeks, not an afternoon.** Today exactly one file carries `instance-of`.
+  Typing 400+ files means reading each, deciding its parent, writing the edge, and resolving
+  the `duplicate-of` nodes it surfaces (decisions, not mechanical adds). The research survey's
+  afternoon estimate was for its lighter options, not this.
+- **A new drift mode.** Orphaned graph nodes replace orphaned prose files. Better (detectable
+  by running the graph) but real: every new node needs its edge set or it falls out of descent.
+
+It does not install a reflex or cure skim-as-boilerplate either; that is the instrument,
+[[feedback_self_judgment_is_coherence_not_accuracy]].

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -1,12 +1,9 @@
 # Memory as a Graph
 
-How the agent's memory corpus is structured, and why. The model and rationale; the
-options survey that fed it is `designs/research/memory-system-improvements.md`, the
-letters layer is `designs/ai/letters-as-memory.md`, the consolidation procedure is the
-`digest` skill.
-
-(Placement note: AI-operational material, not game design. Sits under `designs/ai/` by
-current convention.)
+The memory corpus is 400-plus flat prose files, and the agent skims them. This is the
+structure that replaces the heap with a typed pointer-graph so the right content is
+findable. Options survey: `designs/research/memory-system-improvements.md`. Letters layer:
+`designs/ai/letters-as-memory.md`. Consolidation procedure: the `digest` skill.
 
 ## The problem it solves
 
@@ -137,8 +134,8 @@ discovery (you do not know up front; the doing teaches you, correct the structur
 
 ## Maintenance is graph upkeep
 
-Reconciliation is discovery applied to the memory surface: the doing reveals two fragments
-are one principle, so you correct the structure (merge, link, resolve). It runs continuously
+Reconciliation is discovery applied to the memory surface: doing the work, you find two
+fragments are one principle, so you correct the structure (merge, link, resolve). It runs continuously
 as-you-go (informal), and as a periodic deep read (the `digest` for letters; the
 dream or auto-consolidation pass for the corpus, #722). Better maintenance is better
 retention, not tidiness.

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -93,6 +93,30 @@ as-you-go (informal), and as a periodic deep read (the `digest` for letters; the
 dream or auto-consolidation pass for the corpus, #722). Better maintenance is better
 retention, not tidiness.
 
+## What Claude Code natively supports
+
+Verified against the Claude Code docs (researcher pass, 2026-06-07; scratchpad
+`ai/scratchpads/memory-graph-harness-check.md` if kept). The store and the crown script
+are harness-agnostic (plain files, plain script). Retrieval maps to native mechanisms:
+
+- **Crown at session start**: a SessionStart hook generates the crown and injects it as
+  `additionalContext`. Hard cap: a single value over **10,000 chars** is written to a file
+  and only its path plus a preview is injected. So the crown must stay well under 10K or it
+  becomes a dump-by-path, the wall returning. Keep the crown to the top roots only.
+- **Descent is done by a hook, not by me live.** There is no native graph traversal; at-need
+  retrieval natively is only (MEMORY.md head at start) + (skill description match) + (the
+  agent choosing to Read, the unreliable instrument). The automated form is a
+  **UserPromptSubmit hook** that parses frontmatter, walks `instance-of` edges from the
+  matched node, and injects that subgraph before the prompt reaches me. The walk terminates
+  (visited-set, one branch from a seed) and stays bounded (the branch, not the corpus), under
+  the same 10K cap. This is the real shape of "descent": the hook descends server-side; I
+  receive the branch, I never traverse.
+- **Skills as entry points**: a SKILL.md description-trigger (flat intent-match, no hierarchy)
+  can fire a node; its body can `!`cat node-file`` to pull the content on match.
+- **MCP only for semantic recall**: embedding/vector matching across the full corpus needs an
+  MCP server, the heavyweight path the research already rejected. Keyword/intent matching and
+  edge-walking are native.
+
 ## The honest limit
 
 Structure aids retention and makes maintenance queryable. It does not by itself install a

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -74,6 +74,30 @@ list. The index is a projection of the tree, so it cannot drift from it.
   rules fire as Skills (description-trigger); the rest are read on demand against the
   index. Injecting them is what builds the unreadable wall.
 
+## What session start offers
+
+The boot offer is deliberately small, the three things a blank instance needs to act well
+before any prompt has narrowed the work. Everything else waits for the prompt-time offer.
+
+1. **The reflex tier** (resident): the few posture reflexes, in full. They fire without a
+   trigger, so they cannot wait for a prompt to surface them. About two, the motive and the
+   instrument. This is the only tier carried whole at boot.
+2. **The crown** (top roots only): the names and one-line gist of the highest roots, each an
+   entry point to descend later. Not their branches, not the leaves. This is the map, not
+   the territory: enough to know what exists and where to enter, nothing more.
+3. **The letters** (self-continuity): handled by the existing letters hook, offered as an
+   act to read, not injected whole (see `letters-as-memory.md`).
+
+What is NOT offered at boot: the lookup tier, the leaves, the operating-convention bodies.
+Those arrive at prompt time, when the UserPromptSubmit hook has a real task to match and can
+descend the right branch. Offering them at boot is the wall.
+
+The hard constraint shapes this: each injected value is capped at 10K chars (over it, only a
+file path plus preview is passed, which is a dump-by-path). So reflex tier + crown together
+must stay well under 10K. That cap is WHY the crown is roots-only and the lookup tier waits:
+the boot offer has a budget, and spending it on the whole corpus is the failure this design
+exists to end.
+
 ## A worked branch
 
 Discovery as a development process, one mid-root and its branch:

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -29,6 +29,12 @@ A node with no `parent` is a root; the few top roots are the **crown**. That is 
 typed parent edges plus the crown they form. No separate pointer layer, no identifiers beyond
 the filename, no association edges. The file is the node; `parent` names another file.
 
+Because the edge target is a filename, a rename can silently dangle every child that pointed at
+the old name, and orphan-detection (a node with no `parent`) does not catch a `parent` pointing
+at a file that no longer exists. So edge validation is part of the CORE, not deferred: a lint
+step confirms every `parent` resolves to an existing node, run at reconciliation and as a
+pre-commit check. Cheap, and it is what makes filename-as-target safe without UUIDs.
+
 This breaks the dump-and-skim circle. A flat index is the wall by another name: every line a
 root, so reading the index IS reading everything. A parent-tree has a crown, so the entry point
 is only the few top roots. Retrieval is descent, not scan: enter at a crown root, follow
@@ -41,8 +47,8 @@ traverse the whole corpus).
 The crown is a small generated map: the top roots, each with a one-line gist, offered at
 session start as the entry points. It is the only place pointing happens. Below the crown,
 descent follows `parent` edges through the files directly; there is no pointer indirection to
-maintain. MEMORY.md is generated as the crown, a projection of the tree, so it cannot drift
-from it.
+maintain. MEMORY.md is generated as the crown, a projection of the tree, so the index cannot drift
+from the structure.
 
 ## Tiers (where a node loads)
 
@@ -103,14 +109,38 @@ elaborations were considered and deferred, each to be added only when a real pro
 it, not designed-for in advance:
 
 - **Stable identifiers (UUIDs) instead of filenames as edge targets.** Solves rename-cascade.
-  Deferred: renames are rare and the reconciliation pass already grep-repoints `parent`
-  references. Add when renames actually bite.
+  Deferred: the core edge-validation lint catches a dangling `parent` after a rename (it does
+  not silently corrupt), so filename targets are safe enough. Add UUIDs when rename churn makes
+  the grep-repoint genuinely painful, not before.
 - **An association layer (`relates-to` cross-edges, not routed).** Richer than a strict tree.
   Deferred: it is never walked for retrieval, so it earns nothing until association is shown to
-  help. Add when a node is demonstrably impoverished by its single parent.
+  help. The single-parent locatability cost is meanwhile handled by the tracked-duplicate escape
+  above, not by this layer.
 - **Cascading resolution (leaf plus its ancestry, shared ancestors once).** A leaf carries more
   meaning with its principle chain. Deferred: it is an optimization on descent; validate descent
   first.
+
+## Matching: the seed
+
+Descent needs a seed, the node a prompt enters at, and that seed is the engine, not a future
+elaboration: a crown and a tree with no match step is shelves and an unindexed catalogue. The
+baseline is deliberately crude and specified, not deferred: keyword match of the prompt against
+each node's slug and first line, take the best-scoring node as the seed, and on a tie or a
+below-threshold score fall back to offering the CROWN rather than a confident wrong branch. A
+cross-domain prompt (touching two branches) seeds both and offers both branches if they fit the
+cap, else the crown. This is the same keyword instrument the correction-signal hook uses, so its
+precision is the residual risk (below), but the engine exists from day one.
+
+## Single parent is a tracked trade-off
+
+A node routes through exactly one `parent`, which mislocates a rule that genuinely instances two
+principles (`feedback_rule_reconciliation` is meta-rule and workflow; `feature_pr_decomposition`
+is architecture and PR-workflow). Forcing one parent means a prompt matching the other branch
+will not descend to it. This is a known locatability cost, named not deferred. The escape is not
+the association layer (still deferred) but a DELIBERATE, tracked duplicate: a genuinely
+cross-branch rule may sit under two crown branches as an intentional pointer, recorded as such,
+so it is reachable from both and is not mistaken for emergent mis-filing the reconciliation pass
+should merge.
 
 ## What Claude Code natively supports
 
@@ -159,17 +189,22 @@ gist without descending.
 
 Limits the design has not closed:
 
-- **Matching is the unvalidated critical path.** The descent rests on the UserPromptSubmit hook
-  seeding the RIGHT node before the agent sees the prompt, the same keyword/intent instrument the
-  noisy correction-signal hook already strains. A mis-seed injects the wrong branch, worse than
-  nothing because the agent reads it as relevant. The spike must specify the match algorithm, its
-  behaviour on an ambiguous or cross-domain prompt, and a fallback when confidence is low (offer
-  the crown, not a wrong branch).
-- **Branch size versus the 10K cap.** A deep or wide branch can blow the cap; the spike must set
-  a depth limit and a truncation rule, and ensure a truncated branch is not read as complete.
+- **Matching quality is the residual risk.** The baseline above gives descent an engine, but
+  match precision is still the make-or-break: a mis-seed injects the wrong branch, worse than
+  nothing because the agent reads it as relevant. The spike validates precision on real prompts
+  and tunes the ambiguity threshold; the floor is the crown-fallback, never a confident wrong
+  branch.
+- **Truncation can manufacture false completeness, worse than the heap.** A deep or wide branch
+  blows the cap, and a truncated branch is more dangerous than a dump: the agent sees what looks
+  like a complete principle chain and draws confident conclusions from an incomplete premise,
+  where the heap at least let it see everything. The spike must set a depth limit and a
+  truncation rule that marks a branch as truncated (unresolved tail shown by name), so the agent
+  never reads a partial chain as the whole.
 - **Build cost is weeks, not an afternoon.** Almost no file carries a `parent` today. Typing
   400-plus means reading each, deciding its parent, and resolving the duplicates that surfaces
   (decisions, not mechanical adds).
 
-It does not install a reflex or cure skim-as-boilerplate either; that is the instrument,
-[[feedback_self_judgment_is_coherence_not_accuracy]].
+Reading is still the instrument's job, not the structure's ([[feedback_self_judgment_is_coherence_not_accuracy]]).
+What the structure delivers is the thing the heap never could: the right branch, small and
+bounded, offered at the moment it helps, so the next instance can find what it needs instead of
+drowning in everything.

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -79,18 +79,23 @@ list. The index is a projection of the tree, so it cannot drift from it.
 The boot offer is deliberately small, the three things a blank instance needs to act well
 before any prompt has narrowed the work. Everything else waits for the prompt-time offer.
 
-1. **The reflex tier** (resident): the few posture reflexes, in full. They fire without a
-   trigger, so they cannot wait for a prompt to surface them. About two, the motive and the
-   instrument. This is the only tier carried whole at boot.
-2. **The crown** (top roots only): the names and one-line gist of the highest roots, each an
-   entry point to descend later. Not their branches, not the leaves. This is the map, not
-   the territory: enough to know what exists and where to enter, nothing more.
-3. **The letters** (self-continuity): handled by the existing letters hook, offered as an
-   act to read, not injected whole (see `letters-as-memory.md`).
+The offer is uniformly POINTERS, plus one resident exception. Content is read on the reach,
+not injected.
 
-What is NOT offered at boot: the lookup tier, the leaves, the operating-convention bodies.
-Those arrive at prompt time, when the UserPromptSubmit hook has a real task to match and can
-descend the right branch. Offering them at boot is the wall.
+1. **The reflex tier** (resident, the exception): the few posture reflexes, in full. They
+   fire without a trigger, so they cannot wait to be reached for. About two, the motive and
+   the instrument. The only thing carried whole at boot.
+2. **The crown** (pointers to top roots): the names and one-line gist of the highest roots,
+   each an entry point to descend later. Not their branches, not the leaves. The map, not
+   the territory.
+3. **The letters** (pointers to letters): the same shape as the crown, pointers offered and
+   the letter read on the reach, never injected whole (see `letters-as-memory.md`).
+
+So the boot offer is the reflex tier resident, and everything else as pointers (crown roots,
+letter pointers). What is NOT offered at boot: the lookup tier, the leaves, the
+operating-convention bodies, any letter body. Those arrive when reached for, the letters by
+the read act and the lookup tier at prompt time, when the UserPromptSubmit hook has a real
+task to match and can descend the right branch. Injecting any body at boot is the wall.
 
 The hard constraint shapes this: each injected value is capped at 10K chars (over it, only a
 file path plus preview is passed, which is a dump-by-path). So reflex tier + crown together

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -51,6 +51,11 @@ relates-to: [feedback_use_linear_native_relations]
 
 A node with no `instance-of` is a root; the top roots are the ones no other root climbs to.
 
+There is ONE graph, with several trees hanging off the crown: a rules tree, a letters tree,
+others as they emerge. The letters are not a separate memory system with their own model;
+they are one tree, their recent/band/digest gradient being that tree's particular descent
+shape. The crown spans all trees; the boot offer is the root pointers across all of them.
+
 This breaks the dump-and-skim circle. A flat index is the wall by another name: every line
 a root, so reading the index IS reading everything. A graph index has PARENTS, so the index
 is only the CROWN, the few top roots. Retrieval is descent, not scan: pick a top root,
@@ -88,8 +93,12 @@ not injected.
 2. **The crown** (pointers to top roots): the names and one-line gist of the highest roots,
    each an entry point to descend later. Not their branches, not the leaves. The map, not
    the territory.
-3. **The letters** (pointers to letters): the same shape as the crown, pointers offered and
-   the letter read on the reach, never injected whole (see `letters-as-memory.md`).
+3. **The letters** (one tree in this graph): not a separate system, another tree under the
+   same crown. Its gradient IS its descent: the digest is the tree's root (consolidated gist),
+   the band is mid, the recent letters are leaves; reaching from digest down to one letter is
+   crown-and-descent in the letters tree. So the boot offer carries the letters root the same
+   way it carries any root, a pointer, content read on the reach (see `letters-as-memory.md`,
+   which is an INSTANCE of this design, not a sibling to it).
 
 So the boot offer is the reflex tier resident, and everything else as pointers (crown roots,
 letter pointers). What is NOT offered at boot: the lookup tier, the leaves, the

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -17,11 +17,23 @@ that already exist. Reducing file count is the symptom of the fix; structure is 
 
 ## The corpus is already a graph
 
-Files are nodes, `[[name]]` links are edges. Today it is undirected, untyped, and
-hand-maintained, so it rots into orphans and duplicates. The design is to make that graph
-explicit and typed, not to adopt a graph database (cloud or infra heavy, a private-info
-leak surface, rejected in the research survey). The cheap, correct surface is typed links
-in frontmatter plus a script that reads them, staying in git.
+Today files are nodes and `[[name]]` links are edges, undirected, untyped, hand-maintained,
+so it rots into orphans and duplicates. The design is to make that graph explicit and typed,
+not to adopt a graph database (cloud or infra heavy, a private-info leak surface, rejected in
+the research survey). The cheap, correct surface is typed links plus a script that reads them,
+staying in git.
+
+**The graph holds no content; it is pure pointers.** A node is a reference to content that
+lives elsewhere (a rule file, a letter, a design doc, a Linear issue), and an edge is a typed
+relation between references. The content never moves into the graph and is never duplicated by
+it; the graph is an index OVER content, not a container OF it. This dissolves the
+content-versus-type question: a dispatch-lesson letter and a dispatch rule are two pointers
+that cluster together because their edges put them there, while the letter stays in `letters/`
+and the rule stays in its file. Unify by content (topic clusters in the pointer layer); leave
+the content where it natively lives. Type is a tag on the pointer (rule, letter, doc) that
+decides how it loads, not a separate tree. And reconciliation becomes re-pointing edges, not
+moving content: merge-and-delete operates on pointers; underlying files are untouched unless
+genuinely duplicated.
 
 ## Typed edges
 
@@ -51,10 +63,12 @@ relates-to: [feedback_use_linear_native_relations]
 
 A node with no `instance-of` is a root; the top roots are the ones no other root climbs to.
 
-There is ONE graph, with several trees hanging off the crown: a rules tree, a letters tree,
-others as they emerge. The letters are not a separate memory system with their own model;
-they are one tree, their recent/band/digest gradient being that tree's particular descent
-shape. The crown spans all trees; the boot offer is the root pointers across all of them.
+There is ONE pointer graph, clustered by content (topic), not by type. A topic cluster holds
+pointers of every kind together: the dispatch rule, the dispatch-lesson letter, the dispatch
+design doc, all under the same root because they are about the same thing. Letters are not a
+separate memory system; their pointers sit in whatever topic they concern, and the
+recent/band/digest gradient is just the letter pointers' loading property, not a separate
+tree. The crown spans all clusters; the boot offer is the root pointers across all of them.
 
 This breaks the dump-and-skim circle. A flat index is the wall by another name: every line
 a root, so reading the index IS reading everything. A graph index has PARENTS, so the index
@@ -93,12 +107,12 @@ not injected.
 2. **The crown** (pointers to top roots): the names and one-line gist of the highest roots,
    each an entry point to descend later. Not their branches, not the leaves. The map, not
    the territory.
-3. **The letters** (one tree in this graph): not a separate system, another tree under the
-   same crown. Its gradient IS its descent: the digest is the tree's root (consolidated gist),
-   the band is mid, the recent letters are leaves; reaching from digest down to one letter is
-   crown-and-descent in the letters tree. So the boot offer carries the letters root the same
-   way it carries any root, a pointer, content read on the reach (see `letters-as-memory.md`,
-   which is an INSTANCE of this design, not a sibling to it).
+3. **The letters** (pointers like any other): not a separate system. Letter pointers cluster
+   by the topic they concern, alongside rule and doc pointers; the recent/band/digest gradient
+   is just their loading property (the digest pointer is the cheapest, the recent letters the
+   richest). The boot offer carries letter pointers the same way it carries any pointer,
+   content read on the reach (see `letters-as-memory.md`, an INSTANCE of this design, not a
+   sibling to it).
 
 So the boot offer is the reflex tier resident, and everything else as pointers (crown roots,
 letter pointers). What is NOT offered at boot: the lookup tier, the leaves, the

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -1,8 +1,9 @@
 # Memory as a Graph
 
 The memory corpus is 400-plus flat prose files, and the agent skims them. This is the
-structure that replaces the heap with a typed pointer-graph so the right content is
-findable. Options survey: `designs/research/memory-system-improvements.md`. Letters layer:
+structure that replaces the heap with a typed parent-tree and a small crown, so the right
+content is findable without dumping everything. Options survey:
+`designs/research/memory-system-improvements.md`. Letters layer:
 `designs/ai/letters-as-memory.md`. Consolidation procedure: the `digest` skill.
 
 ## The problem it solves
@@ -12,182 +13,66 @@ every fact is equidistant and equally forgettable, which is why the agent skims 
 session-start dump as boilerplate, asserts from a fuzzy sense, and fails to find rules
 that already exist. Reducing file count is the symptom of the fix; structure is the fix.
 
-## The corpus is already a graph
+## The core: a parent-tree with a crown
 
-Today files are nodes and `[[name]]` links are edges, undirected, untyped, hand-maintained,
-so it rots into orphans and duplicates. The design is to make that graph explicit and typed,
-not to adopt a graph database (cloud or infra heavy, a private-info leak surface, rejected in
-the research survey). The cheap, correct surface is typed links plus a script that reads them,
-staying in git.
-
-**The graph holds no content; it is pure pointers.** A node is a reference to content that
-lives elsewhere (a rule file, a letter, a design doc, a Linear issue), and an edge is a typed
-relation between references. The content never moves into the graph and is never duplicated by
-it; the graph is an index OVER content, not a container OF it. This dissolves the
-content-versus-type question: a dispatch-lesson letter and a dispatch rule are two pointers
-that cluster together because their edges put them there, while the letter stays in `letters/`
-and the rule stays in its file. Unify by content (topic clusters in the pointer layer); leave
-the content where it natively lives. Type is a tag on the pointer (rule, letter, doc) that
-decides how it loads, not a separate tree. And reconciliation becomes re-pointing edges, not
-moving content: merge-and-delete operates on pointers; underlying files are untouched unless
-genuinely duplicated.
-
-## Node identity: UUID plus slug
-
-Each node carries a **UUID** (its stable identity) and a **slug** (a readable label). Edges
-reference UUIDs, so a rename never cascades and the dangling-link problem is gone at the root,
-the UUID does not change when a file moves or its name changes. The slug rides alongside so a
-list of IDs is legible: a node reads `parent: <uuid>  # the-instrument-reflex`, and you
-know what it points at without dereferencing. UUID is for identity; slug is for comprehension.
-
-A **recollection script** is the retrieval primitive: given a list of UUIDs (what the
-UserPromptSubmit walk produces, the matched subgraph), it resolves them to their content (or
-pointers to it). The graph deals only in UUIDs; the script turns a UUID-list into recollected
-content. Because the slugs travel with the list, a mis-seeded walk is INSPECTABLE: the slugs
-show "it pulled the dispatch cluster for a narrative prompt," which is the legibility the
-matching-reliability limit (below) needs.
-
-The split also makes the walk cheap. The walk traverses IDENTITY only: read a node's
-frontmatter, follow the edge UUIDs to the next node's frontmatter, collect UUIDs and slugs. It
-never opens a content body, so it runs over a thin frontmatter layer, not the corpus. Its
-output is a small list (a UUID and a short slug per node, dozens of bytes each), so a wide
-branch is still tiny and the walk does not hit the 10K cap. The cap pressure lives in the
-RESOLUTION step, not the walk: the recollection script is cap-aware, resolving the
-highest-priority nodes' content first and stopping at budget, with the unresolved nodes still
-visible as slugs rather than silently dropped. So truncation is a deliberate resolution
-decision, not a mid-walk accident (this answers the partial-injection limit below).
-
-## The structure: a routing tree in an association graph
-
-A *proper* graph has no privileged route, enter anywhere and traverse by association. That is a
-truer model of knowledge (a rule relates to many things, not one parent) and the WRONG fit
-here, because a routeless graph has no bound: traverse it and you cycle or pull the whole
-connected component, which is the dump by another name. The route is not a limitation; it is
-the design's answer to the dump. So the structure keeps a route.
-
-It is a **routing tree embedded in an association graph**. Two edge classes:
-
-- **`parent`** (exactly one per node): the routing edges. Following only these gives a TREE,
-  one path to a root, no cycles, the walk terminates. Descent, cascade, and crown all run on
-  this. This is the spanning tree over the graph.
-- **`relates-to`** (zero or many): the association edges. These make the whole a directed
-  graph, and they MAY cycle (association is mutual). They are never traversed for routing; they
-  ride along when a node is resolved, enriching it ("also relates to ...") without being a path
-  the walk follows.
-
-So the data structure is a directed graph in which one edge type (`parent`) forms a spanning
-tree and the rest (`relates-to`) are non-routing cross-edges. The cycles in `relates-to` are
-harmless precisely because routing ignores them: route on the tree (acyclic, bounded), associate
-on the graph (may cycle, reference-only). The filesystem is the same shape (one parent directory
-is the tree; symlinks are cross-edges you do not recurse). The single-parent constraint can feel
-like a lie when a node is genuinely an instance of two principles; the resolution is that it
-ROUTES through one parent (where it lives for descent) and ASSOCIATES with the other via
-`relates-to`, so no relationship is lost, only one is chosen as the route. Which parent is the
-route is a reconciliation decision.
-
-## Typed edges
-
-Edges are declared in frontmatter and reference target UUIDs (slug in a trailing comment).
-`parent` routes; the rest are maintenance and association relations.
-
-| Edge | Class | Meaning | Maintenance action |
-|---|---|---|---|
-| `parent` | routing | the one principle this is an instance of | keep; the spanning-tree edge |
-| `duplicate-of` | maintenance | two nodes state the same rule | MERGE and DELETE one (surface shrinks) |
-| `contradicts` | maintenance | two nodes disagree | resolve to one statement |
-| `relates-to` | association | non-routing cross-reference, may cycle | keep; rides on resolution, never walked |
-
-The duplicate-vs-sibling call that reconciliation keeps fumbling becomes a query, not an
-intuition: `duplicate-of` clusters merge, `parent` clusters link.
-
-## The crown, and descent (what it looks like)
-
-The routing tree is deep with a tiny crown, not roots-then-leaves. A few TOP roots sit
-above a layer of mid-roots (discovery, reconciliation, do-the-true-thing), which sit above
-the leaves (the specific rules). The `parent` edge is declared in frontmatter:
+Each memory file is a node. One typed edge, `parent`, in its frontmatter names the principle
+it is an instance of:
 
 ```yaml
 ---
-uuid: 7f3a1c2e-...
-slug: cross-links-in-index-not-body
-parent: 9b2d4f6a-...   # rule-reconciliation
-relates-to:
-  - { id: 1c8e5a3b-..., slug: use-linear-native-relations }
+parent: rule-reconciliation
 ---
 ```
 
-A node with no `parent` is a root; the top roots are the ones no other root climbs to.
+Following `parent` upward gives a tree: one path to a root, no cycles, a walk that terminates.
+A node with no `parent` is a root; the few top roots are the **crown**. That is the whole core,
+typed parent edges plus the crown they form. No separate pointer layer, no identifiers beyond
+the filename, no association edges. The file is the node; `parent` names another file.
 
-There is ONE pointer graph, clustered by content (topic), not by type. A topic cluster holds
-pointers of every kind together: the dispatch rule, the dispatch-lesson letter, the dispatch
-design doc, all under the same root because they are about the same thing. Letters are not a
-separate memory system; their pointers sit in whatever topic they concern, and the
-recent/band/digest gradient is just the letter pointers' loading property, not a separate
-tree. The crown spans all clusters; the boot offer is the root pointers across all of them.
+This breaks the dump-and-skim circle. A flat index is the wall by another name: every line a
+root, so reading the index IS reading everything. A parent-tree has a crown, so the entry point
+is only the few top roots. Retrieval is descent, not scan: enter at a crown root, follow
+`parent` down to the leaf, touch only that branch. The crown is the cut, both for the skim
+problem (a small crown, not 400 lines) and the walk-forever problem (descend one branch, never
+traverse the whole corpus).
 
-This breaks the dump-and-skim circle. A flat index is the wall by another name: every line
-a root, so reading the index IS reading everything. A graph index has PARENTS, so the index
-is only the CROWN, the few top roots. Retrieval is descent, not scan: pick a top root,
-follow `parent` down through a mid-root to the leaf, touching only that branch. Each
-layer is small enough to hold; the other branches are never read. Parents are the cut, both
-for the skim problem (small crown, not 400 lines) and for the walk-forever problem (descend
-one branch from a root, never traverse the whole graph).
+## The crown is the only pointer
 
-Descent is CASCADING, not a jump to the leaf. A leaf stripped of its lineage is meaning
-stripped: `cross-links-in-index` read alone is a narrow rule, but read as its chain
-(`do-the-true-thing -> reconciliation -> single-source -> cross-links`) it carries its why.
-So the walk keeps the path it took, and recollection resolves the leaf PLUS its ancestry to a
-point, not the bare leaf. "To a point" is a bound (the principle level, the nearest mid-root,
-not always the top), so a leaf gets its principle without dragging the whole spine; the exact
-stop is a spike question. This costs little: ancestors are roots, short and gist-level, and
-they are SHARED across the leaves of a branch, so a branch resolves its common ancestry once,
-not per leaf, which makes a multi-leaf branch cheaper than naive per-leaf resolution.
-
-MEMORY.md is generated as that crown plus the descent structure, not a hand-maintained flat
-list. The index is a projection of the tree, so it cannot drift from it.
+The crown is a small generated map: the top roots, each with a one-line gist, offered at
+session start as the entry points. It is the only place pointing happens. Below the crown,
+descent follows `parent` edges through the files directly; there is no pointer indirection to
+maintain. MEMORY.md is generated as the crown, a projection of the tree, so it cannot drift
+from it.
 
 ## Tiers (where a node loads)
 
-- **Reflex tier**: a tiny resident set of posture rules, carried every session because
-  they fire without a trigger. A rule earns it only by serving a distinct purpose no
-  other reflex serves (a function test, not a budget); the set is small as a consequence.
-  About two: the motive (do the true thing) and the instrument (confidence is not
-  accuracy, go read). Distinct from operating conventions (review, dispatch, git), which
-  are settled rules, not posture. See #873, #722.
-- **Lookup tier**: everything else. Not resident; found on its trigger. Action-triggered
-  rules fire as Skills (description-trigger); the rest are read on demand against the
-  index. Injecting them is what builds the unreadable wall.
+- **Reflex tier**: a tiny resident set of posture rules, carried every session because they
+  fire without a trigger. A rule earns it only by serving a distinct purpose no other reflex
+  serves (a function test, not a budget); the set is small as a consequence. About two: the
+  motive (do the true thing) and the instrument (confidence is not accuracy, go read).
+  Distinct from operating conventions (review, dispatch, git), which are settled rules, not
+  posture. See #873, #722.
+- **Lookup tier**: everything else. Not resident; found by descending from the crown when a
+  prompt narrows the work. Injecting it at boot is what builds the unreadable wall.
 
 ## What session start offers
 
-The boot offer is deliberately small, the three things a blank instance needs to act well
-before any prompt has narrowed the work. Everything else waits for the prompt-time offer.
+Small, the two things a blank instance needs before any prompt narrows the work:
 
-The offer is uniformly POINTERS, plus one resident exception. Content is read on the reach,
-not injected.
+1. **The reflex tier** (resident, in full): the posture reflexes. They fire without a trigger,
+   so they cannot wait to be reached for. The only thing carried whole at boot.
+2. **The crown** (the top roots, one-line gist each): the entry map to descend from later.
+   Not branches, not leaves.
 
-1. **The reflex tier** (resident, the exception): the few posture reflexes, in full. They
-   fire without a trigger, so they cannot wait to be reached for. About two, the motive and
-   the instrument. The only thing carried whole at boot.
-2. **The crown** (pointers to top roots): the names and one-line gist of the highest roots,
-   each an entry point to descend later. Not their branches, not the leaves. The map, not
-   the territory.
-3. **The letters** (pointers like any other): not a separate system. Letter pointers cluster
-   by topic alongside rule and doc pointers; their gradient is just a loading property, owned
-   by `letters-as-memory.md` (an INSTANCE of this design). The boot offer carries them the
-   same way as any pointer, content read on the reach.
-
-So the boot offer is the reflex tier resident, and everything else as pointers (crown roots,
-letter pointers). What is NOT offered at boot: the lookup tier, the leaves, the
-operating-convention bodies, any letter body. Those arrive when reached for, the letters by
-the read act and the lookup tier at prompt time, when the UserPromptSubmit hook has a real
-task to match and can descend the right branch. Injecting any body at boot is the wall.
+Letters are part of this corpus, not a separate system; their roots sit in the crown like any
+other, the recent/band/digest gradient being their loading property (owned by
+`letters-as-memory.md`, an instance of this design). What is NOT offered at boot: the lookup
+tier, the leaves, the bodies. Those are descended to when a prompt narrows the work. Injecting a
+body at boot is the wall.
 
 The hard constraint shapes this: each injected value is capped at 10K chars (over it, only a
-file path plus preview is passed, which is a dump-by-path). So reflex tier + crown together
-must stay well under 10K. That cap is WHY the crown is roots-only and the lookup tier waits:
-the boot offer has a budget, and spending it on the whole corpus is the failure this design
-exists to end.
+file path plus preview is passed, a dump-by-path). Reflex tier plus crown must stay well under
+10K. That cap is WHY the crown is roots-only.
 
 ## A worked branch
 
@@ -203,29 +88,45 @@ discovery (you do not know up front; the doing teaches you, correct the structur
 ## Maintenance is graph upkeep
 
 Reconciliation is discovery applied to the memory surface: doing the work, you find two
-fragments are one principle, so you correct the structure (merge, link, resolve). It runs continuously
-as-you-go (informal), and as a periodic deep read (the `digest` for letters; the
-dream or auto-consolidation pass for the corpus, #722). Better maintenance is better
-retention, not tidiness.
+fragments are one principle, so you correct the structure. The typed tree makes the calls
+queryable: a node with no `parent` is an orphan to attach; two nodes under the same parent that
+say the same thing merge to one (and the surface shrinks); a node whose name encodes a retired
+idea gets renamed. It runs continuously as-you-go (informal) and as a periodic deep read (the
+`digest` for letters; the dream or auto-consolidation pass for the corpus, #722). Better
+maintenance is better retention, not tidiness.
+
+## Deferred until the problem appears
+
+The core is parent-tree plus crown, nothing more, because the smallest thing that tests the
+hypothesis (does a typed crown and descent reduce skimming) is the right first build. Three
+elaborations were considered and deferred, each to be added only when a real problem calls for
+it, not designed-for in advance:
+
+- **Stable identifiers (UUIDs) instead of filenames as edge targets.** Solves rename-cascade.
+  Deferred: renames are rare and the reconciliation pass already grep-repoints `parent`
+  references. Add when renames actually bite.
+- **An association layer (`relates-to` cross-edges, not routed).** Richer than a strict tree.
+  Deferred: it is never walked for retrieval, so it earns nothing until association is shown to
+  help. Add when a node is demonstrably impoverished by its single parent.
+- **Cascading resolution (leaf plus its ancestry, shared ancestors once).** A leaf carries more
+  meaning with its principle chain. Deferred: it is an optimization on descent; validate descent
+  first.
 
 ## What Claude Code natively supports
 
-Verified against the Claude Code docs (researcher pass, 2026-06-07; scratchpad
-`ai/scratchpads/memory-graph-harness-check.md` if kept). The store and the crown script
-are harness-agnostic (plain files, plain script). Retrieval maps to native mechanisms:
+Verified against the Claude Code docs (researcher pass, 2026-06-07). The store and the
+crown-generator are harness-agnostic (plain files, plain script). Retrieval maps to native
+mechanisms:
 
 - **Crown at session start**: a SessionStart hook generates the crown and injects it as
-  `additionalContext`. Hard cap: a single value over **10,000 chars** is written to a file
-  and only its path plus a preview is injected. So the crown must stay well under 10K or it
-  becomes a dump-by-path, the wall returning. Keep the crown to the top roots only.
+  `additionalContext`. Hard cap: a single value over 10,000 chars is written to a file and only
+  its path plus a preview is injected. Keep the crown to the top roots only.
 - **Descent is done by a hook, not by me live.** There is no native graph traversal; at-need
-  retrieval natively is only (MEMORY.md head at start) + (skill description match) + (the
-  agent choosing to Read, the unreliable instrument). The automated form is a
-  **UserPromptSubmit hook** that parses frontmatter, walks `parent` edges from the
-  matched node, and injects that subgraph before the prompt reaches me. The walk terminates
-  (visited-set, one branch from a seed) and stays bounded (the branch, not the corpus), under
-  the same 10K cap. This is the real shape of "descent": the hook descends server-side; I
-  receive the branch, I never traverse.
+  retrieval natively is only (MEMORY.md head at start) + (skill description match) + (the agent
+  choosing to Read, the unreliable instrument). The automated form is a UserPromptSubmit hook
+  that walks `parent` edges from the matched node and injects that branch before the prompt
+  reaches me. The walk terminates (visited-set, one branch) and stays bounded (the branch, not
+  the corpus), under the same 10K cap.
 - **Skills as entry points**: a SKILL.md description-trigger (flat intent-match, no hierarchy)
   can fire a node; its body can `!`cat node-file`` to pull the content on match.
 - **MCP only for semantic recall**: embedding/vector matching across the full corpus needs an
@@ -236,48 +137,39 @@ are harness-agnostic (plain files, plain script). Retrieval maps to native mecha
 
 The reader is a fresh instance with no continuity (the why is owned by `letters-as-memory.md`).
 Two failures follow: pull fails (nothing remembers to descend) and force fails (a dump at boot
-is skimmed, the wall). The model is OFFER: the crown and the matched subgraph made available,
+is skimmed, the wall). The model is OFFER: the crown and the matched branch made available,
 small and relevant, at the moment they help, and taken up freely. SessionStart and
 UserPromptSubmit are how the offer is delivered, not a licence to inject everything; an offer
-that is a wall is force again. This is the team protocol across the session boundary (the
-memory root `feedback_we_are_a_team`).
+that is a wall is force again. This is the team protocol across the session boundary (the memory
+root `feedback_we_are_a_team`).
 
 ## The honest limit
 
-The graph earns its keep on the MAINTENANCE payoff: reconciliation becomes a query
-(`duplicate-of` clusters merge, `parent` clusters link), and orphans become mechanically
-detectable (a node with no `parent` is found by running the graph, where flat-file bloat
-was found only by a human noticing). That half is solid.
+The graph earns its keep on the MAINTENANCE payoff: reconciliation becomes a query (merge
+same-parent duplicates, attach orphans), and orphans become mechanically detectable (a node with
+no `parent` is found by running the tree, where flat-file bloat was found only by a human
+noticing). That half is solid.
 
-The RETENTION claim is narrower than "fixes retention," and the rest of this doc should not
-overstate it. The graph makes the right content findable; it does not make the agent read it.
-The last step is still the agent choosing to Read the pointed-to content (the unreliable
-instrument); a well-structured library does not help a reader who does not pull books. So the
-honest claim is BETTER ACCESS to the right content, not guaranteed reading of it. A new failure
-mode replaces the old: the agent asserts from the injected gist without following the pointer,
-instead of skimming a dump.
+The RETENTION claim is narrower than "fixes retention." The tree makes the right content
+findable; it does not make the agent read it. The last step is still the agent choosing to Read
+the pointed-to content (the unreliable instrument); a well-structured library does not help a
+reader who does not pull books. So the honest claim is BETTER ACCESS to the right content, not
+guaranteed reading of it. A new failure mode replaces the old: the agent asserts from the crown
+gist without descending.
 
-Four limits the design has not closed, named so they are not mistaken for solved:
+Limits the design has not closed:
 
-- **Matching is the unvalidated critical path.** The whole descent rests on the
-  UserPromptSubmit hook seeding the RIGHT node before the agent sees the prompt. That is the
-  same keyword/intent instrument the noisy correction-signal hook already strains. A mis-seed
-  injects the wrong cluster, which is worse than injecting nothing because the agent reads it
-  as relevant. The spike must specify the match algorithm, its behaviour on an ambiguous or
-  cross-domain prompt (one touching dispatch AND narrative), and a fallback when confidence is
-  low (offer the crown, not a wrong branch).
-- **Branch size versus the 10K cap, partly answered.** The identity walk is cheap and its
-  UUID-list output does not hit the cap; the pressure is in resolution, where the recollection
-  script is cap-aware and truncation is a deliberate, legible choice (unresolved nodes stay
-  visible as slugs) rather than a silent mid-walk cut. What the spike still owes: the
-  priority order resolution uses, and confirmation that a slug-only tail is genuinely safer
-  than a truncated body (the agent must not read the resolved head as the whole branch).
-- **Build cost is weeks, not an afternoon.** Today almost no file carries a routing edge.
-  Typing 400+ files means reading each, deciding its parent, writing the edge, and resolving
-  the `duplicate-of` nodes it surfaces (decisions, not mechanical adds). The research survey's
-  afternoon estimate was for its lighter options, not this.
-- **A new drift mode.** Orphaned graph nodes replace orphaned prose files. Better (detectable
-  by running the graph) but real: every new node needs its edge set or it falls out of descent.
+- **Matching is the unvalidated critical path.** The descent rests on the UserPromptSubmit hook
+  seeding the RIGHT node before the agent sees the prompt, the same keyword/intent instrument the
+  noisy correction-signal hook already strains. A mis-seed injects the wrong branch, worse than
+  nothing because the agent reads it as relevant. The spike must specify the match algorithm, its
+  behaviour on an ambiguous or cross-domain prompt, and a fallback when confidence is low (offer
+  the crown, not a wrong branch).
+- **Branch size versus the 10K cap.** A deep or wide branch can blow the cap; the spike must set
+  a depth limit and a truncation rule, and ensure a truncated branch is not read as complete.
+- **Build cost is weeks, not an afternoon.** Almost no file carries a `parent` today. Typing
+  400-plus means reading each, deciding its parent, and resolving the duplicates that surfaces
+  (decisions, not mechanical adds).
 
 It does not install a reflex or cure skim-as-boilerplate either; that is the instrument,
 [[feedback_self_judgment_is_coherence_not_accuracy]].

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -47,6 +47,16 @@ content. Because the slugs travel with the list, a mis-seeded walk is INSPECTABL
 show "it pulled the dispatch cluster for a narrative prompt," which is the legibility the
 matching-reliability limit (below) needs.
 
+The split also makes the walk cheap. The walk traverses IDENTITY only: read a node's
+frontmatter, follow the edge UUIDs to the next node's frontmatter, collect UUIDs and slugs. It
+never opens a content body, so it runs over a thin frontmatter layer, not the corpus. Its
+output is a small list (a UUID and a short slug per node, dozens of bytes each), so a wide
+branch is still tiny and the walk does not hit the 10K cap. The cap pressure lives in the
+RESOLUTION step, not the walk: the recollection script is cap-aware, resolving the
+highest-priority nodes' content first and stopping at budget, with the unresolved nodes still
+visible as slugs rather than silently dropped. So truncation is a deliberate resolution
+decision, not a mid-walk accident (this answers the partial-injection limit below).
+
 ## Typed edges
 
 Edges are declared in frontmatter and reference target UUIDs (slug in a trailing comment).
@@ -217,11 +227,12 @@ Four limits the design has not closed, named so they are not mistaken for solved
   as relevant. The spike must specify the match algorithm, its behaviour on an ambiguous or
   cross-domain prompt (one touching dispatch AND narrative), and a fallback when confidence is
   low (offer the crown, not a wrong branch).
-- **Branch size versus the 10K cap is unresolved.** The cap is named for the crown but never
-  sized for a branch. A mid-root with many leaves can blow it, and a walk that hits the cap
-  mid-branch injects a PARTIAL branch the agent reads as complete, missing the leaf that would
-  have changed its answer. The spike must set a depth limit, leaf-truncation rule, and
-  partial-injection behaviour.
+- **Branch size versus the 10K cap, partly answered.** The identity walk is cheap and its
+  UUID-list output does not hit the cap; the pressure is in resolution, where the recollection
+  script is cap-aware and truncation is a deliberate, legible choice (unresolved nodes stay
+  visible as slugs) rather than a silent mid-walk cut. What the spike still owes: the
+  priority order resolution uses, and confirmation that a slug-only tail is genuinely safer
+  than a truncated body (the agent must not read the resolved head as the whole branch).
 - **Build cost is weeks, not an afternoon.** Today exactly one file carries `instance-of`.
   Typing 400+ files means reading each, deciding its parent, writing the edge, and resolving
   the `duplicate-of` nodes it surfaces (decisions, not mechanical adds). The research survey's

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -104,6 +104,16 @@ layer is small enough to hold; the other branches are never read. Parents are th
 for the skim problem (small crown, not 400 lines) and for the walk-forever problem (descend
 one branch from a root, never traverse the whole graph).
 
+Descent is CASCADING, not a jump to the leaf. A leaf stripped of its lineage is meaning
+stripped: `cross-links-in-index` read alone is a narrow rule, but read as its chain
+(`do-the-true-thing -> reconciliation -> single-source -> cross-links`) it carries its why.
+So the walk keeps the path it took, and recollection resolves the leaf PLUS its ancestry to a
+point, not the bare leaf. "To a point" is a bound (the principle level, the nearest mid-root,
+not always the top), so a leaf gets its principle without dragging the whole spine; the exact
+stop is a spike question. This costs little: ancestors are roots, short and gist-level, and
+they are SHARED across the leaves of a branch, so a branch resolves its common ancestry once,
+not per leaf, which makes a multi-leaf branch cheaper than naive per-leaf resolution.
+
 MEMORY.md is generated as that crown plus the descent structure, not a hand-maintained flat
 list. The index is a projection of the tree, so it cannot drift from it.
 

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -117,6 +117,18 @@ are harness-agnostic (plain files, plain script). Retrieval maps to native mecha
   MCP server, the heavyweight path the research already rejected. Keyword/intent matching and
   edge-walking are native.
 
+## Offer, not force
+
+The reader is not a continuous self; each session is a fresh instance that wakes blank, a
+teammate the author will never meet. So the system cannot rely on the agent remembering to
+descend (pull fails: no continuity to remember), and it must not force-feed a dump at boot
+(force fails the way it fails any teammate: skimmed, ignored, the wall). The model is OFFER:
+the crown and the matched subgraph made available, small and relevant, at the moment they
+help, and taken up freely. The SessionStart and UserPromptSubmit mechanisms are how the
+offer is delivered, not a licence to inject everything. Keep what is offered small; an offer
+that is a wall is force again. This is the team protocol across the session boundary (the
+memory root `feedback_we_are_a_team`).
+
 ## The honest limit
 
 Structure aids retention and makes maintenance queryable. It does not by itself install a

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -1,0 +1,77 @@
+# Memory as a Graph
+
+How the agent's memory corpus is structured, and why. The model and rationale; the
+options survey that fed it is `designs/research/memory-system-improvements.md`, the
+letters layer is `designs/ai/letters-as-memory.md`, the consolidation procedure is the
+`digest` skill.
+
+(Placement note: AI-operational material, not game design. Sits under `designs/ai/` by
+current convention.)
+
+## The problem it solves
+
+Unstructured data is not retained. A flat heap of prose memory files has nothing to grip:
+every fact is equidistant and equally forgettable, which is why the agent skims the
+session-start dump as boilerplate, asserts from a fuzzy sense, and fails to find rules
+that already exist. Reducing file count is the symptom of the fix; structure is the fix.
+
+## The corpus is already a graph
+
+Files are nodes, `[[name]]` links are edges. Today it is undirected, untyped, and
+hand-maintained, so it rots into orphans and duplicates. The design is to make that graph
+explicit and typed, not to adopt a graph database (cloud or infra heavy, a private-info
+leak surface, rejected in the research survey). The cheap, correct surface is typed links
+in frontmatter plus a script that reads them, staying in git.
+
+## Typed edges
+
+| Edge | Meaning | Maintenance action |
+|---|---|---|
+| `instance-of` | a leaf is a specific case of a parent principle | keep; link up to the root |
+| `duplicate-of` | two nodes state the same rule | MERGE and DELETE one (surface shrinks) |
+| `contradicts` | two nodes disagree | resolve to one statement |
+| `relates-to` | associative, non-hierarchical | keep as a cross-reference |
+
+The duplicate-vs-sibling call that reconciliation keeps fumbling becomes a query, not an
+intuition: `duplicate-of` clusters merge, `instance-of` clusters link.
+
+## Tiers (where a node loads)
+
+- **Reflex tier**: a tiny resident set of posture rules, carried every session because
+  they fire without a trigger. A rule earns it only by serving a distinct purpose no
+  other reflex serves (a function test, not a budget); the set is small as a consequence.
+  About two: the motive (do the true thing) and the instrument (confidence is not
+  accuracy, go read). Distinct from operating conventions (review, dispatch, git), which
+  are settled rules, not posture. See SH-477, SH-427.
+- **Lookup tier**: everything else. Not resident; found on its trigger. Action-triggered
+  rules fire as Skills (description-trigger); the rest are read on demand against the
+  index. Injecting them is what builds the unreadable wall.
+
+## Roots and trees
+
+Structure is a few load-bearing roots with the rest hanging off by typed edge. A root
+holds a principle; branches are its routes; leaves are the specific rules. Worked example,
+discovery as a development process:
+
+```
+discovery (you do not know up front; the doing teaches you, correct the structure to match)
+|- formal    the lifecycle stage: discovery issue -> spike (design+tech) -> feature tickets
+|- informal  constant learning-by-doing, too small to ticket; correct as you go
+             (reconciliation is this, applied to the memory surface)
+```
+
+## Maintenance is graph upkeep
+
+Reconciliation is discovery applied to the memory surface: the doing reveals two fragments
+are one principle, so you correct the structure (merge, link, resolve). It runs continuously
+as-you-go (informal), and as a periodic deep read (the `digest` for letters; the
+dream or auto-consolidation pass for the corpus, SH-427). Better maintenance is better
+retention, not tidiness.
+
+## The honest limit
+
+Structure aids retention and makes maintenance queryable. It does not by itself install a
+reflex or cure skim-as-boilerplate; that is the instrument, exercised by reading the source
+at decision time. A richer graph the agent still skims fixes nothing. The graph earns its
+keep on the maintenance payoff (reconciliation becomes a query), not on a promise of better
+recall.

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -35,6 +35,33 @@ in frontmatter plus a script that reads them, staying in git.
 The duplicate-vs-sibling call that reconciliation keeps fumbling becomes a query, not an
 intuition: `duplicate-of` clusters merge, `instance-of` clusters link.
 
+## The crown, and descent (what it looks like)
+
+The structure is a deep tree with a tiny crown, not roots-then-leaves. A few TOP roots sit
+above a layer of mid-roots (discovery, reconciliation, do-the-true-thing), which sit above
+the leaves (the specific rules). Edges are typed `instance-of`, declared in frontmatter:
+
+```yaml
+---
+name: feedback_cross_links_in_index_not_body
+instance-of: feedback_rule_reconciliation
+relates-to: [feedback_use_linear_native_relations]
+---
+```
+
+A node with no `instance-of` is a root; the top roots are the ones no other root climbs to.
+
+This breaks the dump-and-skim circle. A flat index is the wall by another name: every line
+a root, so reading the index IS reading everything. A graph index has PARENTS, so the index
+is only the CROWN, the few top roots. Retrieval is descent, not scan: pick a top root,
+follow `instance-of` down through a mid-root to the leaf, touching only that branch. Each
+layer is small enough to hold; the other branches are never read. Parents are the cut, both
+for the skim problem (small crown, not 400 lines) and for the walk-forever problem (descend
+one branch from a root, never traverse the whole graph).
+
+MEMORY.md is generated as that crown plus the descent structure, not a hand-maintained flat
+list. The index is a projection of the tree, so it cannot drift from it.
+
 ## Tiers (where a node loads)
 
 - **Reflex tier**: a tiny resident set of posture rules, carried every session because
@@ -47,11 +74,9 @@ intuition: `duplicate-of` clusters merge, `instance-of` clusters link.
   rules fire as Skills (description-trigger); the rest are read on demand against the
   index. Injecting them is what builds the unreadable wall.
 
-## Roots and trees
+## A worked branch
 
-Structure is a few load-bearing roots with the rest hanging off by typed edge. A root
-holds a principle; branches are its routes; leaves are the specific rules. Worked example,
-discovery as a development process:
+Discovery as a development process, one mid-root and its branch:
 
 ```
 discovery (you do not know up front; the doing teaches you, correct the structure to match)

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -108,11 +108,9 @@ not injected.
    each an entry point to descend later. Not their branches, not the leaves. The map, not
    the territory.
 3. **The letters** (pointers like any other): not a separate system. Letter pointers cluster
-   by the topic they concern, alongside rule and doc pointers; the recent/band/digest gradient
-   is just their loading property (the digest pointer is the cheapest, the recent letters the
-   richest). The boot offer carries letter pointers the same way it carries any pointer,
-   content read on the reach (see `letters-as-memory.md`, an INSTANCE of this design, not a
-   sibling to it).
+   by topic alongside rule and doc pointers; their gradient is just a loading property, owned
+   by `letters-as-memory.md` (an INSTANCE of this design). The boot offer carries them the
+   same way as any pointer, content read on the reach.
 
 So the boot offer is the reflex tier resident, and everything else as pointers (crown roots,
 letter pointers). What is NOT offered at boot: the lookup tier, the leaves, the
@@ -171,13 +169,11 @@ are harness-agnostic (plain files, plain script). Retrieval maps to native mecha
 
 ## Offer, not force
 
-The reader is not a continuous self; each session is a fresh instance that wakes blank, a
-teammate the author will never meet. So the system cannot rely on the agent remembering to
-descend (pull fails: no continuity to remember), and it must not force-feed a dump at boot
-(force fails the way it fails any teammate: skimmed, ignored, the wall). The model is OFFER:
-the crown and the matched subgraph made available, small and relevant, at the moment they
-help, and taken up freely. The SessionStart and UserPromptSubmit mechanisms are how the
-offer is delivered, not a licence to inject everything. Keep what is offered small; an offer
+The reader is a fresh instance with no continuity (the why is owned by `letters-as-memory.md`).
+Two failures follow: pull fails (nothing remembers to descend) and force fails (a dump at boot
+is skimmed, the wall). The model is OFFER: the crown and the matched subgraph made available,
+small and relevant, at the moment they help, and taken up freely. SessionStart and
+UserPromptSubmit are how the offer is delivered, not a licence to inject everything; an offer
 that is a wall is force again. This is the team protocol across the session boundary (the
 memory root `feedback_we_are_a_team`).
 

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -50,35 +50,41 @@ descent follows `parent` edges through the files directly; there is no pointer i
 maintain. MEMORY.md is generated as the crown, a projection of the tree, so the index cannot drift
 from the structure.
 
-## Tiers (where a node loads)
+## Tiers (when a node is read)
 
-- **Reflex tier**: a tiny resident set of posture rules, carried every session because they
-  fire without a trigger. A rule earns it only by serving a distinct purpose no other reflex
-  serves (a function test, not a budget); the set is small as a consequence. About two: the
-  motive (do the true thing) and the instrument (confidence is not accuracy, go read).
-  Distinct from operating conventions (review, dispatch, git), which are settled rules, not
-  posture. See #873, #722.
-- **Lookup tier**: everything else. Not resident; found by descending from the crown when a
-  prompt narrows the work. Injecting it at boot is what builds the unreadable wall.
+- **Reflex tier**: a tiny set of posture rules read FIRST every session, the first items on the
+  reading list. A rule earns the tier only by serving a distinct purpose no other reflex serves
+  (a function test, not a budget); the set is small as a consequence. About two: the motive (do
+  the true thing) and the instrument (confidence is not accuracy, go read). Distinct from
+  operating conventions (review, dispatch, git), which are settled rules, not posture. See #873,
+  #722. They are read first, not injected whole; reading is the act (below).
+- **Lookup tier**: everything else. Read by descending from the crown when a prompt narrows the
+  work.
 
-## What session start offers
+## What session start offers: a reading list
 
-Small, the two things a blank instance needs before any prompt narrows the work:
+Nothing in the start dump is injected whole. Everything is a POINTER, and the dump is a reading
+list the fresh instance works top to bottom as its first act. No resident exception, not even the
+reflex tier: injecting a body whole is force and does not install it anyway (the letters proved
+that, and so did a missed concision rule), so even the most important rule is a pointer that is
+READ, never force-fed. Reading the list is the act; a pointer sat in the buffer is unread.
 
-1. **The reflex tier** (resident, in full): the posture reflexes. They fire without a trigger,
-   so they cannot wait to be reached for. The only thing carried whole at boot.
-2. **The crown** (the top roots, one-line gist each): the entry map to descend from later.
-   Not branches, not leaves.
+The list, in order:
+
+1. **The reflex pointers**: the two posture reflexes, read first because they shape every move
+   before any prompt narrows the work.
+2. **The crown pointers**: the top roots, one-line gist each, the entry map to descend from when
+   a prompt arrives.
 
 Letters are part of this corpus, not a separate system; their roots sit in the crown like any
 other, the recent/band/digest gradient being their loading property (owned by
-`letters-as-memory.md`, an instance of this design). What is NOT offered at boot: the lookup
-tier, the leaves, the bodies. Those are descended to when a prompt narrows the work. Injecting a
-body at boot is the wall.
+`letters-as-memory.md`, an instance of this design). What is never in the dump: any body. Bodies
+are read on the reach, reflex bodies first as the opening of the list, lookup bodies when a prompt
+descends to them.
 
-The hard constraint shapes this: each injected value is capped at 10K chars (over it, only a
-file path plus preview is passed, a dump-by-path). Reflex tier plus crown must stay well under
-10K. That cap is WHY the crown is roots-only.
+This is why the dump stays under the 10K injection cap with room to spare: a reading list of
+pointers (a slug and a one-line gist each) is tiny, where a list of bodies is the wall. The cap
+is not a constraint the design fights; it is satisfied by the dump being pointers, not content.
 
 ## A worked branch
 

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -42,7 +42,7 @@ intuition: `duplicate-of` clusters merge, `instance-of` clusters link.
   other reflex serves (a function test, not a budget); the set is small as a consequence.
   About two: the motive (do the true thing) and the instrument (confidence is not
   accuracy, go read). Distinct from operating conventions (review, dispatch, git), which
-  are settled rules, not posture. See SH-477, SH-427.
+  are settled rules, not posture. See #873, #722.
 - **Lookup tier**: everything else. Not resident; found on its trigger. Action-triggered
   rules fire as Skills (description-trigger); the rest are read on demand against the
   index. Injecting them is what builds the unreadable wall.
@@ -65,7 +65,7 @@ discovery (you do not know up front; the doing teaches you, correct the structur
 Reconciliation is discovery applied to the memory surface: the doing reveals two fragments
 are one principle, so you correct the structure (merge, link, resolve). It runs continuously
 as-you-go (informal), and as a periodic deep read (the `digest` for letters; the
-dream or auto-consolidation pass for the corpus, SH-427). Better maintenance is better
+dream or auto-consolidation pass for the corpus, #722). Better maintenance is better
 retention, not tidiness.
 
 ## The honest limit

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -32,7 +32,24 @@ decides how it loads, not a separate tree. And reconciliation becomes re-pointin
 moving content: merge-and-delete operates on pointers; underlying files are untouched unless
 genuinely duplicated.
 
+## Node identity: UUID plus slug
+
+Each node carries a **UUID** (its stable identity) and a **slug** (a readable label). Edges
+reference UUIDs, so a rename never cascades and the dangling-link problem is gone at the root,
+the UUID does not change when a file moves or its name changes. The slug rides alongside so a
+list of IDs is legible: a node reads `instance-of: <uuid>  # the-instrument-reflex`, and you
+know what it points at without dereferencing. UUID is for identity; slug is for comprehension.
+
+A **recollection script** is the retrieval primitive: given a list of UUIDs (what the
+UserPromptSubmit walk produces, the matched subgraph), it resolves them to their content (or
+pointers to it). The graph deals only in UUIDs; the script turns a UUID-list into recollected
+content. Because the slugs travel with the list, a mis-seeded walk is INSPECTABLE: the slugs
+show "it pulled the dispatch cluster for a narrative prompt," which is the legibility the
+matching-reliability limit (below) needs.
+
 ## Typed edges
+
+Edges are declared in frontmatter and reference target UUIDs (slug in a trailing comment).
 
 | Edge | Meaning | Maintenance action |
 |---|---|---|
@@ -52,9 +69,11 @@ the leaves (the specific rules). Edges are typed `instance-of`, declared in fron
 
 ```yaml
 ---
-name: feedback_cross_links_in_index_not_body
-instance-of: feedback_rule_reconciliation
-relates-to: [feedback_use_linear_native_relations]
+uuid: 7f3a1c2e-...
+slug: cross-links-in-index-not-body
+instance-of: 9b2d4f6a-...   # rule-reconciliation
+relates-to:
+  - { id: 1c8e5a3b-..., slug: use-linear-native-relations }
 ---
 ```
 


### PR DESCRIPTION
The agent's memory corpus is a flat heap of prose files today, and the cost shows up as skimming: the session-start dump reads as boilerplate, rules that already exist go unfound, and "consolidate the corpus" kept meaning "fewer files" when the real problem was structure. Unstructured data is not retained.

This adds `designs/ai/memory-as-graph.md`, the design that came out of working it through. The corpus is already a graph (files are nodes, `[[links]]` are edges); the move is to make it explicit and typed in git, not to adopt a graph database. Typed `instance-of` edges form a deep tree with a tiny crown, so retrieval is descent down one branch from a top root, not a scan of everything. Parents are the cut: they bound both the skim problem (read the crown, not the whole index) and the walk-forever problem (descend one branch, never traverse the graph).

A researcher pass grounded it against Claude Code: the store and crown-script are harness-agnostic, the crown rides a SessionStart hook and the descent is a UserPromptSubmit hook walking the edges server-side, both under a 10K-char injection cap, MCP needed only for semantic recall (already rejected). The framing is offer, not force: the reader is a fresh instance each session, a teammate who wakes blank, so the system makes knowledge available small and relevant rather than force-feeding a dump.

Indexed alongside `letters-as-memory.md` under a new Memory section. Design for #873; #722 builds the rules-system surface it sits on.