### PR TITLE
fix: only reads ground a PR-state claim in the state-check hook

### DIFF
--- a/.claude/hooks/pr-mention-state-check.sh
+++ b/.claude/hooks/pr-mention-state-check.sh
@@ -90,11 +90,13 @@ state_claim = re.search(
     text, re.I) is not None
 
 # Only a live READ this turn grounds a state claim; the command result is the
-# ground truth. Write verbs (create, merge, close, edit, ready, comment, review,
-# reopen) change a PR but do not read its current state, so they do NOT ground a
-# claim like "is mergeable" or "approved". Reading verbs only.
+# ground truth. Reading verbs (view/list/status/checks) and a gh api GET on
+# pulls/issues read current state. `diff` reads the file diff, not the PR's
+# state, so it does NOT ground a state claim. Write verbs (create, merge, close,
+# edit, ready, comment, review, reopen) change a PR without reading its state,
+# and agents never merge here anyway (the maintainer merges by hand).
 touched = re.search(
-    r"gh pr (view|list|status|checks|diff)"
+    r"gh pr (view|list|status|checks)"
     r"|gh api[^\n]*(/pulls|/issues)",
     cmds, re.I) is not None
 

--- a/.claude/hooks/pr-mention-state-check.sh
+++ b/.claude/hooks/pr-mention-state-check.sh
@@ -89,10 +89,12 @@ state_claim = re.search(
     r")\b",
     text, re.I) is not None
 
-# A live read OR a gh pr write this turn grounds the claim (the command result
-# is ground truth), so neither should block.
+# Only a live READ this turn grounds a state claim; the command result is the
+# ground truth. Write verbs (create, merge, close, edit, ready, comment, review,
+# reopen) change a PR but do not read its current state, so they do NOT ground a
+# claim like "is mergeable" or "approved". Reading verbs only.
 touched = re.search(
-    r"gh pr (view|list|status|checks|diff|merge|close|edit|create|reopen|ready|comment|review)"
+    r"gh pr (view|list|status|checks|diff)"
     r"|gh api[^\n]*(/pulls|/issues)",
     cmds, re.I) is not None
 


### PR DESCRIPTION
The Stop hook that catches a PR-state claim made without a live read counted any `gh pr` subcommand as grounding, including writes. So a turn that ran `gh pr create` and then asserted "#878 is mergeable" passed clean, even though creating a PR reads nothing about its current state. The write satisfied the check without proving the claim.

This narrows the grounding set to the reading subcommands: `view`, `list`, `status`, `checks`, `diff` (plus `gh api` on `/pulls` or `/issues`). Write verbs (`create`, `merge`, `close`, `edit`, `ready`, `comment`, `review`, `reopen`) change a PR but do not read its state, so they no longer ground a state claim. The hook still fails open on any error.

Surfaced when a state claim slipped through this session behind a `gh pr create`. A separate gap (the state-claim vocabulary misses phrasings like "awaiting merge") is left as a follow-up; this PR is the grounding fix only.