### PR TITLE
fix: em-dash hook scans edit write-fields, not match targets

### DIFF
--- a/.claude/hooks/em-dash-pre-tool.sh
+++ b/.claude/hooks/em-dash-pre-tool.sh
@@ -25,6 +25,18 @@ if [ "$TOOL" = "Bash" ]; then
   else
     exit 0
   fi
+elif [ "$TOOL" = "Edit" ] || [ "$TOOL" = "Write" ] || [ "$TOOL" = "NotebookEdit" ]; then
+  # Scan only the fields that WRITE content, not the match target. An em dash
+  # in Edit's old_string is being matched to remove it (the cure, not the
+  # violation); only new_string / content / new_source write a dash to a file.
+  SCAN=$(printf '%s' "$INPUT" | jq -r '
+    .tool_input | (.new_string // "") + "\n" + (.content // "") + "\n" + (.new_source // "")
+  ' 2>/dev/null || printf '%s' "$INPUT")
+elif [ "$TOOL" = "MultiEdit" ]; then
+  # Same: scan only the new_string of each edit, never old_string.
+  SCAN=$(printf '%s' "$INPUT" | jq -r '
+    [.tool_input.edits[]?.new_string] | join("\n")
+  ' 2>/dev/null || printf '%s' "$INPUT")
 else
   SCAN=$(printf '%s' "$INPUT" | jq -r '.tool_input | tostring' 2>/dev/null || printf '%s' "$INPUT")
 fi


### PR DESCRIPTION
The em-dash hook scanned every non-Bash tool's input in full, including Edit's `old_string`. So an Edit whose whole purpose was to REMOVE an em dash got blocked, because the dash had to appear in `old_string` to match it. The hook was blocking its own cure: the only way to strip a stray dash from a file is to match it, and matching tripped the guard.

This scans only the fields that WRITE content. For Edit/Write/NotebookEdit, just `new_string`/`content`/`new_source`; for MultiEdit, only each edit's `new_string`; `old_string` is exempt because a dash there is being deleted, not written. Other tools (the Linear and PR MCP text tools, where the whole input is new prose) stay scanned in full. Bash keeps its existing prose-surface logic.

Verified: a dash in old_string passes, a dash in new_string/content still denies, and a Linear save_issue with a dash still denies.