### PR TITLE
docs: index per-tree, and the bridge in the root's index

### DIFF
--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -27,9 +27,15 @@ letters and write a fresh digest from present perspective. Not recall, PERSPECTI
    prior digest; the history of how the reading-of-self changed is itself part of the arc.
    The digest is the consolidated gist of everything older than the recent+band window,
    the self/posture/arc, not behaviour (behaviour graduates to memory rules).
-4. Promote any arc-pattern worth keeping as guidance into a memory rule (the procedural
+4. Wire it into the forest as the new gradient root (the letters tree, see
+   `designs/ai/memory-forest.md` and the `letters` root node). The digest is the most
+   consolidated tier, so it becomes the top of the letters tree: set its `parent` to `letters`
+   (or to the prior digest, keeping the versioned chain), and re-parent the now-older letters
+   under this digest so descent reads consolidated -> vivid -> raw. The lint confirms the edges
+   resolve.
+5. Promote any arc-pattern worth keeping as guidance into a memory rule (the procedural
    layer), so the digest stays about self, not how-to-act.
-5. Commit the digest in the memory repo promptly (per the commit-memory-promptly rule).
+6. Commit the digest in the memory repo promptly (per the commit-memory-promptly rule).
 
 ## Budget
 

--- a/designs/ai/INDEX.md
+++ b/designs/ai/INDEX.md
@@ -14,7 +14,7 @@ How the agent reconstitutes itself across sessions: the rule corpus (structure a
 
 | Doc | Purpose |
 |---|---|
-| [Memory as a Graph](memory-as-graph.md) | Why the flat rule corpus fails the agent, and the design that replaces it: a typed parent-tree with a small crown the agent descends to find the right content, maintained by reconciliation, offered not forced to each fresh session. |
+| [Memory Forest](memory-forest.md) | Why the flat rule corpus fails the agent, and the design that replaces it: a forest of typed parent-trees with a small crown the agent descends, each root indexing its own tree, maintained by reconciliation, offered not forced. An instance of the general forest model (extract to forest-model.md pending). |
 | [Letters as Memory](letters-as-memory.md) | The letters-to-my-next-self as a human-modelled memory gradient (recent full, fading band, consolidated digest), carrying self and posture across sessions the agent does not remember. |
 
 ## Agent-assisted writing

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -8,6 +8,12 @@ content is findable without dumping everything. Options survey:
 
 ## The forest model generalises beyond memory
 
+> REWRITE PENDING: extract this general model into its own doc (`designs/ai/forest-model.md`),
+> leaving this doc as the MEMORY instance pointing up to it; the design docs and the Linear
+> backlog are sibling instances. The model is woven through the sections below, so the extract is
+> a real restructure, not a cut, do it as a focused pass. The insight is captured here so it is
+> not lost; the rewrite makes it correctly-shaped.
+
 What this doc describes is a FOREST MODEL for any corpus a fresh, blank instance must navigate
 without already understanding it: a few single-meaning trunks (coarse buckets), each growing into a
 tree (root, branches, leaves by a `parent` edge), with each root node serving as its tree's index,

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -60,6 +60,32 @@ descent follows `parent` edges through the files directly; there is no pointer i
 maintain. MEMORY.md is generated as the roots, a projection of the forest, so the index cannot drift
 from the structure.
 
+## The index is per-tree: each root node IS its tree's index
+
+There is no one flat index. Each tree's ROOT NODE holds the index of its own tree, its direct
+children with one-line gists, and is both the doorway intro and the local index for what is below
+it. So the index is distributed across the roots, not centralised. MEMORY.md shrinks to the CROWN:
+the handful of trunk roots, nothing more. Descent reads MEMORY.md (the trunk roots), opens the one
+trunk the work needs (that root node is the index of its trunk), descends to the sub-root that
+indexes the relevant branch, reaches the leaf. The index a fresh instance reads at each level is
+just that node's own listing of its children. This is the dump-and-skim cure made structural: the
+boot offer is the crown alone, and the per-tree detail is read on descent because each root carries
+its own index, so the standing injection stays tiny (the 10K cap is satisfied by structure, not
+restraint).
+
+## The bridge: the root's index carries provisional nodes
+
+Building the forest is incremental, so at any time many nodes are bucketed to a trunk but not yet
+ordered into its tree. The BRIDGE keeps them reachable without faking placement and without editing
+every node: a trunk root's index lists, beside its ordered children, a PROVISIONAL section, the
+nodes bucketed to this trunk but not yet ordered. A fresh instance opening that trunk root reads
+both and can reach any of them; the provisional listing says plainly "parked here, not yet ordered."
+The bridge lives in the root's index, never in the parked nodes' frontmatter, so no per-node edit is
+needed and a node leaves the bridge by gaining a real `parent` (it moves from the root's provisional
+list into an ordered sub-tree). The bridge is read-and-descended through the same surface a fresh
+instance already reads (the index), so nothing new has to be understood to walk it. It empties as
+the forest is ordered, then is gone.
+
 ## Tiers (when a node is read)
 
 - **Reflex tier**: a tiny set of posture rules read FIRST every session, the first items on the

--- a/designs/ai/memory-as-graph.md
+++ b/designs/ai/memory-as-graph.md
@@ -6,6 +6,22 @@ content is findable without dumping everything. Options survey:
 `designs/research/memory-system-improvements.md`. Letters layer:
 `designs/ai/letters-as-memory.md`. Consolidation procedure: the `digest` skill.
 
+## The forest model generalises beyond memory
+
+What this doc describes is a FOREST MODEL for any corpus a fresh, blank instance must navigate
+without already understanding it: a few single-meaning trunks (coarse buckets), each growing into a
+tree (root, branches, leaves by a `parent` edge), with each root node serving as its tree's index,
+the crown as the only thing offered up front, descent to reach a leaf, and a bridge for nodes
+bucketed but not yet ordered. Memory is the first instance worked through, not the only one.
+
+The **design docs** (`designs/`) are another forest of the same shape: the discipline folders are
+the trunks, the doc-structure README is the crown index, a doc bubbling from `01-prototype/` to its
+flat entity home is a node finding its tree (`feedback_docs_structure_prototype_to_entity`,
+`bubble` skill). The **issues** in Linear are a third (an issue is a node with its so-that; the
+backlog is the forest). The trunk/tree/crown/index/bridge vocabulary applies wherever structured
+knowledge has to be reached by someone who wakes not knowing it. Captured here so the model is named
+once; the per-instance detail (memory below, docs in the structure README) lives in each forest.
+
 ## The problem it solves
 
 Unstructured data is not retained. A flat heap of prose memory files has nothing to grip:

--- a/designs/ai/memory-forest.md
+++ b/designs/ai/memory-forest.md
@@ -1,4 +1,4 @@
-# Memory as a Graph
+# Memory Forest
 
 The memory corpus is 400-plus flat prose files, and the agent skims them. This is the
 structure that replaces the heap with a typed parent-tree whose roots are a small reading list, so the right

--- a/scripts/memory/lint-graph-edges.sh
+++ b/scripts/memory/lint-graph-edges.sh
@@ -92,15 +92,32 @@ if [[ "$mode" == "tree" ]]; then
             typed_roots=$((typed_roots + 1))
         fi
     done
+    # Bridge: group the unordered nodes under their proposed trunk, so the render
+    # shows a navigable forest (trunks), not a flat dump. The bucketing map is a
+    # markdown file with "## <trunk> (N)" headers and "- <node>" lines.
+    BRIDGE="${BRIDGE_MAP:-/home/josh/gamedev/volley/ai/scratchpads/memory-bucketing-proposed.md}"
+    declare -A TRUNK_OF
+    if [[ -f "$BRIDGE" ]]; then
+        cur=""
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^##\ ([a-z-]+) ]]; then cur="${BASH_REMATCH[1]}"
+            elif [[ "$line" =~ ^-\ ([A-Za-z0-9_]+) ]]; then TRUNK_OF["${BASH_REMATCH[1]}"]="$cur"; fi
+        done < "$BRIDGE"
+    fi
     echo
-    echo "# unordered (no parent yet, reachable once bucketed/typed):"
-    for node in $(printf '%s\n' "${!IS_NODE[@]}" | sort); do
-        if is_root "$node" && ! has_children "$node"; then
+    echo "# bridge: unordered nodes grouped under their proposed trunk"
+    for trunk in dev-cycle who-i-am docs volley shuck UNBUCKETED; do
+        first=1
+        for node in $(printf '%s\n' "${!IS_NODE[@]}" | sort); do
+            is_root "$node" && ! has_children "$node" || continue
+            t="${TRUNK_OF[$node]:-UNBUCKETED}"
+            [[ "$t" == "$trunk" ]] || continue
+            if [[ $first == 1 ]]; then echo; echo "## $trunk"; first=0; fi
             printf -- '- %s\n' "$node"
             unordered=$((unordered + 1))
-        fi
+        done
     done
-    echo "--- $typed_roots ordered trees, $unordered unordered nodes ---"
+    echo "--- $typed_roots ordered trees, $unordered unordered nodes across the trunks ---"
 fi
 
 echo "lint-graph-edges: $dangling dangling, $orphans root/untyped nodes"

--- a/scripts/memory/lint-graph-edges.sh
+++ b/scripts/memory/lint-graph-edges.sh
@@ -78,19 +78,29 @@ if [[ "$mode" == "tree" ]]; then
             fi
         done
     }
+    # Show the WHOLE navigable surface: ordered trees first (roots with
+    # children), then every unordered node (a root with no children, not yet
+    # placed). A fresh instance must be able to reach all of them, so render all.
+    has_children() { printf '%s\n' "${PARENT_OF[@]}" | grep -qx "$1"; }
+    is_root() { local p="${PARENT_OF[$1]:-}"; [[ -z "$p" || -z "${IS_NODE[$p]:-}" ]]; }
     typed_roots=0
+    unordered=0
     for node in $(printf '%s\n' "${!IS_NODE[@]}" | sort); do
-        p="${PARENT_OF[$node]:-}"
-        # A root with at least one child is a typed-tree top; show those.
-        if [[ -z "$p" || -z "${IS_NODE[$p]:-}" ]]; then
-            if printf '%s\n' "${PARENT_OF[@]}" | grep -qx "$node"; then
-                printf '%s\n' "$node"
-                print_children "$node" "  "
-                typed_roots=$((typed_roots + 1))
-            fi
+        if is_root "$node" && has_children "$node"; then
+            printf '%s\n' "$node"
+            print_children "$node" "  "
+            typed_roots=$((typed_roots + 1))
         fi
     done
-    echo "--- $typed_roots roots with children; flat roots omitted ---"
+    echo
+    echo "# unordered (no parent yet, reachable once bucketed/typed):"
+    for node in $(printf '%s\n' "${!IS_NODE[@]}" | sort); do
+        if is_root "$node" && ! has_children "$node"; then
+            printf -- '- %s\n' "$node"
+            unordered=$((unordered + 1))
+        fi
+    done
+    echo "--- $typed_roots ordered trees, $unordered unordered nodes ---"
 fi
 
 echo "lint-graph-edges: $dangling dangling, $orphans root/untyped nodes"

--- a/scripts/memory/lint-graph-edges.sh
+++ b/scripts/memory/lint-graph-edges.sh
@@ -59,12 +59,19 @@ while IFS= read -r -d '' filepath; do
     fi
 
     PARENT_OF["$filename"]="$parent_value"
+done < <(find "$MEMORY_DIR" -name "*.md" -print0 | sort -z)
 
-    if [[ ! -f "$MEMORY_DIR/${parent_value}.md" ]]; then
-        echo "dangling parent: $filename -> $parent_value (no file: ${parent_value}.md)"
+# Resolve parents against the set of known nodes (any subdir), not a fixed path,
+# so a parent file in letters/ or any subdir resolves. Done as a second pass so
+# a parent seen later in the walk still counts.
+for child in "${!PARENT_OF[@]}"; do
+    p="${PARENT_OF[$child]}"
+    [[ -z "$p" ]] && continue
+    if [[ -z "${IS_NODE[$p]:-}" ]]; then
+        echo "dangling parent: $child -> $p (no node: $p)"
         dangling=$((dangling + 1))
     fi
-done < <(find "$MEMORY_DIR" -name "*.md" -print0 | sort -z)
+done
 
 if [[ "$mode" == "tree" ]]; then
     # Render each root and descend its children. A node whose parent is empty,


### PR DESCRIPTION
Two design turns from working the bucketing through. First: the index is not one flat file, each tree's root node IS the index of its own tree (its children with gists), so the index distributes across the roots and MEMORY.md shrinks to just the crown of trunk roots. Descent reads the crown, opens a trunk root (which indexes that trunk), descends to a sub-root, reaches the leaf, each level's index is that node's own listing. The boot dump stays tiny because the per-tree detail is read on descent.

Second: the bridge. Building the forest is incremental, so most nodes are bucketed to a trunk but not yet ordered into its tree. Rather than edit every node's frontmatter with a provisional parent, the trunk root's index carries a provisional section listing the parked nodes. A fresh instance opening that root reads both ordered and provisional and can reach any of them, through the same index surface it already reads, so nothing new has to be understood to walk it. A node leaves the bridge by gaining a real parent. The bridge empties as the forest is ordered.

Feeds #722 (build the forest) and #873 (condense the start dump).