### PR TITLE
chore: bump bundled godotiq addon to 0.5.7

### DIFF
--- a/addons/godotiq/godotiq_server.gd
+++ b/addons/godotiq/godotiq_server.gd
@@ -4,7 +4,7 @@ extends Node
 ## dispatches requests to editor handlers or forwards to the running game.
 
 const DEFAULT_PORT := 6007
-const ADDON_VERSION := "0.5.5"
+const ADDON_VERSION := "0.5.7"
 const SCREENSHOT_TIMEOUT_MS := 30000
 const PERF_TIMEOUT_MS := 5000
 const INPUT_TIMEOUT_MS := 65000

--- a/addons/godotiq/plugin.cfg
+++ b/addons/godotiq/plugin.cfg
@@ -3,5 +3,5 @@
 name="GodotIQ"
 description="AI-assisted Godot development via MCP bridge"
 author="Salvatore Farruggio"
-version="0.5.5"
+version="0.5.7"
 script="godotiq_plugin.gd"


### PR DESCRIPTION
Brings the in-repo GodotIQ addon up to 0.5.7, matching the version of the locally installed package and MCP server. The change is the bundled addon's version constants only (`godotiq_server.gd` and `plugin.cfg`); the addon's behaviour is unchanged between these patch releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)