### PR TITLE
chore: blank-line separate each ordered tree in forest render

### DIFF
--- a/scripts/memory/lint-graph-edges.sh
+++ b/scripts/memory/lint-graph-edges.sh
@@ -94,6 +94,7 @@ if [[ "$mode" == "tree" ]]; then
     unordered=0
     for node in $(printf '%s\n' "${!IS_NODE[@]}" | sort); do
         if is_root "$node" && has_children "$node"; then
+            [[ $typed_roots -gt 0 ]] && echo
             printf '%s\n' "$node"
             print_children "$node" "  "
             typed_roots=$((typed_roots + 1))


### PR DESCRIPTION
The `--tree` render of the memory forest printed every ordered tree back to back with no separator, so the roots ran together as one block and a reader could not tell where one tree ended and the next began. This adds a blank line before each ordered tree after the first, so the trees read as distinct. The bridge section below is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)