### PR TITLE
feat: memory-forest roots generator

### DIFF
--- a/scripts/memory/generate-roots.sh
+++ b/scripts/memory/generate-roots.sh
@@ -1,42 +1,29 @@
 #!/usr/bin/env bash
-# Emits MEMORY.md's CROWN: the five trunk roots plus their ordered children
-# and provisional bridge nodes.
+# Emits MEMORY.md's CROWN: one line per trunk root, slug + gist.
 #
 # A trunk is any .md file whose frontmatter contains node_type: trunk.
 # Plain parentless nodes are NOT trunks and do NOT appear in the crown.
 #
-# Output structure for each trunk:
+# Output (one line per trunk, sorted by filename slug):
 #   <slug>  <gist>
-#     ordered children (nodes whose parent: == trunk slug):
-#       - <child-slug>  <child-gist>
-#     provisional (bridge nodes bucketed to this trunk but not yet typed):
-#       provisional:
-#       - <bridge-slug>
 #
 # Cap: total output must stay under --budget chars (default 10000).
 # Exits 2 with a truncation notice on stderr when the cap would be exceeded.
 #
 # Usage:
-#   generate-roots.sh [MEMORY_DIR] [--budget N] [--bridge PATH]
+#   generate-roots.sh [MEMORY_DIR] [--budget N]
 #
 # MEMORY_DIR defaults to ~/.claude/projects/-home-josh-gamedev-volley/memory
-# --bridge defaults to /home/josh/gamedev/volley/ai/scratchpads/memory-bucketing-proposed.md
-# parent: may sit at the top level of frontmatter or nested (any indent); both are read.
 
 set -euo pipefail
 
 MEMORY_DIR=""
 BUDGET=10000
-BRIDGE_MAP=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --budget)
             BUDGET="$2"
-            shift 2
-            ;;
-        --bridge)
-            BRIDGE_MAP="$2"
             shift 2
             ;;
         *)
@@ -49,7 +36,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 MEMORY_DIR="${MEMORY_DIR:-$HOME/.claude/projects/-home-josh-gamedev-volley/memory}"
-BRIDGE_MAP="${BRIDGE_MAP:-/home/josh/gamedev/volley/ai/scratchpads/memory-bucketing-proposed.md}"
 
 if [[ ! -d "$MEMORY_DIR" ]]; then
     echo "generate-roots: memory dir not found: $MEMORY_DIR" >&2
@@ -64,16 +50,6 @@ read_field() {
         /^---[[:space:]]*$/ { fence++; next }
         fence == 1 && /^[[:space:]]*node_type:[[:space:]]*/ && field == "node_type" {
             sub(/^[[:space:]]*node_type:[[:space:]]*/, "")
-            gsub(/^"/, ""); gsub(/"$/, "")
-            print; exit
-        }
-        fence == 1 && /^[[:space:]]*parent:[[:space:]]*/ && field == "parent" {
-            sub(/^[[:space:]]*parent:[[:space:]]*/, "")
-            gsub(/^"/, ""); gsub(/"$/, "")
-            print; exit
-        }
-        fence == 1 && /^[[:space:]]*slug:[[:space:]]*/ && field == "slug" {
-            sub(/^[[:space:]]*slug:[[:space:]]*/, "")
             gsub(/^"/, ""); gsub(/"$/, "")
             print; exit
         }
@@ -121,12 +97,9 @@ derive_gist() {
     printf '%s' "$gist"
 }
 
-# Walk the corpus once: collect trunks, parent edges, and all known slugs.
+# Walk the corpus once: collect trunks.
 declare -A NODE_FILE
-declare -A PARENT_OF
 declare -A IS_TRUNK
-# trunk_filename_slug -> bridge_slug (from slug: frontmatter field)
-declare -A TRUNK_BRIDGE_SLUG
 
 while IFS= read -r -d '' filepath; do
     slug="$(basename "$filepath" .md)"
@@ -135,15 +108,6 @@ while IFS= read -r -d '' filepath; do
     node_type="$(read_field "$filepath" "node_type")"
     if [[ "$node_type" == "trunk" ]]; then
         IS_TRUNK["$slug"]=1
-        bridge_slug="$(read_field "$filepath" "slug")"
-        if [[ -n "$bridge_slug" ]]; then
-            TRUNK_BRIDGE_SLUG["$slug"]="$bridge_slug"
-        fi
-    fi
-
-    parent="$(read_field "$filepath" "parent")"
-    if [[ -n "$parent" ]]; then
-        PARENT_OF["$slug"]="$parent"
     fi
 done < <(find "$MEMORY_DIR" -name "*.md" -print0 | sort -z)
 
@@ -152,20 +116,6 @@ trunks=()
 for slug in $(printf '%s\n' "${!IS_TRUNK[@]}" | sort); do
     trunks+=("$slug")
 done
-
-# Load the bridge map: trunk slug -> list of node slugs.
-declare -A BRIDGE_NODES
-if [[ -f "$BRIDGE_MAP" ]]; then
-    cur_trunk=""
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^##[[:space:]]+([a-zA-Z0-9_-]+) ]]; then
-            cur_trunk="${BASH_REMATCH[1]}"
-        elif [[ "$line" =~ ^-[[:space:]]+([A-Za-z0-9_/-]+) && -n "$cur_trunk" ]]; then
-            node="${BASH_REMATCH[1]}"
-            BRIDGE_NODES["${cur_trunk}:${node}"]="$node"
-        fi
-    done < "$BRIDGE_MAP"
-fi
 
 # Assemble output in a buffer, enforcing the char budget.
 output_buf=""
@@ -190,48 +140,6 @@ for trunk_slug in "${trunks[@]}"; do
     trunk_gist="$(derive_gist "$trunk_file")"
     if ! append_line "${trunk_slug}  ${trunk_gist}"; then
         break
-    fi
-
-    # Ordered children: nodes whose parent is this trunk slug.
-    for child_slug in $(printf '%s\n' "${!PARENT_OF[@]}" | sort); do
-        if [[ "${PARENT_OF[$child_slug]}" == "$trunk_slug" ]]; then
-            child_file="${NODE_FILE[$child_slug]:-}"
-            child_gist=""
-            if [[ -n "$child_file" ]]; then
-                child_gist="$(derive_gist "$child_file")"
-            fi
-            if ! append_line "  - ${child_slug}  ${child_gist}"; then
-                truncated=1
-                break
-            fi
-        fi
-    done
-
-    [[ "$truncated" -eq 1 ]] && break
-
-    # Provisional bridge nodes bucketed to this trunk but not yet typed.
-    # Bridge map uses the trunk's slug: field, not its filename slug.
-    bridge_key="${TRUNK_BRIDGE_SLUG[$trunk_slug]:-$trunk_slug}"
-    provisional_lines=()
-    for key in $(printf '%s\n' "${!BRIDGE_NODES[@]}" | grep "^${bridge_key}:" | sort); do
-        node="${BRIDGE_NODES[$key]}"
-        # Skip if already a typed child of this trunk.
-        [[ "${PARENT_OF[$node]:-}" == "$trunk_slug" ]] && continue
-        provisional_lines+=("  - ${node}")
-    done
-
-    if [[ "${#provisional_lines[@]}" -gt 0 ]]; then
-        if ! append_line "  provisional:"; then
-            truncated=1
-            break
-        fi
-        for pline in "${provisional_lines[@]}"; do
-            if ! append_line "$pline"; then
-                truncated=1
-                break
-            fi
-        done
-        [[ "$truncated" -eq 1 ]] && break
     fi
 done
 

--- a/scripts/memory/generate-roots.sh
+++ b/scripts/memory/generate-roots.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Emits MEMORY.md's CROWN: the five trunk roots plus their ordered children
+# and provisional bridge nodes.
+#
+# A trunk is any .md file whose frontmatter contains node_type: trunk.
+# Plain parentless nodes are NOT trunks and do NOT appear in the crown.
+#
+# Output structure for each trunk:
+#   <slug>  <gist>
+#     ordered children (nodes whose parent: == trunk slug):
+#       - <child-slug>  <child-gist>
+#     provisional (bridge nodes bucketed to this trunk but not yet typed):
+#       provisional:
+#       - <bridge-slug>
+#
+# Cap: total output must stay under --budget chars (default 10000).
+# Exits 2 with a truncation notice on stderr when the cap would be exceeded.
+#
+# Usage:
+#   generate-roots.sh [MEMORY_DIR] [--budget N] [--bridge PATH]
+#
+# MEMORY_DIR defaults to ~/.claude/projects/-home-josh-gamedev-volley/memory
+# --bridge defaults to /home/josh/gamedev/volley/ai/scratchpads/memory-bucketing-proposed.md
+# parent: may sit at the top level of frontmatter or nested (any indent); both are read.
+
+set -euo pipefail
+
+MEMORY_DIR=""
+BUDGET=10000
+BRIDGE_MAP=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --budget)
+            BUDGET="$2"
+            shift 2
+            ;;
+        --bridge)
+            BRIDGE_MAP="$2"
+            shift 2
+            ;;
+        *)
+            if [[ -z "$MEMORY_DIR" ]]; then
+                MEMORY_DIR="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+MEMORY_DIR="${MEMORY_DIR:-$HOME/.claude/projects/-home-josh-gamedev-volley/memory}"
+BRIDGE_MAP="${BRIDGE_MAP:-/home/josh/gamedev/volley/ai/scratchpads/memory-bucketing-proposed.md}"
+
+if [[ ! -d "$MEMORY_DIR" ]]; then
+    echo "generate-roots: memory dir not found: $MEMORY_DIR" >&2
+    exit 1
+fi
+
+# Read a frontmatter field (top-level or indented under metadata:).
+read_field() {
+    local filepath="$1"
+    local field="$2"
+    awk -v field="$field" '
+        /^---[[:space:]]*$/ { fence++; next }
+        fence == 1 && /^[[:space:]]*node_type:[[:space:]]*/ && field == "node_type" {
+            sub(/^[[:space:]]*node_type:[[:space:]]*/, "")
+            gsub(/^"/, ""); gsub(/"$/, "")
+            print; exit
+        }
+        fence == 1 && /^[[:space:]]*parent:[[:space:]]*/ && field == "parent" {
+            sub(/^[[:space:]]*parent:[[:space:]]*/, "")
+            gsub(/^"/, ""); gsub(/"$/, "")
+            print; exit
+        }
+        fence == 1 && /^[[:space:]]*slug:[[:space:]]*/ && field == "slug" {
+            sub(/^[[:space:]]*slug:[[:space:]]*/, "")
+            gsub(/^"/, ""); gsub(/"$/, "")
+            print; exit
+        }
+        fence == 1 && /^[[:space:]]*description:[[:space:]]*/ && field == "description" {
+            sub(/^[[:space:]]*description:[[:space:]]*/, "")
+            gsub(/^"/, ""); gsub(/"$/, "")
+            print; exit
+        }
+        fence == 1 && /^[[:space:]]*summary:[[:space:]]*/ && field == "summary" {
+            sub(/^[[:space:]]*summary:[[:space:]]*/, "")
+            gsub(/^"/, ""); gsub(/"$/, "")
+            print; exit
+        }
+        fence >= 2 { exit }
+    ' "$filepath"
+}
+
+# First prose line after the frontmatter: not blank, not a heading.
+read_prose_gist() {
+    awk '
+        /^---[[:space:]]*$/ { fence++; next }
+        fence < 2 { next }
+        /^[[:space:]]*$/ { next }
+        /^#/ { next }
+        { print; exit }
+    ' "$1"
+}
+
+derive_gist() {
+    local filepath="$1"
+    local gist
+
+    gist="$(read_field "$filepath" "description")"
+
+    if [[ -z "$gist" ]]; then
+        gist="$(read_field "$filepath" "summary")"
+    fi
+
+    if [[ -z "$gist" ]]; then
+        gist="$(read_prose_gist "$filepath")"
+    fi
+
+    gist="${gist:0:120}"
+    gist="${gist%"${gist##*[! ]}"}"
+    printf '%s' "$gist"
+}
+
+# Walk the corpus once: collect trunks, parent edges, and all known slugs.
+declare -A NODE_FILE
+declare -A PARENT_OF
+declare -A IS_TRUNK
+# trunk_filename_slug -> bridge_slug (from slug: frontmatter field)
+declare -A TRUNK_BRIDGE_SLUG
+
+while IFS= read -r -d '' filepath; do
+    slug="$(basename "$filepath" .md)"
+    NODE_FILE["$slug"]="$filepath"
+
+    node_type="$(read_field "$filepath" "node_type")"
+    if [[ "$node_type" == "trunk" ]]; then
+        IS_TRUNK["$slug"]=1
+        bridge_slug="$(read_field "$filepath" "slug")"
+        if [[ -n "$bridge_slug" ]]; then
+            TRUNK_BRIDGE_SLUG["$slug"]="$bridge_slug"
+        fi
+    fi
+
+    parent="$(read_field "$filepath" "parent")"
+    if [[ -n "$parent" ]]; then
+        PARENT_OF["$slug"]="$parent"
+    fi
+done < <(find "$MEMORY_DIR" -name "*.md" -print0 | sort -z)
+
+# Build the trunk list sorted by filename slug.
+trunks=()
+for slug in $(printf '%s\n' "${!IS_TRUNK[@]}" | sort); do
+    trunks+=("$slug")
+done
+
+# Load the bridge map: trunk slug -> list of node slugs.
+declare -A BRIDGE_NODES
+if [[ -f "$BRIDGE_MAP" ]]; then
+    cur_trunk=""
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^##[[:space:]]+([a-zA-Z0-9_-]+) ]]; then
+            cur_trunk="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ ^-[[:space:]]+([A-Za-z0-9_/-]+) && -n "$cur_trunk" ]]; then
+            node="${BASH_REMATCH[1]}"
+            BRIDGE_NODES["${cur_trunk}:${node}"]="$node"
+        fi
+    done < "$BRIDGE_MAP"
+fi
+
+# Assemble output in a buffer, enforcing the char budget.
+output_buf=""
+truncated=0
+
+append_line() {
+    local line="$1"
+    local len=$(( ${#line} + 1 ))
+    if (( ${#output_buf} + len > BUDGET )); then
+        truncated=1
+        return 1
+    fi
+    output_buf+="${line}"$'\n'
+}
+
+for trunk_slug in "${trunks[@]}"; do
+    trunk_file="${NODE_FILE[$trunk_slug]:-}"
+    if [[ -z "$trunk_file" ]]; then
+        continue
+    fi
+
+    trunk_gist="$(derive_gist "$trunk_file")"
+    if ! append_line "${trunk_slug}  ${trunk_gist}"; then
+        break
+    fi
+
+    # Ordered children: nodes whose parent is this trunk slug.
+    for child_slug in $(printf '%s\n' "${!PARENT_OF[@]}" | sort); do
+        if [[ "${PARENT_OF[$child_slug]}" == "$trunk_slug" ]]; then
+            child_file="${NODE_FILE[$child_slug]:-}"
+            child_gist=""
+            if [[ -n "$child_file" ]]; then
+                child_gist="$(derive_gist "$child_file")"
+            fi
+            if ! append_line "  - ${child_slug}  ${child_gist}"; then
+                truncated=1
+                break
+            fi
+        fi
+    done
+
+    [[ "$truncated" -eq 1 ]] && break
+
+    # Provisional bridge nodes bucketed to this trunk but not yet typed.
+    # Bridge map uses the trunk's slug: field, not its filename slug.
+    bridge_key="${TRUNK_BRIDGE_SLUG[$trunk_slug]:-$trunk_slug}"
+    provisional_lines=()
+    for key in $(printf '%s\n' "${!BRIDGE_NODES[@]}" | grep "^${bridge_key}:" | sort); do
+        node="${BRIDGE_NODES[$key]}"
+        # Skip if already a typed child of this trunk.
+        [[ "${PARENT_OF[$node]:-}" == "$trunk_slug" ]] && continue
+        provisional_lines+=("  - ${node}")
+    done
+
+    if [[ "${#provisional_lines[@]}" -gt 0 ]]; then
+        if ! append_line "  provisional:"; then
+            truncated=1
+            break
+        fi
+        for pline in "${provisional_lines[@]}"; do
+            if ! append_line "$pline"; then
+                truncated=1
+                break
+            fi
+        done
+        [[ "$truncated" -eq 1 ]] && break
+    fi
+done
+
+printf '%s' "$output_buf"
+
+if [[ "$truncated" -eq 1 ]]; then
+    echo "generate-roots: crown truncated; output exceeded $BUDGET chars" >&2
+    echo "[truncated: crown exceeded budget of $BUDGET chars]" >&2
+    exit 2
+fi
+
+echo "generate-roots: ${#trunks[@]} trunks emitted" >&2

--- a/scripts/memory/generate-roots.sh
+++ b/scripts/memory/generate-roots.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Emits MEMORY.md's CROWN: one line per trunk root, slug + gist.
 #
-# A trunk is any .md file whose frontmatter contains node_type: trunk.
+# A trunk is any .md file whose basename starts with `trunk_`.
 # Plain parentless nodes are NOT trunks and do NOT appear in the crown.
 #
 # Output (one line per trunk, sorted by filename slug):
@@ -105,8 +105,7 @@ while IFS= read -r -d '' filepath; do
     slug="$(basename "$filepath" .md)"
     NODE_FILE["$slug"]="$filepath"
 
-    node_type="$(read_field "$filepath" "node_type")"
-    if [[ "$node_type" == "trunk" ]]; then
+    if [[ "$slug" == trunk_* ]]; then
         IS_TRUNK["$slug"]=1
     fi
 done < <(find "$MEMORY_DIR" -name "*.md" -print0 | sort -z)

--- a/scripts/memory/generate-roots.sh
+++ b/scripts/memory/generate-roots.sh
@@ -23,6 +23,10 @@ BUDGET=10000
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --budget)
+            if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+                echo "generate-roots: --budget must be a positive integer, got: $2" >&2
+                exit 1
+            fi
             BUDGET="$2"
             shift 2
             ;;
@@ -108,7 +112,7 @@ while IFS= read -r -d '' filepath; do
     if [[ "$slug" == trunk_* ]]; then
         IS_TRUNK["$slug"]=1
     fi
-done < <(find "$MEMORY_DIR" -name "*.md" -print0 | sort -z)
+done < <(find "$MEMORY_DIR" -maxdepth 1 -name "*.md" -print0 | sort -z)
 
 # Build the trunk list sorted by filename slug.
 trunks=()

--- a/scripts/memory/test-generate-roots.sh
+++ b/scripts/memory/test-generate-roots.sh
@@ -182,10 +182,102 @@ else
     fail=$((fail + 1))
 fi
 
+# --- test 4b: gist from description: frontmatter field, ignoring prose ---
+
+DIR4B=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR4B"' EXIT
+
+cat > "$DIR4B/trunk_desc.md" <<'EOF'
+---
+node_type: trunk
+slug: trunk_desc
+description: Description field gist.
+---
+Prose that must not appear in the crown.
+EOF
+
+output=$("$GEN" "$DIR4B" 2>/dev/null)
+if echo "$output" | grep -qF "Description field gist."; then
+    echo "PASS: gist: description: field used when present"
+    pass=$((pass + 1))
+else
+    echo "FAIL: gist: description: field not used"
+    echo "  output: $output"
+    fail=$((fail + 1))
+fi
+
+if echo "$output" | grep -qF "Prose that must not appear in the crown."; then
+    echo "FAIL: gist: prose leaked into crown despite description: field"
+    echo "  output: $output"
+    fail=$((fail + 1))
+else
+    echo "PASS: gist: prose suppressed when description: field present"
+    pass=$((pass + 1))
+fi
+
+# --- test 4c: gist from summary: frontmatter field when no description: ---
+
+DIR4C=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR4B" "$DIR4C"' EXIT
+
+cat > "$DIR4C/trunk_summ.md" <<'EOF'
+---
+node_type: trunk
+slug: trunk_summ
+summary: Summary field gist.
+---
+EOF
+
+output=$("$GEN" "$DIR4C" 2>/dev/null)
+if echo "$output" | grep -qF "Summary field gist."; then
+    echo "PASS: gist: summary: field used when no description:"
+    pass=$((pass + 1))
+else
+    echo "FAIL: gist: summary: field not used"
+    echo "  output: $output"
+    fail=$((fail + 1))
+fi
+
+# --- test 4d: subdirectory trunk_ files are NOT crowned (maxdepth 1) ---
+
+DIR4D=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR4B" "$DIR4C" "$DIR4D"' EXIT
+
+make_trunk "$DIR4D" "trunk_top" "top-level trunk gist"
+mkdir -p "$DIR4D/letters"
+cat > "$DIR4D/letters/trunk_nested.md" <<'EOF'
+---
+node_type: trunk
+slug: trunk_nested
+---
+This trunk is nested and must not appear in the crown.
+EOF
+
+assert_output_contains "maxdepth: top-level trunk is crowned" "trunk_top" "$GEN" "$DIR4D"
+assert_output_not_contains "maxdepth: nested trunk_ excluded" "trunk_nested" "$GEN" "$DIR4D"
+
+# --- test 4e: non-integer --budget exits 1 with a clear message ---
+
+DIR4E=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR4B" "$DIR4C" "$DIR4D" "$DIR4E"' EXIT
+
+make_trunk "$DIR4E" "trunk_aa" "short"
+
+assert_exit "budget-validate: non-integer --budget exits 1" 1 "$GEN" "$DIR4E" --budget abc
+
+budget_err=$("$GEN" "$DIR4E" --budget xyz 2>&1 || true)
+if echo "$budget_err" | grep -qF "must be a positive integer"; then
+    echo "PASS: budget-validate: clear error message on non-integer --budget"
+    pass=$((pass + 1))
+else
+    echo "FAIL: budget-validate: expected clear error message, got: $budget_err"
+    fail=$((fail + 1))
+fi
+
 # --- test 5: exits 0 when all trunks fit in budget ---
 
 DIR5=$(mktemp -d)
-trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5"' EXIT
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR4B" "$DIR4C" "$DIR4D" "$DIR4E" "$DIR5"' EXIT
 
 make_trunk "$DIR5" "trunk_aa" "short"
 make_trunk "$DIR5" "trunk_bb" "short"
@@ -197,7 +289,7 @@ assert_exit "no truncation: exits 0 when under budget" 0 "$GEN" "$DIR5" --budget
 # so detection must not rely on frontmatter node_type.
 
 DIR6=$(mktemp -d)
-trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5" "$DIR6"' EXIT
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR4B" "$DIR4C" "$DIR4D" "$DIR4E" "$DIR5" "$DIR6"' EXIT
 
 make_trunk_with_node_type "$DIR6" "trunk_normalizer" "memory" "normalizer-safe trunk gist"
 make_node "$DIR6" "plain-node" "" "should not appear"

--- a/scripts/memory/test-generate-roots.sh
+++ b/scripts/memory/test-generate-roots.sh
@@ -71,6 +71,20 @@ $gist
 EOF
 }
 
+make_trunk_with_node_type() {
+    local dir="$1"
+    local slug="$2"
+    local node_type="$3"
+    local gist="${4:-gist for $slug}"
+    cat > "$dir/${slug}.md" <<EOF
+---
+node_type: $node_type
+slug: $slug
+---
+$gist
+EOF
+}
+
 make_node() {
     local dir="$1"
     local slug="$2"
@@ -93,13 +107,13 @@ make_node() {
 DIR1=$(mktemp -d)
 trap 'rm -rf "$DIR1"' EXIT
 
-make_trunk "$DIR1" "trunk-alpha" "alpha trunk gist"
-make_trunk "$DIR1" "trunk-beta" "beta trunk gist"
+make_trunk "$DIR1" "trunk_alpha" "alpha trunk gist"
+make_trunk "$DIR1" "trunk_beta" "beta trunk gist"
 make_node "$DIR1" "plain-root" "" "a plain parentless node"
-make_node "$DIR1" "child-node" "trunk-alpha" "a typed child"
+make_node "$DIR1" "child-node" "trunk_alpha" "a typed child"
 
-assert_output_contains "crown: trunk-alpha listed" "trunk-alpha" "$GEN" "$DIR1"
-assert_output_contains "crown: trunk-beta listed" "trunk-beta" "$GEN" "$DIR1"
+assert_output_contains "crown: trunk_alpha listed" "trunk_alpha" "$GEN" "$DIR1"
+assert_output_contains "crown: trunk_beta listed" "trunk_beta" "$GEN" "$DIR1"
 assert_output_not_contains "crown: plain parentless node excluded" "plain-root" "$GEN" "$DIR1"
 
 # --- test 2: exactly five trunks produce exactly five trunk header lines ---
@@ -107,15 +121,15 @@ assert_output_not_contains "crown: plain parentless node excluded" "plain-root" 
 DIR2=$(mktemp -d)
 trap 'rm -rf "$DIR1" "$DIR2"' EXIT
 
-make_trunk "$DIR2" "trunk-one" "one"
-make_trunk "$DIR2" "trunk-two" "two"
-make_trunk "$DIR2" "trunk-three" "three"
-make_trunk "$DIR2" "trunk-four" "four"
-make_trunk "$DIR2" "trunk-five" "five"
+make_trunk "$DIR2" "trunk_one" "one"
+make_trunk "$DIR2" "trunk_two" "two"
+make_trunk "$DIR2" "trunk_three" "three"
+make_trunk "$DIR2" "trunk_four" "four"
+make_trunk "$DIR2" "trunk_five" "five"
 make_node "$DIR2" "non-trunk-a" "" "not a trunk"
-make_node "$DIR2" "non-trunk-b" "trunk-one" "typed child"
+make_node "$DIR2" "non-trunk-b" "trunk_one" "typed child"
 
-crown_count=$("$GEN" "$DIR2" 2>/dev/null | grep -c "^trunk-" || true)
+crown_count=$("$GEN" "$DIR2" 2>/dev/null | grep -c "^trunk_" || true)
 if [[ "$crown_count" -eq 5 ]]; then
     echo "PASS: crown count: exactly 5 trunk headers"
     pass=$((pass + 1))
@@ -130,7 +144,7 @@ DIR3=$(mktemp -d)
 trap 'rm -rf "$DIR1" "$DIR2" "$DIR3"' EXIT
 
 for i in $(seq 1 5); do
-    make_trunk "$DIR3" "trunk-$(printf '%02d' "$i")" "gist number $i is here and takes space in the output buffer"
+    make_trunk "$DIR3" "trunk_$(printf '%02d' "$i")" "gist number $i is here and takes space in the output buffer"
 done
 
 assert_exit "cap guard: exits 2 when budget exceeded" 2 "$GEN" "$DIR3" --budget 50
@@ -150,10 +164,10 @@ fi
 DIR4=$(mktemp -d)
 trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4"' EXIT
 
-cat > "$DIR4/trunk-prose.md" <<'EOF'
+cat > "$DIR4/trunk_prose.md" <<'EOF'
 ---
 node_type: trunk
-slug: trunk-prose
+slug: trunk_prose
 ---
 The prose gist for this trunk.
 EOF
@@ -173,10 +187,23 @@ fi
 DIR5=$(mktemp -d)
 trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5"' EXIT
 
-make_trunk "$DIR5" "trunk-aa" "short"
-make_trunk "$DIR5" "trunk-bb" "short"
+make_trunk "$DIR5" "trunk_aa" "short"
+make_trunk "$DIR5" "trunk_bb" "short"
 
 assert_exit "no truncation: exits 0 when under budget" 0 "$GEN" "$DIR5" --budget 10000
+
+# --- test 6: trunk_ filename with node_type: memory is still treated as a trunk ---
+# Normalizer-survival: the harness rewrites node_type to "memory" on any edit,
+# so detection must not rely on frontmatter node_type.
+
+DIR6=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5" "$DIR6"' EXIT
+
+make_trunk_with_node_type "$DIR6" "trunk_normalizer" "memory" "normalizer-safe trunk gist"
+make_node "$DIR6" "plain-node" "" "should not appear"
+
+assert_output_contains "normalizer-survival: trunk_ with node_type:memory is in crown" "trunk_normalizer" "$GEN" "$DIR6"
+assert_output_not_contains "normalizer-survival: plain node excluded" "plain-node" "$GEN" "$DIR6"
 
 # --- summary ---
 

--- a/scripts/memory/test-generate-roots.sh
+++ b/scripts/memory/test-generate-roots.sh
@@ -124,92 +124,18 @@ else
     fail=$((fail + 1))
 fi
 
-# --- test 3: typed child appears under its trunk ---
+# --- test 3: cap guard fires, exits 2, emits truncation notice ---
 
 DIR3=$(mktemp -d)
 trap 'rm -rf "$DIR1" "$DIR2" "$DIR3"' EXIT
 
-make_trunk "$DIR3" "trunk-parent" "the parent trunk"
-make_node "$DIR3" "child-of-trunk" "trunk-parent" "a direct trunk child"
-make_node "$DIR3" "unrelated-root" "" "not a trunk"
-
-output=$("$GEN" "$DIR3" 2>/dev/null)
-
-if echo "$output" | grep -qF "child-of-trunk"; then
-    echo "PASS: typed child: child-of-trunk appears"
-    pass=$((pass + 1))
-else
-    echo "FAIL: typed child: child-of-trunk missing"
-    echo "  output: $output"
-    fail=$((fail + 1))
-fi
-
-trunk_line=$(echo "$output" | grep -n "trunk-parent" | head -1 | cut -d: -f1 || echo 0)
-child_line=$(echo "$output" | grep -n "child-of-trunk" | head -1 | cut -d: -f1 || echo 0)
-if [[ "$trunk_line" -gt 0 && "$child_line" -gt "$trunk_line" ]]; then
-    echo "PASS: typed child: child positioned after its trunk"
-    pass=$((pass + 1))
-else
-    echo "FAIL: typed child: child not after trunk (trunk=$trunk_line child=$child_line)"
-    fail=$((fail + 1))
-fi
-
-# --- test 4: bridge node appears in trunk's provisional section ---
-
-DIR4=$(mktemp -d)
-trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4"' EXIT
-
-make_trunk "$DIR4" "trunk-x" "trunk x gist"
-make_node "$DIR4" "bridge-node-a" "" "an untyped node"
-
-BRIDGE4="$DIR4/bridge.md"
-cat > "$BRIDGE4" <<'EOF'
-## trunk-x (1)
-- bridge-node-a
-EOF
-
-output=$("$GEN" "$DIR4" --bridge "$BRIDGE4" 2>/dev/null)
-
-if echo "$output" | grep -qF "bridge-node-a"; then
-    echo "PASS: bridge: bridge-node-a appears"
-    pass=$((pass + 1))
-else
-    echo "FAIL: bridge: bridge-node-a missing"
-    echo "  output: $output"
-    fail=$((fail + 1))
-fi
-
-if echo "$output" | grep -qi "provisional"; then
-    echo "PASS: bridge: provisional section label present"
-    pass=$((pass + 1))
-else
-    echo "FAIL: bridge: no provisional section label"
-    echo "  output: $output"
-    fail=$((fail + 1))
-fi
-
-trunk_line=$(echo "$output" | grep -n "trunk-x" | head -1 | cut -d: -f1 || echo 0)
-bridge_line=$(echo "$output" | grep -n "bridge-node-a" | head -1 | cut -d: -f1 || echo 0)
-if [[ "$trunk_line" -gt 0 && "$bridge_line" -gt "$trunk_line" ]]; then
-    echo "PASS: bridge: bridge node positioned after trunk"
-    pass=$((pass + 1))
-else
-    echo "FAIL: bridge: bridge node not after trunk (trunk=$trunk_line bridge=$bridge_line)"
-    fail=$((fail + 1))
-fi
-
-# --- test 5: cap guard fires, exits 2, emits truncation notice ---
-
-DIR5=$(mktemp -d)
-trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5"' EXIT
-
 for i in $(seq 1 5); do
-    make_trunk "$DIR5" "trunk-$(printf '%02d' "$i")" "gist number $i is here and takes space in the output buffer"
+    make_trunk "$DIR3" "trunk-$(printf '%02d' "$i")" "gist number $i is here and takes space in the output buffer"
 done
 
-assert_exit "cap guard: exits 2 when budget exceeded" 2 "$GEN" "$DIR5" --budget 50
+assert_exit "cap guard: exits 2 when budget exceeded" 2 "$GEN" "$DIR3" --budget 50
 
-cap_output=$("$GEN" "$DIR5" --budget 50 2>&1 || true)
+cap_output=$("$GEN" "$DIR3" --budget 50 2>&1 || true)
 if echo "$cap_output" | grep -qF "truncated"; then
     echo "PASS: cap guard: truncation notice emitted"
     pass=$((pass + 1))
@@ -219,12 +145,12 @@ else
     fail=$((fail + 1))
 fi
 
-# --- test 6: gist from first prose line of trunk ---
+# --- test 4: gist from first prose line of trunk ---
 
-DIR6=$(mktemp -d)
-trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5" "$DIR6"' EXIT
+DIR4=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4"' EXIT
 
-cat > "$DIR6/trunk-prose.md" <<'EOF'
+cat > "$DIR4/trunk-prose.md" <<'EOF'
 ---
 node_type: trunk
 slug: trunk-prose
@@ -232,7 +158,7 @@ slug: trunk-prose
 The prose gist for this trunk.
 EOF
 
-output=$("$GEN" "$DIR6" 2>/dev/null)
+output=$("$GEN" "$DIR4" 2>/dev/null)
 if echo "$output" | grep -qF "The prose gist for this trunk."; then
     echo "PASS: gist: first prose line used"
     pass=$((pass + 1))
@@ -242,15 +168,15 @@ else
     fail=$((fail + 1))
 fi
 
-# --- test 7: exits 0 when all trunks fit in budget ---
+# --- test 5: exits 0 when all trunks fit in budget ---
 
-DIR7=$(mktemp -d)
-trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5" "$DIR6" "$DIR7"' EXIT
+DIR5=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5"' EXIT
 
-make_trunk "$DIR7" "trunk-aa" "short"
-make_trunk "$DIR7" "trunk-bb" "short"
+make_trunk "$DIR5" "trunk-aa" "short"
+make_trunk "$DIR5" "trunk-bb" "short"
 
-assert_exit "no truncation: exits 0 when under budget" 0 "$GEN" "$DIR7" --budget 10000
+assert_exit "no truncation: exits 0 when under budget" 0 "$GEN" "$DIR5" --budget 10000
 
 # --- summary ---
 

--- a/scripts/memory/test-generate-roots.sh
+++ b/scripts/memory/test-generate-roots.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Tests for generate-roots.sh.
+# Creates temporary fixture directories and asserts exit codes + output.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GEN="$SCRIPT_DIR/generate-roots.sh"
+
+pass=0
+fail=0
+
+assert_exit() {
+    local description="$1"
+    local expected_exit="$2"
+    shift 2
+    local actual_exit=0
+    "$@" >/dev/null 2>&1 || actual_exit=$?
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        echo "PASS: $description"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $description (expected exit $expected_exit, got $actual_exit)"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_output_contains() {
+    local description="$1"
+    local expected_substring="$2"
+    shift 2
+    local output
+    output=$("$@" 2>&1 || true)
+    if echo "$output" | grep -qF "$expected_substring"; then
+        echo "PASS: $description"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: $description (expected '$expected_substring' not found)"
+        echo "  actual output: $output"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_output_not_contains() {
+    local description="$1"
+    local absent_substring="$2"
+    shift 2
+    local output
+    output=$("$@" 2>&1 || true)
+    if echo "$output" | grep -qF "$absent_substring"; then
+        echo "FAIL: $description (unexpected '$absent_substring' found)"
+        echo "  actual output: $output"
+        fail=$((fail + 1))
+    else
+        echo "PASS: $description"
+        pass=$((pass + 1))
+    fi
+}
+
+# --- fixture helpers ---
+
+make_trunk() {
+    local dir="$1"
+    local slug="$2"
+    local gist="${3:-gist for $slug}"
+    cat > "$dir/${slug}.md" <<EOF
+---
+node_type: trunk
+slug: $slug
+---
+$gist
+EOF
+}
+
+make_node() {
+    local dir="$1"
+    local slug="$2"
+    local parent="${3:-}"
+    local description="${4:-}"
+    local file="$dir/${slug}.md"
+    mkdir -p "$(dirname "$file")"
+
+    {
+        printf -- '---\n'
+        [[ -n "$parent" ]] && printf 'parent: %s\n' "$parent"
+        [[ -n "$description" ]] && printf 'description: %s\n' "$description"
+        printf -- '---\n'
+        printf 'Body text for %s.\n' "$slug"
+    } > "$file"
+}
+
+# --- test 1: crown lists only trunks, not plain parentless nodes ---
+
+DIR1=$(mktemp -d)
+trap 'rm -rf "$DIR1"' EXIT
+
+make_trunk "$DIR1" "trunk-alpha" "alpha trunk gist"
+make_trunk "$DIR1" "trunk-beta" "beta trunk gist"
+make_node "$DIR1" "plain-root" "" "a plain parentless node"
+make_node "$DIR1" "child-node" "trunk-alpha" "a typed child"
+
+assert_output_contains "crown: trunk-alpha listed" "trunk-alpha" "$GEN" "$DIR1"
+assert_output_contains "crown: trunk-beta listed" "trunk-beta" "$GEN" "$DIR1"
+assert_output_not_contains "crown: plain parentless node excluded" "plain-root" "$GEN" "$DIR1"
+
+# --- test 2: exactly five trunks produce exactly five trunk header lines ---
+
+DIR2=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2"' EXIT
+
+make_trunk "$DIR2" "trunk-one" "one"
+make_trunk "$DIR2" "trunk-two" "two"
+make_trunk "$DIR2" "trunk-three" "three"
+make_trunk "$DIR2" "trunk-four" "four"
+make_trunk "$DIR2" "trunk-five" "five"
+make_node "$DIR2" "non-trunk-a" "" "not a trunk"
+make_node "$DIR2" "non-trunk-b" "trunk-one" "typed child"
+
+crown_count=$("$GEN" "$DIR2" 2>/dev/null | grep -c "^trunk-" || true)
+if [[ "$crown_count" -eq 5 ]]; then
+    echo "PASS: crown count: exactly 5 trunk headers"
+    pass=$((pass + 1))
+else
+    echo "FAIL: crown count: expected 5 trunk headers, got $crown_count"
+    fail=$((fail + 1))
+fi
+
+# --- test 3: typed child appears under its trunk ---
+
+DIR3=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3"' EXIT
+
+make_trunk "$DIR3" "trunk-parent" "the parent trunk"
+make_node "$DIR3" "child-of-trunk" "trunk-parent" "a direct trunk child"
+make_node "$DIR3" "unrelated-root" "" "not a trunk"
+
+output=$("$GEN" "$DIR3" 2>/dev/null)
+
+if echo "$output" | grep -qF "child-of-trunk"; then
+    echo "PASS: typed child: child-of-trunk appears"
+    pass=$((pass + 1))
+else
+    echo "FAIL: typed child: child-of-trunk missing"
+    echo "  output: $output"
+    fail=$((fail + 1))
+fi
+
+trunk_line=$(echo "$output" | grep -n "trunk-parent" | head -1 | cut -d: -f1 || echo 0)
+child_line=$(echo "$output" | grep -n "child-of-trunk" | head -1 | cut -d: -f1 || echo 0)
+if [[ "$trunk_line" -gt 0 && "$child_line" -gt "$trunk_line" ]]; then
+    echo "PASS: typed child: child positioned after its trunk"
+    pass=$((pass + 1))
+else
+    echo "FAIL: typed child: child not after trunk (trunk=$trunk_line child=$child_line)"
+    fail=$((fail + 1))
+fi
+
+# --- test 4: bridge node appears in trunk's provisional section ---
+
+DIR4=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4"' EXIT
+
+make_trunk "$DIR4" "trunk-x" "trunk x gist"
+make_node "$DIR4" "bridge-node-a" "" "an untyped node"
+
+BRIDGE4="$DIR4/bridge.md"
+cat > "$BRIDGE4" <<'EOF'
+## trunk-x (1)
+- bridge-node-a
+EOF
+
+output=$("$GEN" "$DIR4" --bridge "$BRIDGE4" 2>/dev/null)
+
+if echo "$output" | grep -qF "bridge-node-a"; then
+    echo "PASS: bridge: bridge-node-a appears"
+    pass=$((pass + 1))
+else
+    echo "FAIL: bridge: bridge-node-a missing"
+    echo "  output: $output"
+    fail=$((fail + 1))
+fi
+
+if echo "$output" | grep -qi "provisional"; then
+    echo "PASS: bridge: provisional section label present"
+    pass=$((pass + 1))
+else
+    echo "FAIL: bridge: no provisional section label"
+    echo "  output: $output"
+    fail=$((fail + 1))
+fi
+
+trunk_line=$(echo "$output" | grep -n "trunk-x" | head -1 | cut -d: -f1 || echo 0)
+bridge_line=$(echo "$output" | grep -n "bridge-node-a" | head -1 | cut -d: -f1 || echo 0)
+if [[ "$trunk_line" -gt 0 && "$bridge_line" -gt "$trunk_line" ]]; then
+    echo "PASS: bridge: bridge node positioned after trunk"
+    pass=$((pass + 1))
+else
+    echo "FAIL: bridge: bridge node not after trunk (trunk=$trunk_line bridge=$bridge_line)"
+    fail=$((fail + 1))
+fi
+
+# --- test 5: cap guard fires, exits 2, emits truncation notice ---
+
+DIR5=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5"' EXIT
+
+for i in $(seq 1 5); do
+    make_trunk "$DIR5" "trunk-$(printf '%02d' "$i")" "gist number $i is here and takes space in the output buffer"
+done
+
+assert_exit "cap guard: exits 2 when budget exceeded" 2 "$GEN" "$DIR5" --budget 50
+
+cap_output=$("$GEN" "$DIR5" --budget 50 2>&1 || true)
+if echo "$cap_output" | grep -qF "truncated"; then
+    echo "PASS: cap guard: truncation notice emitted"
+    pass=$((pass + 1))
+else
+    echo "FAIL: cap guard: no truncation notice"
+    echo "  output: $cap_output"
+    fail=$((fail + 1))
+fi
+
+# --- test 6: gist from first prose line of trunk ---
+
+DIR6=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5" "$DIR6"' EXIT
+
+cat > "$DIR6/trunk-prose.md" <<'EOF'
+---
+node_type: trunk
+slug: trunk-prose
+---
+The prose gist for this trunk.
+EOF
+
+output=$("$GEN" "$DIR6" 2>/dev/null)
+if echo "$output" | grep -qF "The prose gist for this trunk."; then
+    echo "PASS: gist: first prose line used"
+    pass=$((pass + 1))
+else
+    echo "FAIL: gist: first prose line not used"
+    echo "  output: $output"
+    fail=$((fail + 1))
+fi
+
+# --- test 7: exits 0 when all trunks fit in budget ---
+
+DIR7=$(mktemp -d)
+trap 'rm -rf "$DIR1" "$DIR2" "$DIR3" "$DIR4" "$DIR5" "$DIR6" "$DIR7"' EXIT
+
+make_trunk "$DIR7" "trunk-aa" "short"
+make_trunk "$DIR7" "trunk-bb" "short"
+
+assert_exit "no truncation: exits 0 when under budget" 0 "$GEN" "$DIR7" --budget 10000
+
+# --- summary ---
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Implements `generate-roots.sh`: walks the memory corpus for files whose basename starts with `trunk_`, emits the five trunks as the CROWN (slug + gist), and exits 2 with a truncation notice if the output would exceed the 10K SessionStart cap.

Plain parentless nodes are excluded from the crown. Filename-based detection survives the harness normalizer, which rewrites `node_type` to `memory` on every edit and would clobber `node_type: trunk`.

This is AC2 of #722 (the roots generate as the boot reading list). The generator is intentionally standalone here: wiring its output into MEMORY.md and the SessionStart offer is AC3, a separate follow-up. The anti-drift promise is redeemed when AC3 lands, not in this PR.

#722

Agent-Role: gdscript-implementer