### PR TITLE
feat: cap reviewer inline comments at 300 chars

### DIFF
--- a/.claude/hooks/reviewer-inline-comment-cap.sh
+++ b/.claude/hooks/reviewer-inline-comment-cap.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# PreToolUse on Bash, gated to a reviews/comments POST: deny when any inline finding
+# body exceeds 300 chars. A review comment is a verdict-sized clause (the reviewers
+# skill: 30 words, 2 lines); long inlines restate what the diff already shows.
+# Only fires on `gh api ... pulls/.../reviews` or `.../comments` POSTs. Fails open.
+set -uo pipefail
+
+CAP=300
+input="$(cat)"
+
+result="$(printf '%s' "$input" | python3 -c "
+import json, sys, re
+CAP = $CAP
+try:
+    d = json.load(sys.stdin)
+    cmd = d.get('tool_input', {}).get('command', '')
+    # only reviewer-posting calls: a POST to pulls/.../reviews or .../comments
+    if not re.search(r'pulls/[^ ]*/(reviews|comments)', cmd):
+        print('PASS'); sys.exit()
+    if 'POST' not in cmd and '-X POST' not in cmd:
+        print('PASS'); sys.exit()
+    # find every \"body\": \"...\" value in the command (the inline finding text)
+    bodies = re.findall(r'\"body\"\s*:\s*\"((?:[^\"\\\\]|\\\\.)*)\"', cmd)
+    worst = 0
+    for b in bodies:
+        # unescape \\n, \\\" etc to count visible chars
+        try:
+            v = json.loads('\"' + b + '\"')
+        except Exception:
+            v = b
+        worst = max(worst, len(v))
+    print('DENY %d' % worst if worst > CAP else 'PASS')
+except Exception:
+    print('PASS')  # fail open
+" 2>/dev/null || echo PASS)"
+
+if [ "${result%% *}" = "DENY" ]; then
+  n="${result##* }"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"An inline review comment is %s chars; the cap is %s. A finding is one clause: name the concern and the fix, anchored to the line. Push the reasoning into the dispatcher report, not the PR thread."}}\n' "$n" "$CAP"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,57 +4,102 @@
       {
         "matcher": ".*",
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/em-dash-pre-tool.sh\"" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/em-dash-pre-tool.sh\""
+          }
         ]
       },
       {
         "matcher": "mcp__linear__save_issue",
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-issue-body-cap.sh\"" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-issue-body-cap.sh\""
+          }
         ]
       },
       {
         "matcher": "mcp__linear__save_comment",
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-comment-body-cap.sh\"" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-comment-body-cap.sh\""
+          }
         ]
       },
       {
         "matcher": "Agent",
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/require-background-agent.sh\"" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/require-background-agent.sh\""
+          }
         ]
       },
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/git-rebase-ask.sh\"" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-approved-human.sh\"" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-pr-merge.sh\"" },
-          { "type": "command", "if": "Bash(rm*)", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-permission-reason.sh\"" },
-          { "type": "command", "if": "Bash(*bot-review.yml*)", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/synthesis-body-cap.sh\"" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/git-rebase-ask.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-approved-human.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-pr-merge.sh\""
+          },
+          {
+            "type": "command",
+            "if": "Bash(rm*)",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-permission-reason.sh\""
+          },
+          {
+            "type": "command",
+            "if": "Bash(*bot-review.yml*)",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/synthesis-body-cap.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/reviewer-inline-comment-cap.sh\""
+          }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-mention-state-check.sh\"" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-mention-state-check.sh\""
+          }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/memory-correction-signal.sh\"" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/memory-correction-signal.sh\""
+          }
         ]
       }
     ],
     "SessionStart": [
       {
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-priority-memory.sh\"" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-latest-handoff.sh\"" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-priority-memory.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-latest-handoff.sh\""
+          }
         ]
       }
     ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,102 +4,58 @@
       {
         "matcher": ".*",
         "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/em-dash-pre-tool.sh\""
-          }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/em-dash-pre-tool.sh\"" }
         ]
       },
       {
         "matcher": "mcp__linear__save_issue",
         "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-issue-body-cap.sh\""
-          }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-issue-body-cap.sh\"" }
         ]
       },
       {
         "matcher": "mcp__linear__save_comment",
         "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-comment-body-cap.sh\""
-          }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/linear-comment-body-cap.sh\"" }
         ]
       },
       {
         "matcher": "Agent",
         "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/require-background-agent.sh\""
-          }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/require-background-agent.sh\"" }
         ]
       },
       {
         "matcher": "Bash",
         "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/git-rebase-ask.sh\""
-          },
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-approved-human.sh\""
-          },
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-pr-merge.sh\""
-          },
-          {
-            "type": "command",
-            "if": "Bash(rm*)",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-permission-reason.sh\""
-          },
-          {
-            "type": "command",
-            "if": "Bash(*bot-review.yml*)",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/synthesis-body-cap.sh\""
-          },
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/reviewer-inline-comment-cap.sh\""
-          }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/git-rebase-ask.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-approved-human.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-pr-merge.sh\"" },
+          { "type": "command", "if": "Bash(rm*)", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-permission-reason.sh\"" },
+          { "type": "command", "if": "Bash(*bot-review.yml*)", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/synthesis-body-cap.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/reviewer-inline-comment-cap.sh\"" }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-mention-state-check.sh\""
-          }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-mention-state-check.sh\"" }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/memory-correction-signal.sh\""
-          }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/memory-correction-signal.sh\"" }
         ]
       }
     ],
     "SessionStart": [
       {
         "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-priority-memory.sh\""
-          },
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-latest-handoff.sh\""
-          }
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-priority-memory.sh\"" },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-latest-handoff.sh\"" }
         ]
       }
     ]


### PR DESCRIPTION
The reviewers skill caps an inline finding at 30 words and two lines, but nothing enforced it: only the synthesis verdict body and the Linear comment/issue bodies had char-cap hooks. A long inline restates what the diff already shows and buries the one clause that matters. This adds a PreToolUse hook on Bash, gated to a reviews or comments POST, that denies when any inline finding body exceeds 300 chars, the same ceiling the synthesis body and Linear comment hooks use. The deny message points the reviewer to put reasoning in the dispatcher report, not the thread. Non-review commands and parse errors pass.