### PR TITLE
chore: split battle out of dispatch as its own skill

### DIFF
--- a/.claude/skills/battle/SKILL.md
+++ b/.claude/skills/battle/SKILL.md
@@ -1,46 +1,46 @@
 ---
 name: battle
-description: Dispatcher-side rules for running a reviewer battle against a challenge: when it fires, scope-filtering reviewers by changed path, the design-PR required lane, one-round discipline, consensus on disagreement, and firing the synthesis verdict. Read when Josh asks for a battle. The challenge being battled is the `pr` skill; the per-reviewer contract is the `reviewers` skill.
+description: Dispatcher-side rules for battling a challenge: the end-to-end review loop. Ground-read review state, dispatch at least one independent reviewer (more by scope), converge without churn, resolve the verdict against the issue's AC, fire the bot review, then push and move on. Read when battling any PR. The owning memory is feedback_battle_review_process; the challenge body shape is the `pr` skill; the per-reviewer contract is the `reviewers` skill.
 ---
 
-# Running a battle
+# Battling a challenge
 
-The organiser's side of a reviewer battle: the adversarial review pass against an open challenge. A *challenge* is the PR (see [`pr`](../pr/SKILL.md) for its body shape); a *battle* is the review run against it. This skill is what Gru reads to run that pass. The reviewer agent's own contract (posture, verdict shape, inline-finding discipline) lives in [`reviewers`](../reviewers/SKILL.md); brief each reviewer to read it. The memory branch for the whole loop is [[feedback_battle_review_process]] under [[trunk_dev_cycle]].
+The organiser's side of a review battle. A *challenge* is the PR (see [`pr`](../pr/SKILL.md) for its body shape); a *battle* is the review run against it. This skill is what Gru reads to run that pass; it renders the memory branch [[feedback_battle_review_process]] under [[trunk_dev_cycle]], which is the authority. The reviewer agent's own contract (posture, finding form, inline discipline) lives in [`reviewers`](../reviewers/SKILL.md); brief each reviewer to read it.
 
-## When a battle fires
+A battle is a confidence pass over a shipped challenge, not an exhaustive audit. It is minion work, dispatched by default rather than run in-thread. The depth scales with the diff, but the floor never drops to zero.
 
-The default is no reviewer fan-out. The dispatcher spot-checks every diff (read it, run the suite, verify the behaviour holds) and that is the review for most increments: docs, renames, mechanical changes, small fixes. A big PR is one review surface, spot-checked once at the right depth, never re-battled per commit.
+## The floor: one independent reviewer, always
 
-A reviewer battle runs only when Josh asks for one. When he does: scope-filter the diff by changed path and fan only the matching specialists (code-quality, gdscript-conventions, test-coverage on a GDScript diff; domain reviewers on the files they own). The full path → specialist map and the verdict contract live in [`reviewers`](../reviewers/SKILL.md). Battlers (devils-advocate, integration-scenario-author) fire alongside only when the battle is requested. Devils-advocate has Bash, so it posts its findings as inline review comments like any reviewer; brief it to do so, and do not tell it to reason from the diff text alone.
+Every PR gets at least one independent reviewer before it is reviewed. "No fan-out" and "spot-check" mean one reviewer at the right depth instead of a full panel, not zero reviewers. Reading my own diff and finding it correct is not a review: I wrote it, so I find it coherent, which is [[feedback_self_judgment_is_coherence_not_accuracy]] applied to my own change. The dispatcher reading the diff first is due diligence before handoff, not the review.
 
-## Design-PR battles are generative
+The tell, and it fires often: I am about to tell Josh a PR is "ready" or "yours to merge" having only read it myself. That PR has had zero reviews. Dispatch one reviewer first. Pick the single lens the diff calls for (devils-advocate for a rule-bearing doc, code-quality for a small code change, docs-and-writing for prose) and dispatch it. Fan to several specialists only when the diff's scope justifies it; the minimum is one, not zero.
 
-On a **design or spec doc** (a `designs/**` change that argues a design, not just prose), devils-advocate is a REQUIRED lane, not the optional fresh-eyes pass: fan it on the design's claims alongside docs-and-writing and repetition-reviewer. That battle is GENERATIVE, the right outcome is often that the design changes between rounds, so re-battle a design PR after a substantive rewrite (not after a typo fix). See [[feedback_battle_review_process]], the design-PR clause.
+## The loop
 
-## One round, no stacked re-battles
+1. **Ground-read before dispatch, review state included.** The pre-battle `gh` read covers `state`, `mergeable`, HEAD, checks AND `reviewDecision` plus the per-PR reviews (`gh api .../pulls/<n>/reviews`), not just CI. Skipping the reviews means battling a PR that may already carry an approval; stale approvals do not auto-dismiss, so a PR can show an active bot APPROVE on an old SHA. Know the review state before re-treading it. Then dispatch reviewers scoped to the diff's lanes, always `run_in_background: true`, against the live HEAD. The path → specialist map is in [`reviewers`](../reviewers/SKILL.md). Findings go inline.
 
-Within a requested battle, run one round. Re-check a blocked finding with the one reviewer who raised it on the incremental, not a fresh fan-out; a clean incremental is a silent approve. Do not stack re-battles.
+2. **Converge, do not churn.** After a round or two with findings addressed and CI green, another battle surfaces nothing new; it just spins. Do not re-battle a converged PR; that is churn dressed as diligence. Once converged, the bottleneck is a decision, not more review signal.
 
-The dispatcher dispatches reviewers at explicit review moments (first open, author "ready for re-review"), not on every push. On re-run, pass each reviewer `last-approved-sha..current-head` as the incremental range; the prior approval stands for everything up to `<last-approved>`.
+3. **Resolve the verdict yourself, against the AC.** The organiser resolves reviewer consensus into approve / request-changes / comment. This is mine to call as advisor: do NOT ask permission to fire the bot; asking defeats the automation. Pause only if the verdict itself is genuinely undecided. Resolve it from the inline PR threads, the durable record, not from the agents' direct reports: `gh api .../pulls/<n>/comments` and read the live threads. The report-back is for what a reviewer cannot anchor inline (off-diff findings, confidence, the failure modes it cleared).
 
-## Brief every reviewer the same line
+   **Before approving, check the PR meets its issue's AC**, not merely that its commits are clean. A bug found later that means the PR can't meet its own AC is not a follow-up ticket; it is unfinished work that folds into the same PR, and it means an earlier APPROVE was premature. An approve means the change was verified against its AC; replying to comments alone does not earn it. A reviewer who approves while flagging a global-state or production-vs-test caveat is reporting a block-worthy concern; weigh it as one.
 
-Every reviewer dispatch brief restates one line: inline comments only, never the main thread, report your verdict to me. Reviewers apply no verdict label; they report their verdict to Gru and post findings inline.
+4. **Fire the bot review.** `gh workflow run bot-review.yml -f pr=N -f event=APPROVE|REQUEST_CHANGES|COMMENT -f body="..."`. It posts as a distinct bot identity, so its APPROVE is a real approving review, not self-approval (the bot did not author the PR). Trigger is `workflow_dispatch` only; CI never runs Claude on `pull_request` events (injection surface). The body highlights the individual reviewer findings (attributed, mine if any), not an aggregated synthesis paragraph; verdict on its own line; under 400 chars; omit any line that has nothing. The body template lives in [`reviewers`](../reviewers/SKILL.md), "Synthesis body (organiser)".
 
-## Fire the synthesis verdict
+5. **Push and move on; CI calls back only on failure.** After a push, attention goes to the next piece of work. CI runs itself, and the merge queue plus the maintainer own the path to green; a passing or pending run is theirs. A FAILURE is the one CI event that is mine, acted on when it lands. Read CI state once when a claim needs grounding, then return to the work. No watching a pending run.
 
-On every review round Gru posts one synthesis review via the `bot-review` workflow:
+6. **The decision is Josh's.** He merges if he agrees with the bot's verdict. The bot APPROVE is not the approval that ships code; the merge click is. No auto-merge.
 
-```bash
-gh workflow run bot-review.yml -f pr=N -f event=APPROVE|REQUEST_CHANGES -f body="..."
-```
+## Re-battle scope
 
-The synthesis keys on SEVERITY, not finding-count: REQUEST_CHANGES only if some reviewer raised an unresolved `issue:`; APPROVE otherwise, even when reviewers posted `nitpick:`/`suggestion:`/`question:` inlines (those are folded or ignored by the author, never block, never force a re-battle). A pass whose only findings are non-blocking is an approve, not a block-fix-reapprove cycle.
+Re-battle only when a push materially changes scope (a real feature change, not a mechanical fix or a type narrow), or when Josh asks. A converged PR with only mechanical follow-ups is a silent pass, not another round.
 
-The body template, its 300-char cap, and the clean-pass / block / re-review shapes live in [`reviewers`](../reviewers/SKILL.md), "Synthesis body (organiser)". Verify the inline findings landed before posting the synthesis verdict. The verdict does not gate merge: required checks are Tests and Lint, and the maintainer's manual merge is the approval; the bot review is the attributed agent verdict, not a required check.
+When you do re-battle, scope it to the NEW change, not the whole PR: choose reviewers by what the new commit touches (drop lenses whose surface didn't change, e.g. save-format-warden when no persisted shape moved; add one if the new commit enters its lane), and point each at the new commit's diff range (`git diff <prev>..<new>`), not `main...HEAD`. Re-reviewing already-cleared parts is the same churn. A push that invalidates the prior round's synthesis verdict earns a fresh review.
+
+## Design and docs PRs battle on a different axis
+
+A code PR battles its lanes (code-quality, signals-lifecycle, save-format, etc.). A design PR (a `.md` that argues a design, not just prose) battles the IDEA: devils-advocate scoped to the design's claims is a REQUIRED lane, not the optional fresh-eyes pass, alongside docs-and-writing (STYLE) and repetition-reviewer (cross-doc dup). That battle is GENERATIVE, not a confidence pass: the right outcome is often that the design CHANGES between rounds. Re-battle a design PR after a substantive rewrite (discovery-rewrites-the-spec), not after a typo fix. The severity rule still governs the verdict: only an `issue:` blocks; `nitpick:`/`suggestion:` ride along and never force a re-battle.
 
 ## Consensus on disagreement
 
-When two minions reach opposite conclusions on the same evidence (reviewer approves while battler blocks, two reviewers split, etc.), don't pick a side. Dispatch two more independent agents on the same question, briefed not to read each other's reports. Whichever side reaches three votes wins. Surface the consensus to Josh with the evidence each agent cited.
-
-If consensus is still split 2-2, that's a sign the question itself isn't decidable from the evidence at hand; flag for Josh and don't merge.
+When two minions reach opposite conclusions on the same evidence (reviewer approves while battler blocks, two reviewers split), don't pick a side. Dispatch two more independent agents on the same question, briefed not to read each other's reports. Whichever side reaches three votes wins. Surface the consensus to Josh with the evidence each agent cited. If it stays split 2-2, the question isn't decidable from the evidence at hand; flag for Josh and don't merge.

--- a/.claude/skills/battle/SKILL.md
+++ b/.claude/skills/battle/SKILL.md
@@ -13,4 +13,4 @@ The shape, in brief:
 - The floor is one independent reviewer on every PR. Reading my own diff is not a review; "yours to merge" off my own reading alone is the tell.
 - The loop: ground-read review state, dispatch reviewers scoped to the diff, converge without churn, resolve the verdict against the issue's AC from the inline threads, fire the bot review, then push and move on (CI calls back only on failure). Josh's merge is the gate.
 
-Read the memory branch for any of this in full.
+Read the memory branch for the full process.

--- a/.claude/skills/battle/SKILL.md
+++ b/.claude/skills/battle/SKILL.md
@@ -1,46 +1,16 @@
 ---
 name: battle
-description: Dispatcher-side rules for battling a challenge: the end-to-end review loop. Ground-read review state, dispatch at least one independent reviewer (more by scope), converge without churn, resolve the verdict against the issue's AC, fire the bot review, then push and move on. Read when battling any PR. The owning memory is feedback_battle_review_process; the challenge body shape is the `pr` skill; the per-reviewer contract is the `reviewers` skill.
+description: Dispatcher-side entry to battling a challenge: the review loop, owned by the memory branch feedback_battle_review_process. Read when battling any PR. The challenge body shape is the `pr` skill; the per-reviewer contract is the `reviewers` skill.
 ---
 
 # Battling a challenge
 
-The organiser's side of a review battle. A *challenge* is the PR (see [`pr`](../pr/SKILL.md) for its body shape); a *battle* is the review run against it. This skill is what Gru reads to run that pass; it renders the memory branch [[feedback_battle_review_process]] under [[trunk_dev_cycle]], which is the authority. The reviewer agent's own contract (posture, finding form, inline discipline) lives in [`reviewers`](../reviewers/SKILL.md); brief each reviewer to read it.
+A *challenge* is the PR (see [`pr`](../pr/SKILL.md)); a *battle* is the review run against it. The loop is owned by the memory branch [[feedback_battle_review_process]] under [[trunk_dev_cycle]]: descend there for the full process, and into its leaves for depth. The reviewer agent's own contract lives in [`reviewers`](../reviewers/SKILL.md).
 
-A battle is a confidence pass over a shipped challenge, not an exhaustive audit. It is minion work, dispatched by default rather than run in-thread. The depth scales with the diff, but the floor never drops to zero.
+The shape, in brief:
 
-## The floor: one independent reviewer, always
+- A battle is a confidence pass over a shipped challenge, dispatched to minions, not an in-thread audit.
+- The floor is one independent reviewer on every PR. Reading my own diff is not a review; "yours to merge" off my own reading alone is the tell.
+- The loop: ground-read review state, dispatch reviewers scoped to the diff, converge without churn, resolve the verdict against the issue's AC from the inline threads, fire the bot review, then push and move on (CI calls back only on failure). Josh's merge is the gate.
 
-Every PR gets at least one independent reviewer before it is reviewed. "No fan-out" and "spot-check" mean one reviewer at the right depth instead of a full panel, not zero reviewers. Reading my own diff and finding it correct is not a review: I wrote it, so I find it coherent, which is [[feedback_self_judgment_is_coherence_not_accuracy]] applied to my own change. The dispatcher reading the diff first is due diligence before handoff, not the review.
-
-The tell, and it fires often: I am about to tell Josh a PR is "ready" or "yours to merge" having only read it myself. That PR has had zero reviews. Dispatch one reviewer first. Pick the single lens the diff calls for (devils-advocate for a rule-bearing doc, code-quality for a small code change, docs-and-writing for prose) and dispatch it. Fan to several specialists only when the diff's scope justifies it; the minimum is one, not zero.
-
-## The loop
-
-1. **Ground-read before dispatch, review state included.** The pre-battle `gh` read covers `state`, `mergeable`, HEAD, checks AND `reviewDecision` plus the per-PR reviews (`gh api .../pulls/<n>/reviews`), not just CI. Skipping the reviews means battling a PR that may already carry an approval; stale approvals do not auto-dismiss, so a PR can show an active bot APPROVE on an old SHA. Know the review state before re-treading it. Then dispatch reviewers scoped to the diff's lanes, always `run_in_background: true`, against the live HEAD. The path → specialist map is in [`reviewers`](../reviewers/SKILL.md). Findings go inline.
-
-2. **Converge, do not churn.** After a round or two with findings addressed and CI green, another battle surfaces nothing new; it just spins. Do not re-battle a converged PR; that is churn dressed as diligence. Once converged, the bottleneck is a decision, not more review signal.
-
-3. **Resolve the verdict yourself, against the AC.** The organiser resolves reviewer consensus into approve / request-changes / comment. This is mine to call as advisor: do NOT ask permission to fire the bot; asking defeats the automation. Pause only if the verdict itself is genuinely undecided. Resolve it from the inline PR threads, the durable record, not from the agents' direct reports: `gh api .../pulls/<n>/comments` and read the live threads. The report-back is for what a reviewer cannot anchor inline (off-diff findings, confidence, the failure modes it cleared).
-
-   **Before approving, check the PR meets its issue's AC**, not merely that its commits are clean. A bug found later that means the PR can't meet its own AC is not a follow-up ticket; it is unfinished work that folds into the same PR, and it means an earlier APPROVE was premature. An approve means the change was verified against its AC; replying to comments alone does not earn it. A reviewer who approves while flagging a global-state or production-vs-test caveat is reporting a block-worthy concern; weigh it as one.
-
-4. **Fire the bot review.** `gh workflow run bot-review.yml -f pr=N -f event=APPROVE|REQUEST_CHANGES|COMMENT -f body="..."`. It posts as a distinct bot identity, so its APPROVE is a real approving review, not self-approval (the bot did not author the PR). Trigger is `workflow_dispatch` only; CI never runs Claude on `pull_request` events (injection surface). The body highlights the individual reviewer findings (attributed, mine if any), not an aggregated synthesis paragraph; verdict on its own line; under 400 chars; omit any line that has nothing. The body template lives in [`reviewers`](../reviewers/SKILL.md), "Synthesis body (organiser)".
-
-5. **Push and move on; CI calls back only on failure.** After a push, attention goes to the next piece of work. CI runs itself, and the merge queue plus the maintainer own the path to green; a passing or pending run is theirs. A FAILURE is the one CI event that is mine, acted on when it lands. Read CI state once when a claim needs grounding, then return to the work. No watching a pending run.
-
-6. **The decision is Josh's.** He merges if he agrees with the bot's verdict. The bot APPROVE is not the approval that ships code; the merge click is. No auto-merge.
-
-## Re-battle scope
-
-Re-battle only when a push materially changes scope (a real feature change, not a mechanical fix or a type narrow), or when Josh asks. A converged PR with only mechanical follow-ups is a silent pass, not another round.
-
-When you do re-battle, scope it to the NEW change, not the whole PR: choose reviewers by what the new commit touches (drop lenses whose surface didn't change, e.g. save-format-warden when no persisted shape moved; add one if the new commit enters its lane), and point each at the new commit's diff range (`git diff <prev>..<new>`), not `main...HEAD`. Re-reviewing already-cleared parts is the same churn. A push that invalidates the prior round's synthesis verdict earns a fresh review.
-
-## Design and docs PRs battle on a different axis
-
-A code PR battles its lanes (code-quality, signals-lifecycle, save-format, etc.). A design PR (a `.md` that argues a design, not just prose) battles the IDEA: devils-advocate scoped to the design's claims is a REQUIRED lane, not the optional fresh-eyes pass, alongside docs-and-writing (STYLE) and repetition-reviewer (cross-doc dup). That battle is GENERATIVE, not a confidence pass: the right outcome is often that the design CHANGES between rounds. Re-battle a design PR after a substantive rewrite (discovery-rewrites-the-spec), not after a typo fix. The severity rule still governs the verdict: only an `issue:` blocks; `nitpick:`/`suggestion:` ride along and never force a re-battle.
-
-## Consensus on disagreement
-
-When two minions reach opposite conclusions on the same evidence (reviewer approves while battler blocks, two reviewers split), don't pick a side. Dispatch two more independent agents on the same question, briefed not to read each other's reports. Whichever side reaches three votes wins. Surface the consensus to Josh with the evidence each agent cited. If it stays split 2-2, the question isn't decidable from the evidence at hand; flag for Josh and don't merge.
+Read the memory branch for any of this in full.

--- a/.claude/skills/battle/SKILL.md
+++ b/.claude/skills/battle/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: battle
+description: Dispatcher-side rules for running a reviewer battle against a challenge: when it fires, scope-filtering reviewers by changed path, the design-PR required lane, one-round discipline, consensus on disagreement, and firing the synthesis verdict. Read when Josh asks for a battle. The challenge being battled is the `pr` skill; the per-reviewer contract is the `reviewers` skill.
+---
+
+# Running a battle
+
+The organiser's side of a reviewer battle: the adversarial review pass against an open challenge. A *challenge* is the PR (see [`pr`](../pr/SKILL.md) for its body shape); a *battle* is the review run against it. This skill is what Gru reads to run that pass. The reviewer agent's own contract (posture, verdict shape, inline-finding discipline) lives in [`reviewers`](../reviewers/SKILL.md); brief each reviewer to read it. The memory branch for the whole loop is [[feedback_battle_review_process]] under [[trunk_dev_cycle]].
+
+## When a battle fires
+
+The default is no reviewer fan-out. The dispatcher spot-checks every diff (read it, run the suite, verify the behaviour holds) and that is the review for most increments: docs, renames, mechanical changes, small fixes. A big PR is one review surface, spot-checked once at the right depth, never re-battled per commit.
+
+A reviewer battle runs only when Josh asks for one. When he does: scope-filter the diff by changed path and fan only the matching specialists (code-quality, gdscript-conventions, test-coverage on a GDScript diff; domain reviewers on the files they own). The full path → specialist map and the verdict contract live in [`reviewers`](../reviewers/SKILL.md). Battlers (devils-advocate, integration-scenario-author) fire alongside only when the battle is requested. Devils-advocate has Bash, so it posts its findings as inline review comments like any reviewer; brief it to do so, and do not tell it to reason from the diff text alone.
+
+## Design-PR battles are generative
+
+On a **design or spec doc** (a `designs/**` change that argues a design, not just prose), devils-advocate is a REQUIRED lane, not the optional fresh-eyes pass: fan it on the design's claims alongside docs-and-writing and repetition-reviewer. That battle is GENERATIVE, the right outcome is often that the design changes between rounds, so re-battle a design PR after a substantive rewrite (not after a typo fix). See [[feedback_battle_review_process]], the design-PR clause.
+
+## One round, no stacked re-battles
+
+Within a requested battle, run one round. Re-check a blocked finding with the one reviewer who raised it on the incremental, not a fresh fan-out; a clean incremental is a silent approve. Do not stack re-battles.
+
+The dispatcher dispatches reviewers at explicit review moments (first open, author "ready for re-review"), not on every push. On re-run, pass each reviewer `last-approved-sha..current-head` as the incremental range; the prior approval stands for everything up to `<last-approved>`.
+
+## Brief every reviewer the same line
+
+Every reviewer dispatch brief restates one line: inline comments only, never the main thread, report your verdict to me. Reviewers apply no verdict label; they report their verdict to Gru and post findings inline.
+
+## Fire the synthesis verdict
+
+On every review round Gru posts one synthesis review via the `bot-review` workflow:
+
+```bash
+gh workflow run bot-review.yml -f pr=N -f event=APPROVE|REQUEST_CHANGES -f body="..."
+```
+
+The synthesis keys on SEVERITY, not finding-count: REQUEST_CHANGES only if some reviewer raised an unresolved `issue:`; APPROVE otherwise, even when reviewers posted `nitpick:`/`suggestion:`/`question:` inlines (those are folded or ignored by the author, never block, never force a re-battle). A pass whose only findings are non-blocking is an approve, not a block-fix-reapprove cycle.
+
+The body template, its 300-char cap, and the clean-pass / block / re-review shapes live in [`reviewers`](../reviewers/SKILL.md), "Synthesis body (organiser)". Verify the inline findings landed before posting the synthesis verdict. The verdict does not gate merge: required checks are Tests and Lint, and the maintainer's manual merge is the approval; the bot review is the attributed agent verdict, not a required check.
+
+## Consensus on disagreement
+
+When two minions reach opposite conclusions on the same evidence (reviewer approves while battler blocks, two reviewers split, etc.), don't pick a side. Dispatch two more independent agents on the same question, briefed not to read each other's reports. Whichever side reaches three votes wins. Surface the consensus to Josh with the evidence each agent cited.
+
+If consensus is still split 2-2, that's a sign the question itself isn't decidable from the evidence at hand; flag for Josh and don't merge.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -65,7 +65,7 @@ Every code-writing minion runs this sequence once dispatched. Brief them on it i
 2. **Cycle placement.** If the claimed ticket has no cycle, move it into the active one: `mcp__linear__list_cycles(teamId, type: "current")` then `mcp__linear__save_issue(id, cycleId)`. Skip if no active cycle.
 3. **Log progress in Linear.** Significant moments (claim, blocker, ready-for-review) post as a Linear comment on the ticket, not into a shared file. The git log carries the rest.
 4. **Sync before opening and before every later push.** `git fetch origin main && git merge origin/main`, resolve, re-run `./scripts/ci/run_gut.sh`, push. Repeat any time work resumes or before asking Josh to merge. `git rev-list --count HEAD..origin/main` reads "behind by N".
-5. **Open the challenge.** After `gh pr create`, do not enable auto-merge and do not apply approval labels; the maintainer merges by hand. Review is a dispatcher spot-check by default (read the diff, run the suite, verify the behaviour); do NOT fan reviewers automatically. A reviewer battle fires only when Josh asks for one. When he does, fan the scope-matched specialists by changed path (mapping in `.claude/skills/reviewers/SKILL.md`).
+5. **Open the challenge.** After `gh pr create`, do not enable auto-merge and do not apply approval labels; the maintainer merges by hand. Review is a dispatcher spot-check by default (read the diff, run the suite, verify the behaviour); do NOT fan reviewers automatically. A reviewer battle fires only when Josh asks for one; when he does, run it per [`battle`](../battle/SKILL.md).
 6. **Hand off.** Re-sync against `main`, then report the challenge to Josh. Don't flag comments in chat; the challenge is the source of truth.
 7. **Block or spin.** Loop on the same issue twice, then escalate per the rule below. No third silent variant.
 
@@ -79,7 +79,7 @@ Every code-writing minion runs this sequence once dispatched. Brief them on it i
 - **Merge queue serialises `main`.** "Merge when ready" pulls the challenge into a `merge_group` ref, re-runs lint and tests against `main + challenge`, then fast-forwards `main`. The pre-challenge `git merge origin/main` still matters: the queue catches mechanical staleness, not semantic conflicts.
 - **Godot tool discipline.** Prefer GodotIQ MCP tools over raw file ops. Never delete-and-rebuild scenes; `node_ops` plus `save_scene` for `.tscn`. Godot 4 quirks live in `ai/godot-quirks.md`.
 
-Commit-side rules (sign-off, no-amend, no-force, fresh branch after merge, ggut after every change, hooks fire on commit) live in `.claude/skills/commits/SKILL.md`. Reviewer-side rules (verdict shape, inline-finding shape, fan-out by path) live in `.claude/skills/reviewers/SKILL.md`.
+Commit-side rules (sign-off, no-amend, no-force, fresh branch after merge, ggut after every change, hooks fire on commit) live in `.claude/skills/commits/SKILL.md`. Running a requested reviewer battle lives in [`battle`](../battle/SKILL.md); the per-reviewer contract (verdict shape, inline-finding shape, fan-out by path) lives in `.claude/skills/reviewers/SKILL.md`.
 
 ## Godot session tiers
 
@@ -158,19 +158,7 @@ If the fan would require any file to appear in two slices, the work is not fan-s
 
 The default is no reviewer fan-out. The dispatcher spot-checks every diff (read it, run the suite, verify the behaviour holds) and that is the review for most increments: docs, renames, mechanical changes, small fixes. A big PR is one review surface, spot-checked once at the right depth, never re-battled per commit.
 
-A reviewer battle runs only when Josh asks for one. When he does: scope-filter the diff by changed path and fan only the matching specialists (code-quality, gdscript-conventions, test-coverage on a GDScript diff; domain reviewers on the files they own). The full path → specialist map and the verdict contract live in `.claude/skills/reviewers/SKILL.md`. Battlers (devils-advocate, integration-scenario-author) fire alongside only when the battle is requested. Devils-advocate has Bash, so it posts its findings as inline review comments like any reviewer; brief it to do so, and do not tell it to reason from the diff text alone.
-
-On a **design or spec doc** (a `designs/**` change that argues a design, not just prose), devils-advocate is a REQUIRED lane, not the optional fresh-eyes pass: fan it on the design's claims alongside docs-and-writing and repetition-reviewer. That battle is GENERATIVE, the right outcome is often that the design changes between rounds, so re-battle a design PR after a substantive rewrite (not after a typo fix). See [[feedback_battle_review_process]], the design-PR clause.
-
-Within a requested battle, run one round. Re-check a blocked finding with the one reviewer who raised it on the incremental, not a fresh fan-out; a clean incremental is a silent approve. Do not stack re-battles.
-
-Reviewers apply no verdict label; they report their verdict to Gru and post findings inline. On every review round Gru posts one synthesis review via the `bot-review` workflow (`gh workflow run bot-review.yml -f pr=N -f event=APPROVE|REQUEST_CHANGES`). The synthesis keys on SEVERITY, not finding-count: REQUEST_CHANGES only if some reviewer raised an unresolved `issue:`; APPROVE otherwise, even when reviewers posted `nitpick:`/`suggestion:`/`question:` inlines (those are folded or ignored by the author, never block, never force a re-battle). A pass whose only findings are non-blocking is an approve, not a block-fix-reapprove cycle. Every reviewer dispatch brief restates one line, inline comments only, never the main thread, report your verdict to me. Gru verifies the inline findings landed before posting the synthesis verdict. The verdict does not gate merge: required checks are Tests and Lint, and the maintainer's manual merge is the approval; the bot review is the attributed agent verdict, not a required check.
-
-## Consensus on disagreement
-
-When two minions reach opposite conclusions on the same evidence (reviewer approves while battler blocks, two reviewers split, etc.), don't pick a side. Dispatch two more independent agents on the same question, briefed not to read each other's reports. Whichever side reaches three votes wins. Surface the consensus to Josh with the evidence each agent cited.
-
-If consensus is still split 2-2, that's a sign the question itself isn't decidable from the evidence at hand; flag for Josh and don't merge.
+A reviewer battle runs only when Josh asks for one. Running that pass (scope-filtering reviewers by path, the design-PR required lane, one-round discipline, consensus on disagreement, firing the synthesis verdict) lives in [`battle`](../battle/SKILL.md). The per-reviewer contract is [`reviewers`](../reviewers/SKILL.md); the challenge being battled is [`pr`](../pr/SKILL.md).
 
 ## Spike rule
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -20,3 +20,5 @@ References: bare GitHub `#N`, no closing verb, no Linear `SH-N` on any public su
 Aliases: spell out Josh's zsh aliases on every public surface (body, commit, repo docs): `./scripts/ci/run_gut.sh` not `ggut`, `git checkout -b` not `gcb`. A contributor or CI runner does not have them.
 
 Secrets: if the diff adds a `pull_request*` (or post-PR `workflow_run`) workflow referencing `${{ secrets.* }}` beyond `GITHUB_TOKEN`, stop and flag it in the body and to Josh. Contributor PRs run workflows automatically, so a secret on that path is exfiltratable.
+
+The challenge (PR) written here is what a reviewer battle runs against: running that pass lives in [`battle`](../battle/SKILL.md). The memory branch for challenge-description discipline is [[feedback_pr_description_brevity]] under [[trunk_dev_cycle]].

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -21,4 +21,4 @@ Aliases: spell out Josh's zsh aliases on every public surface (body, commit, rep
 
 Secrets: if the diff adds a `pull_request*` (or post-PR `workflow_run`) workflow referencing `${{ secrets.* }}` beyond `GITHUB_TOKEN`, stop and flag it in the body and to Josh. Contributor PRs run workflows automatically, so a secret on that path is exfiltratable.
 
-The challenge (PR) written here is what a reviewer battle runs against: running that pass lives in [`battle`](../battle/SKILL.md). The memory branch for challenge-description discipline is [[feedback_pr_description_brevity]] under [[trunk_dev_cycle]].
+The challenge this skill describes is what a reviewer battle runs against: running that pass lives in [`battle`](../battle/SKILL.md). The memory branch for challenge-description discipline is [[feedback_pr_description_brevity]] under [[trunk_dev_cycle]].


### PR DESCRIPTION
The dispatch skill carried two jobs: the minion-dispatch flow and the reviewer-battle loop. This pulls the battle loop into a new dispatcher-side skill (battle), sibling to dispatch, leaving the agent-facing reviewers skill untouched.

The battle skill is written as the faithful render of its owning memory branch (feedback_battle_review_process under trunk_dev_cycle), not lifted from the dispatch prose: the six-step loop (ground-read review state, converge without churn, resolve the verdict against the issue's AC, fire the bot review, push and move on, Josh decides), the floor of at least one independent reviewer on every PR, synthesising from the inline threads, re-battle scoping, and the generative design-PR axis. Battle and pr cross-link, and both point at their memory-forest branch so reading the skill routes into the right branch.