### PR TITLE
docs: spike decides 1080p base with native 4K via canvas_items

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,4 @@
 # common-typo corrections only.
 builtin = clear,rare,informal,usage,code,names
 skip = ./.git,./.godot,./addons,./builds,./exports,./logs,./designs/art/mood-boards,./designs/private,./scripts/dev,*.uid,*.import,*.tres,*.tscn,*.svg,*.png,*.jpg,*.jpeg,*.webp,*.ogg,*.wav,*.mp3,*.ttf,*.otf
-ignore-words-list = thew,wit,sme,kinda,sting,singed,browseable,followings,artic,lod,demagog,thq,dota,pre-empt,pre-empting,pre-empts,master,damon,tim,airscape,devault,bloc,ons,obscur,cant,gonna,wen,sanity-check,pullrequest,theses,miniscule
+ignore-words-list = thew,wit,sme,kinda,sting,singed,browseable,followings,artic,lod,demagog,thq,dota,pre-empt,pre-empting,pre-empts,master,masters,damon,tim,airscape,devault,bloc,ons,obscur,cant,gonna,wen,sanity-check,pullrequest,theses,miniscule

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -126,9 +126,15 @@ degrades. One master therefore covers the whole range, with no second authored t
 maintain. The master pixel size is the level-of-detail decision's to set, since it owns
 how big Sam is on screen.
 
-The stretch config (`canvas_items` at a 1920x1080 base, already set) renders the scene at
-the physical window resolution, so the master draws at or above 1:1 on a matching display
-and the engine downscales the rest. The master is always shown at or below its authored
+Two layers compose here. The stretch config (`canvas_items` at a 1920x1080 base, already
+set) is the frame layer: it treats 1080p as a logical coordinate space and rasterizes the
+scene at the physical display resolution, so on a 4K display the scale is 2x and a sprite
+sized to 100 logical pixels is drawn into 200 physical pixels. The texture layer then fills
+those physical pixels from the sprite's source. Because `canvas_items` rasterizes at the
+physical count (unlike `viewport` mode, which renders into a base-size buffer and scales the
+whole frame, capping every texture at 1080p), a 4K master genuinely fills a 4K display, and
+the master resolution is what bounds sharpness. So the master draws at or above 1:1 on a
+matching display and the engine downscales the rest. The master is always shown at or below its authored
 size, which is minification, the case mipmaps exist for: a mipmap chain is a set of
 pre-downsampled copies, so a reduction like 4K to 1440p samples a clean smaller copy
 instead of aliasing the full texture. Mipmaps cost about a third more memory per frame, so

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -115,49 +115,18 @@ convention. Individual images are the most swap-friendly and artist-friendly pat
 AnimatedSprite2D; a spritesheet would suit AnimationPlayer's region keying, which is
 not the chosen node.
 
-## Target resolution: one master, downscale only
+## Target resolution
 
-The game targets 1080p and 4K. Each frame is authored once at a single master sized to
-the largest Sam ever appears on screen, his fixed maximum at 4K, and every display
-downscales from that master. Upscaling hand-drawn art reads blocky, so the master is the
-ceiling nothing climbs above; a 4K display draws it at or near 1:1, and 1440p, 1080p, and
-any smaller window take it down. Downscaling holds detail; only upscaling invents it and
-degrades. One master therefore covers the whole range, with no second authored tier to
-maintain. The master pixel size is the level-of-detail decision's to set, since it owns
-how big Sam is on screen.
+Resolution and authoring density follow the art pipeline (`designs/art/tech-pipeline.md`):
+1080p logical base under `canvas_items`, art authored above target (the @2x default) so the
+downscale path carries the weight, with per-class import settings for filter and mipmaps.
+That doc is the authority; this spike does not re-decide it.
 
-Two layers compose here. The stretch config (`canvas_items` at a 1920x1080 base, already
-set) is the frame layer: it treats 1080p as a logical coordinate space and rasterizes the
-scene at the physical display resolution, so on a 4K display the scale is 2x and a sprite
-sized to 100 logical pixels is drawn into 200 physical pixels. The texture layer then fills
-those physical pixels from the sprite's source. Because `canvas_items` rasterizes at the
-physical count (unlike `viewport` mode, which renders into a base-size buffer and scales the
-whole frame, capping every texture at 1080p), a 4K master genuinely fills a 4K display, and
-the master resolution is what bounds sharpness. So the master draws at or above 1:1 on a
-matching display and the engine downscales the rest. The master is always shown at or below its authored
-size, which is minification, the case mipmaps exist for: a mipmap chain is a set of
-pre-downsampled copies, so a reduction like 4K to 1440p samples a clean smaller copy
-instead of aliasing the full texture. Mipmaps cost about a third more memory per frame, so
-they are the expected setting here but earn it only if the downscaled art actually aliases
-without them, which is a check against real frames once art exists, not a settled given.
-The `window/stretch/aspect` setting is `expand` so non-16:9 displays extend the canvas
-rather than distort; it is unset today and this establishes it.
-([Godot multiple-resolutions docs](https://docs.godotengine.org/en/stable/tutorials/rendering/multiple_resolutions.html).)
-
-The scaffold stays size-agnostic regardless: a swappable `SpriteFrames` with no hardcoded
-frame dimensions, so the master frames drop in as a resource. A single master per frame is
-a large texture, which for a one-character paddle is a negligible cost. Two future
-conditions change the rule, and neither is built now. If texture memory ever bites at scale
-(many characters, many frames), the levers in order are atlas packing first (designed for
-2D sprite animation, no quality loss), then downscaling the source masters to the largest
-size any display needs, then per-display tiers. VRAM block compression is a last resort, not
-an early lever: Godot's docs steer it to 3D and it adds visible block artifacts on smooth
-painterly gradients, so it is reached for only if nothing safer suffices and only after
-testing it on the worst frames. If
-the camera ever zooms in past the master's on-screen size, runtime level-of-detail is added
-then, since zoom is the only thing that would demand a larger source than the master holds.
-The font-text blur under `canvas_items` on resize (Godot #86563) is a separate UI concern
-for whenever 4K text crispness is required.
+What the scaffold owes that rule is to stay size-agnostic: a swappable `SpriteFrames` with
+no hardcoded frame dimensions, so a frame authored at any density drops in as a resource.
+The one paddle-specific note for later: if the camera ever zooms in past a frame's authored
+size, runtime level-of-detail is added then, since zoom is the only thing that would demand
+a source larger than the authored frame holds.
 
 ## The seam, today
 

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -128,11 +128,12 @@ how big Sam is on screen.
 
 The stretch config (`canvas_items` at a 1920x1080 base, already set) renders the scene at
 the physical window resolution, so the master draws at or above 1:1 on a matching display
-and the engine downscales the rest. Mipmaps are the mechanism: a mipmap chain is a set of
-pre-downsampled copies, so a fractional reduction like 4K to 1440p samples a clean smaller
-copy rather than aliasing the full texture. The texture filter is `linear_mipmap` and the
-import pipeline enables mipmaps on every sprite (sources today import with
-`mipmaps/generate=false`, so this is a precondition for any real art, not an afterthought).
+and the engine downscales the rest. The master is always shown at or below its authored
+size, which is minification, the case mipmaps exist for: a mipmap chain is a set of
+pre-downsampled copies, so a reduction like 4K to 1440p samples a clean smaller copy
+instead of aliasing the full texture. Mipmaps cost about a third more memory per frame, so
+they are the expected setting here but earn it only if the downscaled art actually aliases
+without them, which is a check against real frames once art exists, not a settled given.
 The `window/stretch/aspect` setting is `expand` so non-16:9 displays extend the canvas
 rather than distort; it is unset today and this establishes it.
 ([Godot multiple-resolutions docs](https://docs.godotengine.org/en/stable/tutorials/rendering/multiple_resolutions.html).)
@@ -141,8 +142,12 @@ The scaffold stays size-agnostic regardless: a swappable `SpriteFrames` with no 
 frame dimensions, so the master frames drop in as a resource. A single master per frame is
 a large texture, which for a one-character paddle is a negligible cost. Two future
 conditions change the rule, and neither is built now. If texture memory ever bites at scale
-(many characters, many frames), the levers in order are mipmaps already present, then GPU
-texture compression, then atlasing, then per-display tiers, reached for when measured. If
+(many characters, many frames), the levers in order are atlas packing first (designed for
+2D sprite animation, no quality loss), then downscaling the source masters to the largest
+size any display needs, then per-display tiers. VRAM block compression is a last resort, not
+an early lever: Godot's docs steer it to 3D and it adds visible block artifacts on smooth
+painterly gradients, so it is reached for only if nothing safer suffices and only after
+testing it on the worst frames. If
 the camera ever zooms in past the master's on-screen size, runtime level-of-detail is added
 then, since zoom is the only thing that would demand a larger source than the master holds.
 The font-text blur under `canvas_items` on resize (Godot #86563) is a separate UI concern

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -117,26 +117,31 @@ not the chosen node.
 
 ## Target resolution: two source tiers, downscale only
 
-The game targets 1080p and 4K. Sam's art is authored at both: a 1080p source set and a
-4K source set. Upscaling this hand-drawn art reads blocky, so the game never enlarges a
-source past its authored size. Every display between and below the two tiers downscales
-from the nearest higher source, which stays clean; only upscaling degrades it. Two
-authored tiers therefore cover the whole range.
+The game targets 1080p and 4K, so art is authored at both: a 1080p source set and a 4K
+source set. Upscaling hand-drawn art reads blocky, so the rule is that a source is never
+enlarged past its authored size. Every other resolution downscales from the nearest
+higher tier: a 1440p or 1080p display takes the 4K source down, a sub-1080p window takes
+the 1080p source down. Downscaling holds detail; only upscaling invents it and degrades.
+Two authored tiers therefore cover the whole range by downscale, with 4K as the ceiling
+nothing climbs above.
 
 The stretch config (`canvas_items` at a 1920x1080 base, already set) renders the scene
 at the physical window resolution, so the source that matches or exceeds the display
-draws at or above 1:1 and the engine downscales the rest. Texture filter is
-`linear_mipmap` with mipmaps enabled on the sprite imports (today all import with
-`mipmaps/generate=false`, so this is real import work), which is what makes the
-downscaled sizes clean. Set `window/stretch/aspect` to `expand` so non-16:9 displays
-extend the canvas rather than distort, since it is currently unset.
+draws at or above 1:1 and the engine downscales the rest. The texture filter is
+`linear_mipmap`, and the import pipeline enables mipmaps on every sprite (sources today
+import with `mipmaps/generate=false`): the mipmap chain is what keeps a fractional
+downscale, like 4K to 1440p, clean rather than aliased, so it is a precondition for any
+real art tier, not an afterthought. The `window/stretch/aspect` setting is `expand` so
+non-16:9 displays extend the canvas rather than distort; it is unset today and this
+establishes it.
 ([Godot multiple-resolutions docs](https://docs.godotengine.org/en/stable/tutorials/rendering/multiple_resolutions.html).)
 
 This is the art-and-import shape, not a scaffold concern: the scaffold stays
 size-agnostic (a swappable `SpriteFrames`, no hardcoded frame dimensions), so a source
-tier drops in as a resource. Selecting which tier loads for the current display is its
-own work, tied to the resolution-settings spike and the level-of-detail decision, not
-this scaffold. The font-text blur under `canvas_items` on resize (Godot #86563) is a
+tier drops in as a resource. Loading the right tier for the current display is real work
+the scaffold does not do, so a real build needs that selection wired before it ships, or
+it loads one tier for every display and the foundation goes unused. That selection is its
+own follow-up, tied to the resolution-settings spike and the level-of-detail decision. The font-text blur under `canvas_items` on resize (Godot #86563) is a
 separate UI concern for whenever 4K text crispness is required.
 
 ## The seam, today

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -115,30 +115,29 @@ convention. Individual images are the most swap-friendly and artist-friendly pat
 AnimatedSprite2D; a spritesheet would suit AnimationPlayer's region keying, which is
 not the chosen node.
 
-## Target resolution: 1080p base, native 4K
+## Target resolution: two source tiers, downscale only
 
-The game targets 1080p as the base and must also render correctly at 4K. The project
-is already configured for this: `canvas_items` stretch at a 1920x1080 base viewport.
-Keep it. Sam's frames are authored at 1080p native and the scaffold hardcodes no frame
-size, so the engine handles 4K with no code or asset-swap work.
+The game targets 1080p and 4K. Sam's art is authored at both: a 1080p source set and a
+4K source set. Upscaling this hand-drawn art reads blocky, so the game never enlarges a
+source past its authored size. Every display between and below the two tiers downscales
+from the nearest higher source, which stays clean; only upscaling degrades it. Two
+authored tiers therefore cover the whole range.
 
-Under `canvas_items` the scene renders natively at the physical window resolution: 1:1
-on a 1080p display, a full 3840x2160 render on 4K with the 1080p sprite upscaled 2x by
-the GPU sampler. There is no viewport-upscale pass that blurs the whole framebuffer.
-For painterly hand-drawn art a 2x linear upscale reads as smooth, not blocky, so this
-is the right mode (it is `viewport` mode that suits pixel art and would soften this
-art). `canvas_items` is also the Godot 4.7+ default. Set the texture filter to
-`linear_mipmap` and enable mipmaps on the sprite imports, so any zoom-out and the 4K
-case stay clean. ([Godot multiple-resolutions docs](https://docs.godotengine.org/en/stable/tutorials/rendering/multiple_resolutions.html), [proposal #3939](https://github.com/godotengine/godot-proposals/issues/3939).)
+The stretch config (`canvas_items` at a 1920x1080 base, already set) renders the scene
+at the physical window resolution, so the source that matches or exceeds the display
+draws at or above 1:1 and the engine downscales the rest. Texture filter is
+`linear_mipmap` with mipmaps enabled on the sprite imports (today all import with
+`mipmaps/generate=false`, so this is real import work), which is what makes the
+downscaled sizes clean. Set `window/stretch/aspect` to `expand` so non-16:9 displays
+extend the canvas rather than distort, since it is currently unset.
+([Godot multiple-resolutions docs](https://docs.godotengine.org/en/stable/tutorials/rendering/multiple_resolutions.html).)
 
-No runtime resolution-tier asset swapping. Godot has no native mechanism for it and the
-linear upscale is visually acceptable, so a single 1080p frame set is the convention. The
-optional art-budget upgrade is to author at 2x and downscale on import (`scale` on the
-texture preset), giving 4K a 1:1 render at 4x the source pixels per frame; defer that to
-the art tickets, it is not a scaffold concern. Two follow-ups this surfaced, out of scope
-here: the resolution-and-refresh-rate settings screen (its own spike), and font-text blur
-under `canvas_items` on resize (Godot #86563), a separate UI concern if 4K text crispness
-becomes a requirement.
+This is the art-and-import shape, not a scaffold concern: the scaffold stays
+size-agnostic (a swappable `SpriteFrames`, no hardcoded frame dimensions), so a source
+tier drops in as a resource. Selecting which tier loads for the current display is its
+own work, tied to the resolution-settings spike and the level-of-detail decision, not
+this scaffold. The font-text blur under `canvas_items` on resize (Godot #86563) is a
+separate UI concern for whenever 4K text crispness is required.
 
 ## The seam, today
 

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -115,6 +115,31 @@ convention. Individual images are the most swap-friendly and artist-friendly pat
 AnimatedSprite2D; a spritesheet would suit AnimationPlayer's region keying, which is
 not the chosen node.
 
+## Target resolution: 1080p base, native 4K
+
+The game targets 1080p as the base and must also render correctly at 4K. The project
+is already configured for this: `canvas_items` stretch at a 1920x1080 base viewport.
+Keep it. Sam's frames are authored at 1080p native and the scaffold hardcodes no frame
+size, so the engine handles 4K with no code or asset-swap work.
+
+Under `canvas_items` the scene renders natively at the physical window resolution: 1:1
+on a 1080p display, a full 3840x2160 render on 4K with the 1080p sprite upscaled 2x by
+the GPU sampler. There is no viewport-upscale pass that blurs the whole framebuffer.
+For painterly hand-drawn art a 2x linear upscale reads as smooth, not blocky, so this
+is the right mode (it is `viewport` mode that suits pixel art and would soften this
+art). `canvas_items` is also the Godot 4.7+ default. Set the texture filter to
+`linear_mipmap` and enable mipmaps on the sprite imports, so any zoom-out and the 4K
+case stay clean. ([Godot multiple-resolutions docs](https://docs.godotengine.org/en/stable/tutorials/rendering/multiple_resolutions.html), [proposal #3939](https://github.com/godotengine/godot-proposals/issues/3939).)
+
+No runtime resolution-tier asset swapping. Godot has no native mechanism for it and the
+linear upscale is visually acceptable, so a single 1080p frame set is the convention. The
+optional art-budget upgrade is to author at 2x and downscale on import (`scale` on the
+texture preset), giving 4K a 1:1 render at 4x the source pixels per frame; defer that to
+the art tickets, it is not a scaffold concern. Two follow-ups this surfaced, out of scope
+here: the resolution-and-refresh-rate settings screen (its own spike), and font-text blur
+under `canvas_items` on resize (Godot #86563), a separate UI concern if 4K text crispness
+becomes a requirement.
+
 ## The seam, today
 
 Three paddle scenes, all 2D `CharacterBody2D`, share `paddle.gd`:

--- a/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
+++ b/designs/01-prototype/tech/2026-06-06-paddle-animation-collision-spike.md
@@ -115,34 +115,38 @@ convention. Individual images are the most swap-friendly and artist-friendly pat
 AnimatedSprite2D; a spritesheet would suit AnimationPlayer's region keying, which is
 not the chosen node.
 
-## Target resolution: two source tiers, downscale only
+## Target resolution: one master, downscale only
 
-The game targets 1080p and 4K, so art is authored at both: a 1080p source set and a 4K
-source set. Upscaling hand-drawn art reads blocky, so the rule is that a source is never
-enlarged past its authored size. Every other resolution downscales from the nearest
-higher tier: a 1440p or 1080p display takes the 4K source down, a sub-1080p window takes
-the 1080p source down. Downscaling holds detail; only upscaling invents it and degrades.
-Two authored tiers therefore cover the whole range by downscale, with 4K as the ceiling
-nothing climbs above.
+The game targets 1080p and 4K. Each frame is authored once at a single master sized to
+the largest Sam ever appears on screen, his fixed maximum at 4K, and every display
+downscales from that master. Upscaling hand-drawn art reads blocky, so the master is the
+ceiling nothing climbs above; a 4K display draws it at or near 1:1, and 1440p, 1080p, and
+any smaller window take it down. Downscaling holds detail; only upscaling invents it and
+degrades. One master therefore covers the whole range, with no second authored tier to
+maintain. The master pixel size is the level-of-detail decision's to set, since it owns
+how big Sam is on screen.
 
-The stretch config (`canvas_items` at a 1920x1080 base, already set) renders the scene
-at the physical window resolution, so the source that matches or exceeds the display
-draws at or above 1:1 and the engine downscales the rest. The texture filter is
-`linear_mipmap`, and the import pipeline enables mipmaps on every sprite (sources today
-import with `mipmaps/generate=false`): the mipmap chain is what keeps a fractional
-downscale, like 4K to 1440p, clean rather than aliased, so it is a precondition for any
-real art tier, not an afterthought. The `window/stretch/aspect` setting is `expand` so
-non-16:9 displays extend the canvas rather than distort; it is unset today and this
-establishes it.
+The stretch config (`canvas_items` at a 1920x1080 base, already set) renders the scene at
+the physical window resolution, so the master draws at or above 1:1 on a matching display
+and the engine downscales the rest. Mipmaps are the mechanism: a mipmap chain is a set of
+pre-downsampled copies, so a fractional reduction like 4K to 1440p samples a clean smaller
+copy rather than aliasing the full texture. The texture filter is `linear_mipmap` and the
+import pipeline enables mipmaps on every sprite (sources today import with
+`mipmaps/generate=false`, so this is a precondition for any real art, not an afterthought).
+The `window/stretch/aspect` setting is `expand` so non-16:9 displays extend the canvas
+rather than distort; it is unset today and this establishes it.
 ([Godot multiple-resolutions docs](https://docs.godotengine.org/en/stable/tutorials/rendering/multiple_resolutions.html).)
 
-This is the art-and-import shape, not a scaffold concern: the scaffold stays
-size-agnostic (a swappable `SpriteFrames`, no hardcoded frame dimensions), so a source
-tier drops in as a resource. Loading the right tier for the current display is real work
-the scaffold does not do, so a real build needs that selection wired before it ships, or
-it loads one tier for every display and the foundation goes unused. That selection is its
-own follow-up, tied to the resolution-settings spike and the level-of-detail decision. The font-text blur under `canvas_items` on resize (Godot #86563) is a
-separate UI concern for whenever 4K text crispness is required.
+The scaffold stays size-agnostic regardless: a swappable `SpriteFrames` with no hardcoded
+frame dimensions, so the master frames drop in as a resource. A single master per frame is
+a large texture, which for a one-character paddle is a negligible cost. Two future
+conditions change the rule, and neither is built now. If texture memory ever bites at scale
+(many characters, many frames), the levers in order are mipmaps already present, then GPU
+texture compression, then atlasing, then per-display tiers, reached for when measured. If
+the camera ever zooms in past the master's on-screen size, runtime level-of-detail is added
+then, since zoom is the only thing that would demand a larger source than the master holds.
+The font-text blur under `canvas_items` on resize (Godot #86563) is a separate UI concern
+for whenever 4K text crispness is required.
 
 ## The seam, today
 


### PR DESCRIPTION
The paddle animation and collision spike decided the animation architecture but never addressed target resolution, which is load-bearing for a sprite-swap game that must run on both 1080p and 4K displays. This adds a Target resolution section with the decision and its reasoning.

The decision: keep the project's existing canvas_items stretch at a 1920x1080 base. Under canvas_items the scene renders natively at the physical window resolution, so 4K gets a full 3840x2160 render with the 1080p sprite upscaled 2x by the GPU sampler, which reads as smooth for painterly art rather than blocky. No viewport-upscale pass, no runtime resolution-tier asset swapping. The scaffold therefore stays resolution-agnostic and the engine handles 4K with no code or asset work. The decision is grounded in the Godot multiple-resolutions docs and the canvas_items-as-default proposal, cited inline.

This unblocks the Sam animation scaffold (SH-483) by settling the 4K question its scaffold has to be built against. It also surfaced two out-of-scope follow-ups, noted in the doc: the resolution-and-refresh-rate settings screen (filed as its own spike) and canvas_items font-text blur on resize.