### PR TITLE
docs: flag the characters-mipmaps-off bet at 1440p

### DIFF
--- a/designs/art/tech-pipeline.md
+++ b/designs/art/tech-pipeline.md
@@ -49,7 +49,7 @@ Each PNG has a sibling `.import` file committed to the repo. Import settings per
 
 | Class | Filter | Mipmaps | Fix alpha border | Notes |
 |---|---|---|---|---|
-| Characters | Linear | Off | On | The line must stay crisp; nearest-neighbour reads pixel-art, linear with mipmaps off reads drawn. |
+| Characters | Linear | Off | On | The line must stay crisp; nearest-neighbour reads pixel-art, linear with mipmaps off reads drawn. The mipmaps-off bet is unverified at 1440p, where a character downscales a fractional 0.67x from the @2x master and may shimmer; check it against real art and flip mipmaps on for characters if it does. |
 | Surfaces (props, items, UI marks, signage) | Linear | Off | On | Same hand across world and HUD; render at roughly native scale, so mipmaps waste memory. |
 | Backgrounds | Linear | On | On | Parallax2D layers may render at fractional scales; mipmaps prevent shimmer on slow drift. |
 


### PR DESCRIPTION
The art pipeline sets characters to import with mipmaps off, on the reasoning that they render at roughly native scale where mipmaps would waste memory. At 1440p that bet is at its weakest: a character downscales a fractional 0.67x from the @2x master, which is the case most likely to shimmer without a mipmap chain. This adds a note to the character import row flagging the bet as unverified, to check against real character art once it exists and flip mipmaps on for characters if it shows.