### PR TITLE
fix: rack-return gear no longer requires equip-pose timeout

### DIFF
--- a/designs/01-prototype/tech/gear.md
+++ b/designs/01-prototype/tech/gear.md
@@ -60,6 +60,6 @@ Over-capacity state across designer changes (an equipped item retired, `kit_slot
 
 The equip window opens on `TimeoutController.main_character_reached_equip_pose` and closes on `timeout_ended`. `CharacterDropTarget.can_accept` reads `TimeoutController.get_state() == AT_EQUIP_POSE` directly. Off-court releases hit other targets.
 
-Unequip is symmetric: dragging an equipped item back to the rack within the same window calls `unequip` and frees its slot. Outside the window, the character's drop target stays inert and the dragged item passes through to the next target in the priority list.
+Rack-return is unconditional: dragging an equipped item to the rack calls `unequip` and frees its slot regardless of timeout state. Only equipping onto the character requires `AT_EQUIP_POSE`.
 
 Mid-rally, the press on an equipped item is refused at the gesture entry. While a rally is in progress (`TimeoutController.IDLE` and at least one ball in `PLAY_NORMAL` / `PLAY_ARC`) the gesture never starts; nothing is held, nothing deactivates. The shared check lives on `RallyGate.is_rally_in_progress`, called with injected refs at every callsite. The dev panel's per-item remove-level button uses the same gate so debug paths cannot desync the effect system during play.

--- a/scripts/items/drop_targets/rack_drop_target.gd
+++ b/scripts/items/drop_targets/rack_drop_target.gd
@@ -6,19 +6,16 @@ extends DropTarget
 var _item_manager: Node
 var _drop_area: Area2D
 var _role: StringName
-var _timeout_controller: TimeoutController
 
 
 func configure(
 	item_manager: Node,
 	drop_area: Area2D,
 	role: StringName,
-	timeout_controller: TimeoutController = null,
 ) -> void:
 	_item_manager = item_manager
 	_drop_area = drop_area
 	_role = role
-	_timeout_controller = timeout_controller
 
 
 func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:

--- a/scripts/items/drop_targets/rack_drop_target.gd
+++ b/scripts/items/drop_targets/rack_drop_target.gd
@@ -26,10 +26,6 @@ func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0)
 		return false
 	if not _is_role_match(item_key):
 		return false
-	# Equipment unequip is symmetric with equip per gear.md: only the equip pose permits removal so
-	# the player cannot desync effects mid-rally or in any other lull.
-	if _role == &"equipment" and not RallyGate.removal_allowed(_timeout_controller):
-		return false
 	return _position_inside_area(position)
 
 

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -825,7 +825,6 @@ func _make_rack_target(area: Area2D, role: StringName) -> RackDropTarget:
 	if area == null:
 		return null
 	var rack_target: RackDropTarget = RackDropTarget.new()
-	# The gear-role branch in can_accept gates removal on the equip pose; only the timeout ref is needed.
 	rack_target.configure(_item_manager, area, role, timeout_controller)
 	return rack_target
 

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -825,7 +825,7 @@ func _make_rack_target(area: Area2D, role: StringName) -> RackDropTarget:
 	if area == null:
 		return null
 	var rack_target: RackDropTarget = RackDropTarget.new()
-	rack_target.configure(_item_manager, area, role, timeout_controller)
+	rack_target.configure(_item_manager, area, role)
 	return rack_target
 
 

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -149,23 +149,7 @@ func test_rack_drop_target_accepts_equipment_unequip_outside_equip_pose() -> voi
 
 	assert_true(
 		target.can_accept("gear_rack_gate", Vector2(-500, 0)),
-		"rack-return is unconditional: accepted outside the equip pose",
-	)
-
-
-func test_rack_drop_target_accepts_equipment_unequip_at_equip_pose() -> void:
-	var manager: Node = ItemFactory.create_manager(self)
-	var equipment: ItemDefinition = _make_equipment_definition("gear_rack_gate")
-	manager.items.assign([equipment] as Array[ItemDefinition])
-
-	var area: Area2D = _make_drop_area(Vector2(-500, 0), Vector2(200, 100))
-
-	var target: RackDropTarget = RackDropTargetScript.new()
-	target.configure(manager, area, &"equipment")
-
-	assert_true(
-		target.can_accept("gear_rack_gate", Vector2(-500, 0)),
-		"equipment unequip-to-rack is permitted once the character reaches the equip pose",
+		"rack-return is unconditional: accepted regardless of timeout state",
 	)
 
 

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -143,12 +143,9 @@ func test_rack_drop_target_accepts_equipment_unequip_outside_equip_pose() -> voi
 	manager.items.assign([equipment] as Array[ItemDefinition])
 
 	var area: Area2D = _make_drop_area(Vector2(-500, 0), Vector2(200, 100))
-	var timeout: TimeoutController = TimeoutControllerScript.new()
-	add_child_autofree(timeout)
-	timeout._state = TimeoutController.State.IDLE
 
 	var target: RackDropTarget = RackDropTargetScript.new()
-	target.configure(manager, area, &"equipment", timeout)
+	target.configure(manager, area, &"equipment")
 
 	assert_true(
 		target.can_accept("gear_rack_gate", Vector2(-500, 0)),
@@ -162,12 +159,9 @@ func test_rack_drop_target_accepts_equipment_unequip_at_equip_pose() -> void:
 	manager.items.assign([equipment] as Array[ItemDefinition])
 
 	var area: Area2D = _make_drop_area(Vector2(-500, 0), Vector2(200, 100))
-	var timeout: TimeoutController = TimeoutControllerScript.new()
-	add_child_autofree(timeout)
-	timeout._state = TimeoutController.State.AT_EQUIP_POSE
 
 	var target: RackDropTarget = RackDropTargetScript.new()
-	target.configure(manager, area, &"equipment", timeout)
+	target.configure(manager, area, &"equipment")
 
 	assert_true(
 		target.can_accept("gear_rack_gate", Vector2(-500, 0)),

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -137,8 +137,7 @@ func test_rack_drop_target_without_drop_area_rejects() -> void:
 	assert_false(target.can_accept("ball_alpha", Vector2.ZERO))
 
 
-# SH-412: unequip-to-rack is the sibling of SH-413's equip-pose gate; only the pose permits removal.
-func test_rack_drop_target_rejects_equipment_unequip_outside_equip_pose() -> void:
+func test_rack_drop_target_accepts_equipment_unequip_outside_equip_pose() -> void:
 	var manager: Node = ItemFactory.create_manager(self)
 	var equipment: ItemDefinition = _make_equipment_definition("gear_rack_gate")
 	manager.items.assign([equipment] as Array[ItemDefinition])
@@ -151,9 +150,9 @@ func test_rack_drop_target_rejects_equipment_unequip_outside_equip_pose() -> voi
 	var target: RackDropTarget = RackDropTargetScript.new()
 	target.configure(manager, area, &"equipment", timeout)
 
-	assert_false(
+	assert_true(
 		target.can_accept("gear_rack_gate", Vector2(-500, 0)),
-		"equipment unequip-to-rack bounces unless the character is at the equip pose",
+		"rack-return is unconditional: accepted outside the equip pose",
 	)
 
 


### PR DESCRIPTION
Equipped gear could not be dragged back to the rack outside a timeout window. The `RackDropTarget.can_accept` gate was incorrectly calling `RallyGate.removal_allowed`, which requires `AT_EQUIP_POSE` (the same constraint as equipping onto the character). Rack-return is unconditional; only equipping requires the pose.

Removes the guard from `RackDropTarget`, inverts the test that codified the broken behaviour, and corrects the doc sentence in `gear.md`.

#824

Agent-Role: gdscript-implementer