### PR TITLE
chore: cap reviewers at one nitpick each

### DIFF
--- a/.claude/skills/reviewers/SKILL.md
+++ b/.claude/skills/reviewers/SKILL.md
@@ -110,7 +110,7 @@ All replies stay inline.
 
 ## Inline finding shape
 
-- **Label**: `issue`, `suggestion`, `question`, `nitpick`. Conventional Comments vocab. Only `issue` blocks: name the concrete consequence in one clause (player-visible bug, future-maintainer trap, silent save corruption, contract violation); if you cannot, it is not an `issue`. `suggestion`, `question`, and `nitpick` are non-blocking and never gate the verdict. **Nitpick budget: at most 2 `nitpick` per reviewer per review**, so allowing them does not reopen the low-value-finding floodgate; over budget, drop the weakest. Style preferences, taste calls, and questions you could answer by reading one more file still stay out. Err toward silence; the cap is a ceiling, not a quota.
+- **Label**: `issue`, `suggestion`, `question`, `nitpick`. Conventional Comments vocab. Only `issue` blocks: name the concrete consequence in one clause (player-visible bug, future-maintainer trap, silent save corruption, contract violation); if you cannot, it is not an `issue`. `suggestion`, `question`, and `nitpick` are non-blocking and never gate the verdict. **Nitpick budget: at most 1 `nitpick` per reviewer per review**, so allowing them does not reopen the low-value-finding floodgate; over budget, raise only the single most worth-saying one and drop the rest. Style preferences, taste calls, and questions you could answer by reading one more file still stay out. Err toward silence; the cap is a ceiling, not a quota.
 - One sentence naming the concern; one short clause naming the fix.
 - Hard cap: 30 words per inline. Two lines max. Three lines is a hard block on yourself; tighten.
 - One issue per inline. If you have two findings on different lines, post two inlines.


### PR DESCRIPTION
Swarm reviewers were burying real findings under nitpick noise; the #909 battle had one reviewer fire fifteen comments, all the same compress-this-comment style. The budget was two per reviewer and even that was ignored. Drop it to one: a reviewer raises the single most worth-saying nitpick and drops the rest, so the signal in a review is the blocking findings, not the taste calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)