### PR TITLE
Record settings-screen decision

### DIFF
--- a/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
+++ b/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
@@ -17,8 +17,8 @@ and Audio tabs. Settings are independent of the gameplay save system, so a save 
 | Display | Resolution | Windowed only. Hardcoded 16:9 list filtered to `<= DisplayServer.screen_get_size()` |
 | Display | Refresh rate | Read-only display of the detected rate. Godot cannot set it; the OS/monitor owns it |
 | Display | VSync | **On / Off only** (see renderer note) |
-| Display | FPS cap | `Engine.max_fps`. Off (0) plus a list (30/60/120/144/165/240). The real frame control when VSync is off |
-| Display | FPS counter | Toggle for an on-screen FPS readout |
+| Display | FPS cap | `Engine.max_fps`. Off (0) or 30 / 60 / 120 / 144 / 165 / 240 |
+| Display | FPS readout | Live FPS shown in the settings panel itself (alongside refresh rate), not an option the player sets |
 | Audio | Master / Music / SFX volume | Sliders, linear 0.0 to 1.0 |
 
 ## Display: enumerate and apply
@@ -30,9 +30,10 @@ supported modes. So resolution is a hardcoded 16:9 list (1280x720, 1600x900, 192
 
 Apply is three `DisplayServer` calls plus the frame cap: `window_set_mode`, `window_set_size` (windowed
 only; a no-op in fullscreen), `window_set_vsync_mode`, and `Engine.max_fps` for the cap (0 means
-uncapped). Refresh rate is shown, not set: `screen_get_refresh_rate()` reports the detected value (guard
-the `-1.0` fallback), and the FPS cap is how the user actually bounds the frame rate. The FPS counter is
-a toggled label reading `Engine.get_frames_per_second()`.
+uncapped). Refresh rate is shown, not set; `screen_get_refresh_rate()` reports the detected value,
+guarding the `-1.0` fallback. The FPS cap is how the user actually bounds the frame rate. The settings panel
+also shows a live FPS readout (`Engine.get_frames_per_second()`, polled while the panel is open),
+alongside the refresh rate, so the player can see the effect of the cap and vsync choices in place.
 
 The `canvas_items` stretch (1080p base, per #907) scales transparently when the window resizes; the 4K
 path is exclusive fullscreen scaling the 1080p canvas up. No extra code. One catch: set

--- a/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
+++ b/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
@@ -65,7 +65,7 @@ The `Settings` autoload, the `settings.tscn` TabContainer screen, the `Music`/`S
 player rerouting, and wiring the screen into the menu. Each AC above is an implementation surface.
 
 ## Citations
-Godot 4 docs (verified this session):
+Godot 4 docs:
 - DisplayServer (no mode-enumeration API; `screen_get_size`/`screen_get_refresh_rate`; window mode/size/vsync): https://github.com/godotengine/godot-docs/blob/master/classes/class_displayserver.md
 - Window (`content_scale_aspect`): https://github.com/godotengine/godot-docs/blob/master/classes/class_window.md
 - Viewports (`canvas_items` stretch scaling): https://github.com/godotengine/godot-docs/blob/master/tutorials/rendering/viewports.md

--- a/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
+++ b/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
@@ -38,9 +38,9 @@ exposing them would show the user a no-op. VSync is On/Off only unless the rende
 
 ## Audio: bus setup required first
 
-Volley has only the implicit Master bus (no `default_bus_layout.tres`). The audio options need, created
-in the editor Audio panel: `Music` and `SFX` buses, both sending to Master, with stream players routed
-by name. The editor writes `default_bus_layout.tres`.
+Volley runs on the engine's implicit Master bus alone. The audio options need two more, created in the
+editor Audio panel: `Music` and `SFX`, both sending to Master, with stream players routed by name. The
+editor then writes `default_bus_layout.tres`.
 
 Volume is the one thing every project gets wrong: **persist the linear slider value (0.0 to 1.0); apply
 `linear_to_db()` only at the `AudioServer.set_bus_volume_db` call site; never store dB.** A mute toggle
@@ -65,5 +65,12 @@ The `Settings` autoload, the `settings.tscn` TabContainer screen, the `Music`/`S
 player rerouting, and wiring the screen into the menu. Each AC above is an implementation surface.
 
 ## Citations
-DisplayServer / Window / Viewports / ConfigFile / AudioServer / audio-buses / singletons, Godot 4 docs
-(full URLs in the two angle agents' returns, this session).
+Godot 4 docs (verified this session):
+- DisplayServer (no mode-enumeration API; `screen_get_size`/`screen_get_refresh_rate`; window mode/size/vsync): https://github.com/godotengine/godot-docs/blob/master/classes/class_displayserver.md
+- Window (`content_scale_aspect`): https://github.com/godotengine/godot-docs/blob/master/classes/class_window.md
+- Viewports (`canvas_items` stretch scaling): https://github.com/godotengine/godot-docs/blob/master/tutorials/rendering/viewports.md
+- ConfigFile (`load`/`get_value` default/`set_value`/`save`): https://github.com/godotengine/godot-docs/blob/master/classes/class_configfile.md
+- AudioServer (`set_bus_volume_db`/`set_bus_mute`): https://github.com/godotengine/godot-docs/blob/master/classes/class_audioserver.md
+- Audio buses (bus layout, `default_bus_layout.tres`): https://github.com/godotengine/godot-docs/blob/master/tutorials/audio/audio_buses.md
+- `linear_to_db` (@GlobalScope): https://github.com/godotengine/godot-docs/blob/master/classes/class_@globalscope.md
+- Singletons / Autoload (load order, `_enter_tree`): https://github.com/godotengine/godot-docs/blob/master/tutorials/scripting/singletons_autoload.md

--- a/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
+++ b/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
@@ -33,7 +33,7 @@ only; a no-op in fullscreen), `window_set_vsync_mode`, and `Engine.max_fps` for 
 uncapped). Refresh rate is shown, not set; `screen_get_refresh_rate()` reports the detected value,
 guarding the `-1.0` fallback. The FPS cap is how the user bounds the frame rate. The settings panel
 also shows a live FPS readout (`Engine.get_frames_per_second()`, polled while the panel is open),
-alongside the refresh rate, so the player can see the effect of the cap and vsync choices in place.
+alongside the refresh rate, so the player sees the cap and vsync choices take effect.
 
 The `canvas_items` stretch (1080p base, per #907) scales transparently when the window resizes; the 4K
 path is exclusive fullscreen scaling the 1080p canvas up. No extra code. One catch: set

--- a/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
+++ b/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
@@ -31,7 +31,7 @@ supported modes. So resolution is a hardcoded 16:9 list (1280x720, 1600x900, 192
 Apply is three `DisplayServer` calls plus the frame cap: `window_set_mode`, `window_set_size` (windowed
 only; a no-op in fullscreen), `window_set_vsync_mode`, and `Engine.max_fps` for the cap (0 means
 uncapped). Refresh rate is shown, not set; `screen_get_refresh_rate()` reports the detected value,
-guarding the `-1.0` fallback. The FPS cap is how the user actually bounds the frame rate. The settings panel
+guarding the `-1.0` fallback. The FPS cap is how the user bounds the frame rate. The settings panel
 also shows a live FPS readout (`Engine.get_frames_per_second()`, polled while the panel is open),
 alongside the refresh rate, so the player can see the effect of the cap and vsync choices in place.
 

--- a/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
+++ b/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
@@ -1,0 +1,69 @@
+# Settings screen spike
+
+Decision record for how Volley's settings screen enumerates, applies, and persists options.
+Closes the spike (#906). Implementation is follow-up work, not part of this spike.
+
+## Decision
+
+A `Settings` autoload owns a separate `user://settings.cfg` (ConfigFile), loads and applies it at
+`_enter_tree`, and exposes a setter that applies-then-saves. The screen is a TabContainer with Display
+and Audio tabs. Settings are independent of the gameplay save system, so a save wipe leaves them intact.
+
+## Options the screen holds
+
+| Tab | Option | Notes |
+|---|---|---|
+| Display | Window mode | Windowed / Borderless Fullscreen / Exclusive Fullscreen |
+| Display | Resolution | Windowed only. Hardcoded 16:9 list filtered to `<= DisplayServer.screen_get_size()` |
+| Display | VSync | **On / Off only** (see renderer note) |
+| Audio | Master / Music / SFX volume | Sliders, linear 0.0 to 1.0 |
+
+## Display: enumerate and apply
+
+Godot 4 has **no video-mode enumeration API**. `DisplayServer` exposes `screen_get_size()` and
+`screen_get_refresh_rate()` (guard the latter, it returns `-1.0` on some platforms) but no list of
+supported modes. So resolution is a hardcoded 16:9 list (1280x720, 1600x900, 1920x1080, 2560x1440,
+3840x2160) filtered at startup to those fitting the detected screen.
+
+Apply is three calls: `window_set_mode`, `window_set_size` (windowed only; a no-op in fullscreen),
+`window_set_vsync_mode`.
+
+The `canvas_items` stretch (1080p base, per #907) scales transparently when the window resizes; the 4K
+path is exclusive fullscreen scaling the 1080p canvas up. No extra code. One catch: set
+`content_scale_aspect = KEEP` on the root Window or a freely-resized window stretches content.
+
+**Renderer note (decided against the live project):** Volley renders with `gl_compatibility`. Under the
+Compatibility renderer, `VSYNC_ADAPTIVE` and `VSYNC_MAILBOX` silently fall back to `VSYNC_ENABLED`, so
+exposing them would show the user a no-op. VSync is On/Off only unless the renderer changes.
+
+## Audio: bus setup required first
+
+Volley has only the implicit Master bus (no `default_bus_layout.tres`). The audio options need, created
+in the editor Audio panel: `Music` and `SFX` buses, both sending to Master, with stream players routed
+by name. The editor writes `default_bus_layout.tres`.
+
+Volume is the one thing every project gets wrong: **persist the linear slider value (0.0 to 1.0); apply
+`linear_to_db()` only at the `AudioServer.set_bus_volume_db` call site; never store dB.** A mute toggle
+uses `set_bus_mute`, not volume to `-inf`.
+
+## Persistence lifecycle
+
+`Settings` autoload (registered above the autoloads that consume settings, so its `_enter_tree` applies
+first):
+
+1. `_enter_tree`: `config.load("user://settings.cfg")`. A first-run miss returns a non-OK error, not a
+   crash; ignore it and fall through to defaults via the third arg of `get_value(section, key, default)`.
+2. Apply every value (AudioServer volumes, window mode/size/vsync).
+3. Public `set(section, key, value)`: writes to memory, applies that domain, then `config.save(...)`.
+4. Audio sliders apply immediately (real-time feedback); `save()` fires on confirmed close and again in
+   `_exit_tree` as a safety net, not on every slider tick.
+5. A reset-to-defaults button per tab writes each key's hardcoded default and saves.
+
+## Follow-up (separate tickets, not this spike)
+
+The `Settings` autoload, the `settings.tscn` TabContainer screen, the `Music`/`SFX` bus layout plus
+player rerouting, and wiring the screen into the menu. Each AC above is an implementation surface.
+
+## Citations
+DisplayServer / Window / Viewports / ConfigFile / AudioServer / audio-buses / singletons, Godot 4 docs
+(full URLs in the two angle agents' returns, this session).

--- a/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
+++ b/designs/01-prototype/tech/2026-06-11-settings-screen-spike.md
@@ -15,7 +15,10 @@ and Audio tabs. Settings are independent of the gameplay save system, so a save 
 |---|---|---|
 | Display | Window mode | Windowed / Borderless Fullscreen / Exclusive Fullscreen |
 | Display | Resolution | Windowed only. Hardcoded 16:9 list filtered to `<= DisplayServer.screen_get_size()` |
+| Display | Refresh rate | Read-only display of the detected rate. Godot cannot set it; the OS/monitor owns it |
 | Display | VSync | **On / Off only** (see renderer note) |
+| Display | FPS cap | `Engine.max_fps`. Off (0) plus a list (30/60/120/144/165/240). The real frame control when VSync is off |
+| Display | FPS counter | Toggle for an on-screen FPS readout |
 | Audio | Master / Music / SFX volume | Sliders, linear 0.0 to 1.0 |
 
 ## Display: enumerate and apply
@@ -25,8 +28,11 @@ Godot 4 has **no video-mode enumeration API**. `DisplayServer` exposes `screen_g
 supported modes. So resolution is a hardcoded 16:9 list (1280x720, 1600x900, 1920x1080, 2560x1440,
 3840x2160) filtered at startup to those fitting the detected screen.
 
-Apply is three calls: `window_set_mode`, `window_set_size` (windowed only; a no-op in fullscreen),
-`window_set_vsync_mode`.
+Apply is three `DisplayServer` calls plus the frame cap: `window_set_mode`, `window_set_size` (windowed
+only; a no-op in fullscreen), `window_set_vsync_mode`, and `Engine.max_fps` for the cap (0 means
+uncapped). Refresh rate is shown, not set: `screen_get_refresh_rate()` reports the detected value (guard
+the `-1.0` fallback), and the FPS cap is how the user actually bounds the frame rate. The FPS counter is
+a toggled label reading `Engine.get_frames_per_second()`.
 
 The `canvas_items` stretch (1080p base, per #907) scales transparently when the window resizes; the 4K
 path is exclusive fullscreen scaling the 1080p canvas up. No extra code. One catch: set


### PR DESCRIPTION
Closes the settings-screen spike (#906). The game has no display or settings handling yet; this records the approach so the feature can be built against a known design rather than guessed.

The decision is in [designs/01-prototype/tech/2026-06-11-settings-screen-spike.md](designs/01-prototype/tech/2026-06-11-settings-screen-spike.md): a Settings autoload owning a separate user:// ConfigFile (independent of the gameplay save, so a save wipe leaves settings intact), a TabContainer screen with Display and Audio tabs. It records the findings that shaped it: Godot 4 has no video-mode enumeration API (resolution is a filtered hardcoded list), VSync is On/Off only because the project renders with gl_compatibility (Adaptive silently degrades there), and audio volume persists linear with linear_to_db applied only at the call site. Implementation is follow-up work.