### PR TITLE
Fail loud when memory render runs against the wrong dir

### DIFF
--- a/scripts/memory/lint-graph-edges.sh
+++ b/scripts/memory/lint-graph-edges.sh
@@ -61,6 +61,15 @@ while IFS= read -r -d '' filepath; do
     PARENT_OF["$filename"]="$parent_value"
 done < <(find "$MEMORY_DIR" -name "*.md" -print0 | sort -z)
 
+# A real memory dir always holds the trunk spine. If MEMORY.md and the trunks
+# are absent, MEMORY_DIR points at the wrong tree (e.g. the repo root when the
+# boot command was run with a cwd-relative "."). Fail loudly rather than render
+# a plausible-but-empty forest that reads as a broken one.
+if [[ -z "${IS_NODE[MEMORY]:-}" || -z "${IS_NODE[trunk_unordered]:-}" ]]; then
+    echo "lint-graph-edges: $MEMORY_DIR has no MEMORY.md/trunk spine; wrong dir?" >&2
+    exit 2
+fi
+
 # Resolve parents against the set of known nodes (any subdir), not a fixed path,
 # so a parent file in letters/ or any subdir resolves. Done as a second pass so
 # a parent seen later in the walk still counts.

--- a/scripts/memory/lint-graph-edges.sh
+++ b/scripts/memory/lint-graph-edges.sh
@@ -61,10 +61,7 @@ while IFS= read -r -d '' filepath; do
     PARENT_OF["$filename"]="$parent_value"
 done < <(find "$MEMORY_DIR" -name "*.md" -print0 | sort -z)
 
-# A real memory dir always holds the trunk spine. If MEMORY.md and the trunks
-# are absent, MEMORY_DIR points at the wrong tree (e.g. the repo root when the
-# boot command was run with a cwd-relative "."). Fail loudly rather than render
-# a plausible-but-empty forest that reads as a broken one.
+# No spine means MEMORY_DIR is the wrong tree, not an empty forest.
 if [[ -z "${IS_NODE[MEMORY]:-}" || -z "${IS_NODE[trunk_unordered]:-}" ]]; then
     echo "lint-graph-edges: $MEMORY_DIR has no MEMORY.md/trunk spine; wrong dir?" >&2
     exit 2


### PR DESCRIPTION
The memory boot command rendered the forest with a cwd-relative `.` argument. From the repo root, where every session starts, that resolved `MEMORY_DIR` to a directory holding no forest, and `lint-graph-edges.sh --tree` then printed a flat dump of every loose markdown file as if it were a broken corpus. A fresh session reads that as the memory's true state.

This guards tree mode: when the target dir holds no `MEMORY.md`/trunk spine, the script exits 2 with a "wrong dir?" message instead of rendering a plausible-but-empty forest. The companion fix to the boot command itself (dropping the `.`) lives in the memory repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)