### PR TITLE
ci: add 500KB binary size gate via lefthook and CI

### DIFF
--- a/.github/workflows/asset-size.yml
+++ b/.github/workflows/asset-size.yml
@@ -26,4 +26,10 @@ jobs:
           fetch-depth: 0
 
       - name: Check asset sizes
-        run: bash scripts/ci/check_asset_size.sh --diff ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            base_sha="${{ github.event.merge_group.base_sha }}"
+          else
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          fi
+          bash scripts/ci/check_asset_size.sh --diff "$base_sha"

--- a/.github/workflows/asset-size.yml
+++ b/.github/workflows/asset-size.yml
@@ -1,0 +1,29 @@
+name: Asset size gate
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+concurrency:
+  group: asset-size-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-asset-size:
+    name: check-asset-size
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Check asset sizes
+        run: bash scripts/ci/check_asset_size.sh --diff ${{ github.event.pull_request.base.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ lefthook install
 
 CI runs the same checks on every PR, so whatever passes locally will pass there.
 
-A pre-commit hook also enforces a **500 KB size gate** on staged files. Any binary over that threshold must be tracked via Git LFS rather than committed directly. The hook skips `.import` sidecars (generated config) and files already tracked by LFS. CI runs the same check on every pull request as a backstop for skipped local hooks.
+A pre-commit hook also enforces a **500 KB size gate** on staged files. Any binary over that threshold must be tracked via Git LFS rather than committed directly. The hook skips `.import` sidecars (generated config) and files already tracked by LFS. CI runs the same check on every pull request as a backstop for skipped local hooks. If you pull a change that adds or removes hooks, re-run `lefthook install` to pick up the new hook set.
 
 ## Submitting a PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ lefthook install
 
 CI runs the same checks on every PR, so whatever passes locally will pass there.
 
+A pre-commit hook also enforces a **500 KB size gate** on staged files. Any binary over that threshold must be tracked via Git LFS rather than committed directly. The hook skips `.import` sidecars (generated config) and files already tracked by LFS. CI runs the same check on every pull request as a backstop for skipped local hooks.
+
 ## Submitting a PR
 
 Open the PR against `main`. Branch name format is `<intent>/<gh-issue>-<short-description>`, where `<intent>` matches the ticket's label and `<gh-issue>` is the GitHub issue number. See [`designs/process/labels.md`](designs/process/labels.md) for the full label set and examples.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,6 @@
 # Auto-sync re-runs installHooks() on every git command, and 2.1.x refuses to
-# write while core.hooksPath is set locally — printing "Skipping hook sync" on
-# every invocation. Disable it; run `lefthook install` manually after edits here.
+# write while core.hooksPath is set locally (printing "Skipping hook sync" on
+# every invocation). Disable it; run `lefthook install` manually after edits here.
 no_auto_install: true
 
 output:
@@ -46,6 +46,11 @@ pre-commit:
       exclude:
         - "addons/**"
       run: ./scripts/ci/run_gut.sh
+    check-asset-size:
+      exclude:
+        - "addons/**"
+        - "*.import"
+      run: ./scripts/ci/check_asset_size.sh
     pip-audit:
       glob: "requirements-dev.txt"
       run: pip-audit --requirement requirements-dev.txt --strict

--- a/scripts/ci/check_asset_size.sh
+++ b/scripts/ci/check_asset_size.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Fails non-zero when any staged (or diff-listed) binary file exceeds the
+# threshold. Called by the lefthook pre-commit command and the CI workflow.
+#
+# Usage:
+#   Pre-commit mode (no args): checks files staged in the git index.
+#   CI mode (--diff BASE):     checks files added/modified vs BASE commit.
+
+set -euo pipefail
+
+THRESHOLD_KB=500
+THRESHOLD_BYTES=$(( THRESHOLD_KB * 1024 ))
+
+mode="staged"
+base_ref=""
+
+if [[ "${1:-}" == "--diff" ]]; then
+    mode="diff"
+    base_ref="${2:?'--diff requires a base ref'}"
+fi
+
+get_files() {
+    if [[ "$mode" == "staged" ]]; then
+        git diff --cached --name-only --diff-filter=d
+    else
+        git diff --name-only --diff-filter=d "${base_ref}...HEAD"
+    fi
+}
+
+is_lfs_pointer() {
+    local file="$1"
+    local blob_ref first_line
+    if [[ "$mode" == "staged" ]]; then
+        blob_ref=":${file}"
+    else
+        blob_ref="HEAD:${file}"
+    fi
+    first_line=$(git show "${blob_ref}" 2>/dev/null | head -1 || true)
+    [[ "$first_line" == "version https://git-lfs.github.com/spec/v1" ]]
+}
+
+get_size() {
+    local file="$1"
+    if [[ "$mode" == "staged" ]]; then
+        git cat-file -s ":${file}" 2>/dev/null || printf 0
+    else
+        git cat-file -s "HEAD:${file}" 2>/dev/null || printf 0
+    fi
+}
+
+failed=0
+
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+
+    case "$file" in
+        *.import)  continue ;;
+        addons/*)  continue ;;
+    esac
+
+    if is_lfs_pointer "$file"; then
+        continue
+    fi
+
+    size=$(get_size "$file")
+
+    if (( size > THRESHOLD_BYTES )); then
+        size_kb=$(( size / 1024 ))
+        printf 'error: %s is %dKB, exceeds %dKB limit\n' "$file" "$size_kb" "$THRESHOLD_KB" >&2
+        failed=1
+    fi
+done < <(get_files)
+
+if (( failed )); then
+    printf '\nLarge binaries must be tracked via Git LFS, not committed directly.\n' >&2
+    printf 'Run: git lfs track <pattern>\n' >&2
+    exit 1
+fi


### PR DESCRIPTION
Adds a pre-commit hook and a CI PR check that block plain binary files over 500 KB from entering git history. Both surfaces call the same `scripts/ci/check_asset_size.sh` script so the threshold is defined once. The `.import` sidecars and LFS pointer files are excluded. This adds a new CI workflow (`asset-size.yml`) that runs on every pull request.

#819

Agent-Role: Norbert (implementer)