### PR TITLE
docs: wire studio LFS upload setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,41 @@ Concept art under `concepts/` is opt-in and not fetched on clone. Pull it when y
 make concepts
 ```
 
+### Pushing LFS art (studio members)
+
+If you have been given an upload key you can push new LFS-tracked art from your branch. The
+upload key is never committed; it lives only in your local `.git/config` for the one machine you
+push from.
+
+One-time local setup (obtain your key from a maintainer out of band):
+
+```sh
+LFS_UPLOAD_KEY=<your-key> make lfs-upload-setup
+```
+
+That runs `git config lfs.url ...` with your key and writes the result to `.git/config`, which
+git never commits. Every other clone keeps pulling through the committed `.lfsconfig` download
+key; only your machine uses the upload key for `git push`.
+
+After setup, a normal `git add / commit / push` of any LFS-tracked file uploads the bytes to the
+proxy's `preview/` store. When the PR merges to `main`, CI promotes the objects to `release/`
+automatically. You do not need to do anything extra on merge.
+
+To verify the override is set (it should show your key, not the download key):
+
+```sh
+git config lfs.url
+```
+
+To remove the override and revert to download-only:
+
+```sh
+git config --unset lfs.url
+```
+
+**Never commit your upload key.** If `git config lfs.url` shows in a staged diff, run
+`git config --unset lfs.url` before committing and re-run setup.
+
 ## Tests and lint
 
 Tests use [GUT (Godot Unit Test)](https://github.com/bitwes/Gut), vendored under `addons/gut/`. Run the suite headlessly:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,14 +60,18 @@ To verify the override is set (it should show your key, not the download key):
 git config lfs.url
 ```
 
+That output contains your upload key, so keep it off shared screens and chat channels.
+
 To remove the override and revert to download-only:
 
 ```sh
 git config --unset lfs.url
 ```
 
-**Never commit your upload key.** If `git config lfs.url` shows in a staged diff, run
-`git config --unset lfs.url` before committing and re-run setup.
+**Never commit your upload key.** The override lives in `.git/config`, which git never stages, so the
+key cannot reach a commit on its own. The one path into history is an accidental edit to the committed
+`.lfsconfig`; if that file shows in a staged diff, restore it with `git checkout .lfsconfig` before
+committing.
 
 ## Tests and lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,15 @@
-.PHONY: concepts
+.PHONY: concepts lfs-upload-setup
 
 concepts:
 	git lfs pull --include="concepts/**"
+
+lfs-upload-setup:
+	@if [ -z "$$LFS_UPLOAD_KEY" ]; then \
+		echo "Error: LFS_UPLOAD_KEY is not set."; \
+		echo "Obtain your upload key from a maintainer, then run:"; \
+		echo "  LFS_UPLOAD_KEY=<your-key> make lfs-upload-setup"; \
+		exit 1; \
+	fi
+	git config lfs.url "https://volley:$$LFS_UPLOAD_KEY@volley-lfs-proxy.volcanoem.workers.dev"
+	@echo "Local lfs.url written to .git/config (not committed)."
+	@echo "Normal git add / commit / push of LFS-tracked art now uploads to preview/."


### PR DESCRIPTION
The committed `.lfsconfig` carries the download key, which the Worker's upload path rejects. A studio member with an upload key had no documented path to push LFS bytes.

This change adds a `make lfs-upload-setup` target that takes the upload key as an environment variable and writes it to the local `.git/config` as `lfs.url`. The local git config overrides `.lfsconfig` for that machine only; every other clone continues pulling through the committed download key. The target guards against a missing key (exits non-zero with a clear message) and prints confirmation that the override is local and not committed. CONTRIBUTING gets a new "Pushing LFS art (studio members)" subsection that walks through the one-time setup, explains the preview/release promotion flow, and includes a safety note against staging the key.

No new secret is introduced in any committed file. The upload key is supplied by the user at the shell and written only to `.git/config`, which git never stages.

AC4 (real `concepts/` push verifying the end-to-end path with the live upload key) is a manual follow-up by Josh and Gru with the live key. It is not part of this PR.

#947

Agent-Role: infra-implementer