### PR TITLE
Add concept art into subject folders via LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,13 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
 
-# Concept art wholesale: all files in concepts/ go to LFS.
+# Concept art wholesale: all files in concepts/ go to LFS, except text docs that
+# must stay readable on a plain clone (README, .gdignore).
 concepts/** filter=lfs diff=lfs merge=lfs -text
+concepts/**/*.md !filter !diff !merge text
+concepts/*.md !filter !diff !merge text
+concepts/**/.gdignore !filter !diff !merge text
+concepts/.gdignore !filter !diff !merge text
 
 # Large source-art formats.
 *.psd filter=lfs diff=lfs merge=lfs -text
@@ -27,3 +32,4 @@ concepts/** filter=lfs diff=lfs merge=lfs -text
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.webm filter=lfs diff=lfs merge=lfs -text
 *.mov filter=lfs diff=lfs merge=lfs -text
+*.ogv filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,10 @@ concepts/** filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
 *.exr filter=lfs diff=lfs merge=lfs -text
 *.hdr filter=lfs diff=lfs merge=lfs -text
+
+# Video and animation previews (concepts hold video/gif; frame-by-frame lives in assets).
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.apng filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.webm filter=lfs diff=lfs merge=lfs -text
+*.mov filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,12 @@ ai/scratchpads/
 *.kra~
 *.psd~
 *.xcf~
-*.{psb,psd}.tmp
-*.{ai,svg}.tmp
-~*.{ai,psd}
+*.psb.tmp
+*.psd.tmp
+*.ai.tmp
+*.svg.tmp
+~*.ai
+~*.psd
 .~lock.*
 *.aseprite-data
 *.ase~
@@ -88,7 +91,7 @@ ai/scratchpads/
 *.pcl~
 *_bak.pclx
 backup/*.tnz
-sandbox/
+/sandbox/
 
 # OS junk
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,36 @@ ai/swarm/_bootstrap.md
 # the injection-guard hook log. Not committed.
 ai/scratchpads/
 
+# Art-app autosaves and temp files (commit the source masters, not the crash recovery)
+*-autosave.kra
+*.kra~
+*.psd~
+*.xcf~
+*.{psb,psd}.tmp
+*.{ai,svg}.tmp
+~*.{ai,psd}
+.~lock.*
+*.aseprite-data
+*.ase~
+*.aseprite~
+*.blend1
+*.blend2
+*.blend@
+# Animation apps (Spine, DragonBones, After Effects, Moho)
+*.spine-backup
+*.dbbak
+*.aep~
+*.aep.lock
+*.moho~
+# Frame-by-frame apps (OpenToonz, TVPaint, Pencil2D) autosaves and backups
+*.tnz~
+*.tvpp~
+*.pclx~
+*.pcl~
+*_bak.pclx
+backup/*.tnz
+sandbox/
+
 # OS junk
 .DS_Store
 Thumbs.db

--- a/concepts/README.md
+++ b/concepts/README.md
@@ -1,4 +1,3 @@
-# Concept art
-
-Concept art lives here, tracked via Git LFS through the R2 proxy. This directory is opt-in: a
-normal clone does not pull these files. Run `make concepts` to fetch them locally.
+version https://git-lfs.github.com/spec/v1
+oid sha256:088aca93e8250a86d4f40f6bdb9b40b99ba137135adcb7ca499c8f63414c2dfe
+size 192

--- a/concepts/README.md
+++ b/concepts/README.md
@@ -1,3 +1,4 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:088aca93e8250a86d4f40f6bdb9b40b99ba137135adcb7ca499c8f63414c2dfe
-size 192
+# Concept art
+
+Concept art lives here, tracked via Git LFS through the R2 proxy. This directory is opt-in: a
+normal clone does not pull these files. Run `make concepts` to fetch them locally.

--- a/concepts/character/early-1.png
+++ b/concepts/character/early-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:660764060958d67a3fb701f194cab67a6a406906d97deeb41912c45a23f18eff
+size 2544546

--- a/concepts/character/early-2.png
+++ b/concepts/character/early-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:592f09feabfa03d0e234aa7df8a82b74b41e14e24fbfdd81413def41fc249dce
+size 2972626

--- a/concepts/character/early-3.png
+++ b/concepts/character/early-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aadbd61baed9b007ab5c92447bc03718998ed5a69aaa132a483e46822553ee7
+size 383132

--- a/concepts/character/early-4.png
+++ b/concepts/character/early-4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e46d7a0e179d66cd60b83e72642126b90c85e235284d753e7e5b788c985a9d3
+size 471100

--- a/concepts/character/early-age-expressions.png
+++ b/concepts/character/early-age-expressions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbde9f07a05b2ddfb9892828ad32c1ef5a1345b672ea5933b029a782f607b093
+size 236744

--- a/concepts/character/early-age.png
+++ b/concepts/character/early-age.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22e502d25f09f1a28c26f5b7e86eafa667132343b8ae23c23428048569c13fa9
+size 183072

--- a/concepts/character/early-expressions.png
+++ b/concepts/character/early-expressions.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c26abfafa81d4918c3dadd3fcffc9cb13d094e12b1fe9107048d0cd65fa60395
+size 1936006

--- a/concepts/character/explore-1.png
+++ b/concepts/character/explore-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58ac1363a9e69948ffb6972130c7b7c1ae24eb70496b086b93da94dff724b188
+size 3328372

--- a/concepts/character/explore-2.png
+++ b/concepts/character/explore-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56fa0c9115dc1f35b3caa3a1a52fbdcc219ae1fa490dd489e09479bdcee6d45d
+size 1079874

--- a/concepts/character/explore-3.png
+++ b/concepts/character/explore-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:114fea36c26f3174ce5c382b9c4a641c02449a5ca0b43dff3ae5d24ebe5b3873
+size 2555461

--- a/concepts/early-board.png
+++ b/concepts/early-board.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2466345bafc2a907490acd50bd484d45addfb9ba14a750d28cf0d5912dea8058
+size 1766467

--- a/concepts/garden/court-layout-and-props.png
+++ b/concepts/garden/court-layout-and-props.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6e4510cf03a9df76e3b2db859b11aa23676b04b80da872775d0664653ecf494
+size 4511010

--- a/concepts/garden/court-layout-sketch-2.png
+++ b/concepts/garden/court-layout-sketch-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6beb18269a4121447bd665ba5b16197d9127b4cc9614136dc35998c920d73735
+size 1692525

--- a/concepts/garden/court-layout-sketch.png
+++ b/concepts/garden/court-layout-sketch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ad92ddc0ffa1af17909e4fdc5bf26de56a3be5c049aa6c03eaba4030b955b24
+size 8742135

--- a/concepts/garden/map-2.png
+++ b/concepts/garden/map-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85b47915ae3fc65f7728ccba028b2a4711cb5775ad6888f7c3b15fe493adc7c8
+size 165471

--- a/concepts/garden/map.png
+++ b/concepts/garden/map.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:921f2e8f183d7a1eb2fa464780cbd229bc9ed33966ab9273d2b6b8994ec6e01a
+size 78980

--- a/concepts/garden/mood-studies.png
+++ b/concepts/garden/mood-studies.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f77ac1c526e3c7b5e3817eb1de7154fdfeee681dba8274de9bb21d6ba589a38b
+size 5472215

--- a/concepts/garden/props.png
+++ b/concepts/garden/props.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d94b562243b00dafee37c905761e8cd9d78c85209fe3cf9476a1da75872ebf9f
+size 3545174

--- a/concepts/items/balls.png
+++ b/concepts/items/balls.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a9c8b13bc55b1463eb8b1217ce334a3e2ca116c042a8b02360f7eb1a2322c04
+size 1614419

--- a/concepts/items/gear.png
+++ b/concepts/items/gear.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ac5f127557646625943f2fd4fb8cb1c98e1e9cc9862b91c3f55dceb0d9b5d2d
+size 1737507

--- a/concepts/movement/swings-and-balls.png
+++ b/concepts/movement/swings-and-balls.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9524e909fb98e6a31a5752bf205796846937803f73023d7f3626f9042980fe87
+size 1884587

--- a/concepts/movement/swings.png
+++ b/concepts/movement/swings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:788c0722e8047b85d44d12a09e0a1fab5d732f711d866cdd387c2a99459f7e36
+size 2460392

--- a/concepts/raw/character-early-concept-sheet.psd
+++ b/concepts/raw/character-early-concept-sheet.psd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b5eb0cc4a37c3a108a36d0a57927c8e50bd3fcf0a98056852a47901e02c9044
+size 18076504

--- a/concepts/raw/character-movements.psd
+++ b/concepts/raw/character-movements.psd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbbf692f8b726ce7f4c4499d5edbc9bec9921f70e39c1f568d6b8b3013e72f00
+size 24093172

--- a/concepts/soul/glowstick.png
+++ b/concepts/soul/glowstick.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a27b22f49932003cec31c2b0420035a0391b59492ec7ba6fb3f4c4186df4c63
+size 3581774


### PR DESCRIPTION
First real use of the R2 LFS pipeline: the concept art batch, organised into subject folders (garden, character, movement, items, soul) with raw masters under concepts/raw, and the early pitch board at the root. Every binary is an LFS pointer; the 95MB of real bytes uploaded to the bucket preview prefix and verified retrievable.

Two pipeline gaps closed alongside: .gitattributes now routes video and animation formats (gif, apng, mp4, webm, mov) to LFS so frame-by-frame work in assets does not land in plain git, and .gitignore now covers the autosave and temp cruft for the main art and animation apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)