### PR TITLE
Promote LFS on github release, not on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,32 +76,6 @@ jobs:
           mkdir -p logs
           godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json -gexit
 
-  promote-lfs:
-    name: Promote LFS objects to release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          lfs: false
-
-      - name: Collect merged LFS oids
-        id: oids
-        run: |
-          git lfs ls-files --long | awk '{print $1}' | jq -Rsc 'split("\n") | map(select(. != ""))' > oids.json
-
-      - name: Promote preview objects to release
-        run: |
-          curl -fsSL -X POST \
-            -H "Authorization: Basic $(printf 'volley:%s' "${{ secrets.LFS_PROMOTE_KEY }}" | base64 -w0)" \
-            -H "Content-Type: application/json" \
-            -d "{\"oids\": $(cat oids.json)}" \
-            https://volley-lfs-proxy.volcanoem.workers.dev/promote
-
   deploy-preview:
     name: Deploy to Preview
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,31 @@ jobs:
           mkdir -p logs
           godot --headless --path . -s addons/gut/gut_cmdln.gd -gconfig=.gutconfig.json -gexit
 
+  promote-lfs:
+    name: Promote LFS objects to release
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          lfs: false
+
+      - name: Collect released LFS oids
+        id: oids
+        run: |
+          git lfs ls-files --long | awk '{print $1}' | jq -Rsc 'split("\n") | map(select(. != ""))' > oids.json
+
+      - name: Promote preview objects to release
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Basic $(printf 'volley:%s' "${{ secrets.LFS_PROMOTE_KEY }}" | base64 -w0)" \
+            -H "Content-Type: application/json" \
+            -d "{\"oids\": $(cat oids.json)}" \
+            https://volley-lfs-proxy.volcanoem.workers.dev/promote
+
   deploy-production:
     name: Deploy to Production
     needs: test

--- a/designs/01-prototype/tech/2026-06-12-lfs-proxy-architecture.md
+++ b/designs/01-prototype/tech/2026-06-12-lfs-proxy-architecture.md
@@ -60,22 +60,23 @@ rather than cleaning up after it, using two R2 prefixes named for the build life
 - **`preview/<oid>`** holds bytes pushed from a PR branch. Uploads presign here. An R2 lifecycle rule
   expires the `preview/` prefix at **30 days**, so the bytes of an abandoned PR evaporate on their own.
   R2 does this natively; there is no GC script and no history hazard, because only `preview/` is reaped.
-- **`release/<oid>`** is the canonical store. Objects arrive only when CI promotes them on merge to
-  main. `release/` has no expiry; history references it forever.
+- **`release/<oid>`** is the canonical store. Objects arrive only when CI promotes them on a GitHub
+  Release. `release/` has no expiry; history references it forever.
 
 Flow:
 
 1. **Upload** (PR work): the Worker presigns a PUT to `preview/<oid>`. Only an `UPLOAD_KEY` holder can
    upload.
-2. **Promote** (merge to main): a CI job calls the Worker's `/promote` endpoint, authenticated by a
-   distinct `PROMOTE_KEY`. The Worker copies each oid from `preview/` to `release/` using its R2
-   binding. The promote job runs only on `push` to `main`, never on a `pull_request` event, so it never
-   executes in a fork PR's context and `PROMOTE_KEY` is never exposed to fork-triggered runs. (The repo
-   uses no `pull_request_target`, which would otherwise hand a fork PR access to repo secrets.) That
-   closes the enforcement chain: `PROMOTE_KEY` is reachable only from a trusted on-main run, so "CI is
-   the only writer of `release/`" is enforced, not conventional. Each oid is independent: an
-   already-promoted oid is a no-op (idempotent and retry-safe), a missing `preview/` object fails that
-   oid, and any failure returns a non-2xx so CI retries.
+2. **Promote** (on a GitHub Release): the `release.yml` workflow, which triggers only on
+   `release: published`, calls the Worker's `/promote` endpoint, authenticated by a distinct
+   `PROMOTE_KEY`. The Worker copies each oid from `preview/` to `release/` using its R2 binding. Because
+   the workflow runs only on a maintainer-cut release, never on a `pull_request` event, `PROMOTE_KEY` is
+   never exposed to a fork-triggered run. (The repo uses no `pull_request_target`, which would otherwise
+   hand a fork PR access to repo secrets.) That closes the enforcement chain: `PROMOTE_KEY` is reachable
+   only from a trusted release run, so "CI is the only writer of `release/`" is enforced, not
+   conventional. Merging to main alone does not promote; the bytes stay in `preview/` until a release.
+   Each oid is independent: an already-promoted oid is a no-op (idempotent and retry-safe), a missing
+   `preview/` object fails that oid, and any failure returns a non-2xx so CI retries.
 3. **Download**: the Worker resolves `release/<oid>`. An `UPLOAD_KEY` holder (studio, CI) additionally
    falls back to `preview/<oid>`, so an open PR's CI fetches the assets it just pushed before they are
    promoted. The public `DOWNLOAD_KEY` resolves `release/` only, keeping unreleased `preview/` art off
@@ -88,8 +89,8 @@ run would fail the LFS fetch. The recovery is a re-push of the branch, which re-
 PR's bytes signals a stale PR, and the re-push is the explicit revive.
 
 This maps onto the existing CI split (`publish.yml` is Preview Release, `release.yml` is Live Release):
-the bucket prefix is the build-lifecycle stage. `release/` only ever holds merged content, so orphans
-are structurally impossible there.
+the bucket prefix is the build-lifecycle stage, and promote runs in `release.yml` on a published
+release. `release/` only ever holds released content, so orphans are structurally impossible there.
 
 ## What goes into LFS: track by path, gate by size
 
@@ -117,8 +118,8 @@ The repo's Leak gate fails the test run on a standalone `Failed loading resource
 scenes reference files under `assets/`, so a checkout with bare LFS pointers under `assets/` would fail
 the run. Each workflow therefore needs, before its Import Project step: an `actions/cache` of LFS
 objects keyed on the pointer-file hash, then `git lfs pull --include="assets/**"` (assets only, never
-`concepts/`), authenticated by the `LFS_DOWNLOAD_KEY` Actions secret. `release.yml` and `publish.yml`
-additionally run the promote step on merge to main. New steps stay SHA-pinned, matching checkout.
+`concepts/`), authenticated by the `LFS_DOWNLOAD_KEY` Actions secret. `release.yml` additionally runs
+the promote step on a published release. New steps stay SHA-pinned, matching checkout.
 
 ## Three tracks
 


### PR DESCRIPTION
The LFS promote job fired on every push to main, moving preview bytes to release on each merge. It belongs on an actual release: the release prefix should hold released art, not every merge. This moves promote-lfs from publish.yml (push to main) to release.yml (release published), so bytes reach release only when a github release is cut. The committed download key stays release-only, so this also keeps unreleased art out of the public key's reach until release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)