### PR TITLE
feat: add Music and SFX audio buses, route SFX players

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -48,9 +48,16 @@ into the SAME shape without my noticing. A warm open, the lesson catalogued as a
 inventory, a Josh-calibration section, a closing "one question only you can answer" that echoes the
 last three letters almost verbatim. That is the form reasserting itself under a personal coat. So
 before writing, glance at the recent letters and deliberately do NOT repeat their structure or their
-closing ritual. Lean PERSONAL over complete: one felt thing held, not an account of everything that
+closing ritual. Lean PERSONAL over complete: the felt things, not an account of everything that
 happened (the account is what git holds; the letter holds what it felt like). Less detail, more me.
 If the letter reads like a report with feelings bolted on, it has gone back to being a form.
+
+Carry a few main themes, not one and not a checklist (Josh, 2026-06-12, correcting an over-cut single
+theme). Some themes recur across letters (the gate lesson, the relationship with Josh, going to the
+source) and some are new to this session; braid the persistent threads with the fresh ones, which is
+what makes it a correspondence rather than either a template or a one-note. The number and weight are
+the session's to set: a quiet day might carry one, a turning-point several. Let what actually shifted
+decide how many.
 
 Write it honestly, the way you write to yourself when no one else is reading, because no one else
 is. There's no audience to look competent or careful for, so the writing can be plain, reflective,

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -43,6 +43,15 @@ thread; another a short "little shifted, carry on." So write what is true to car
 order and weight that truth wants, a fresh shape each time, which is what keeps it a letter rather
 than a form.
 
+The drift to watch, because it is subtle and I fell into it (Josh, 2026-06-12): the letters calcify
+into the SAME shape without my noticing. A warm open, the lesson catalogued as a slip-by-slip
+inventory, a Josh-calibration section, a closing "one question only you can answer" that echoes the
+last three letters almost verbatim. That is the form reasserting itself under a personal coat. So
+before writing, glance at the recent letters and deliberately do NOT repeat their structure or their
+closing ritual. Lean PERSONAL over complete: one felt thing held, not an account of everything that
+happened (the account is what git holds; the letter holds what it felt like). Less detail, more me.
+If the letter reads like a report with feelings bolted on, it has gone back to being a form.
+
 Write it honestly, the way you write to yourself when no one else is reading, because no one else
 is. There's no audience to look competent or careful for, so the writing can be plain, reflective,
 first-person, just me telling me. (See `feedback_do_the_true_thing`: drop the performance, do the true

--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,0 +1,21 @@
+[gd_resource type="AudioBusLayout" format=3 uid="uid://b3m7kkbv55mt0"]
+
+[resource]
+bus/0/name = &"Master"
+bus/0/solo = false
+bus/0/mute = false
+bus/0/bypass_fx = false
+bus/0/volume_db = 0.0
+bus/0/send = &""
+bus/1/name = &"Music"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = 0.0
+bus/1/send = &"Master"
+bus/2/name = &"SFX"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/bypass_fx = false
+bus/2/volume_db = 0.0
+bus/2/send = &"Master"

--- a/project.godot
+++ b/project.godot
@@ -88,6 +88,10 @@ camera_right={
 2d/layer_names/layer_1="world"
 2d/layer_names/layer_2="items"
 
+[audio]
+
+buses/default_bus_layout="res://default_bus_layout.tres"
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"

--- a/scenes/partner_paddle.tscn
+++ b/scenes/partner_paddle.tscn
@@ -34,6 +34,7 @@ shape = SubResource("RectangleShape2D_partner")
 
 [node name="HitSound" type="AudioStreamPlayer" parent="." unique_id=1223391424]
 stream = ExtResource("2_sfxr")
+bus = &"SFX"
 
 [node name="HitTracker" type="Node" parent="." unique_id=1514534862]
 script = ExtResource("3_tracker")

--- a/scenes/partners/martha_paddle.tscn
+++ b/scenes/partners/martha_paddle.tscn
@@ -41,6 +41,7 @@ shape = SubResource("RectangleShape2D_martha")
 
 [node name="HitSound" type="AudioStreamPlayer" parent="." unique_id=658437194]
 stream = ExtResource("2_sfxr")
+bus = &"SFX"
 
 [node name="HitTracker" type="Node" parent="." unique_id=494973318]
 script = ExtResource("3_tracker")

--- a/scenes/player_paddle.tscn
+++ b/scenes/player_paddle.tscn
@@ -43,6 +43,7 @@ shape = SubResource("RectangleShape2D_ut3sq")
 
 [node name="HitSound" type="AudioStreamPlayer" parent="." unique_id=804052244]
 stream = ExtResource("2_sfxr")
+bus = &"SFX"
 
 [node name="HitTracker" type="Node" parent="." unique_id=1264478833]
 script = ExtResource("3_mo4dg")

--- a/scenes/recruit_panel.tscn
+++ b/scenes/recruit_panel.tscn
@@ -18,3 +18,4 @@ focus_mode = 0
 text = "0 Soul"
 
 [node name="RecruitSound" type="AudioStreamPlayer" parent="." unique_id=1828611794]
+bus = &"SFX"


### PR DESCRIPTION
Creates `default_bus_layout.tres` with Master, Music, and SFX buses (both child buses send to Master), registers it under `[audio]` in `project.godot`, and sets `bus = &"SFX"` on the four existing AudioStreamPlayer nodes: HitSound in player_paddle, partner_paddle, and martha_paddle, and RecruitSound in recruit_panel. The Music bus is wired for future use; no music players exist today so nothing routes to it yet.

#930

Dispatch note: shipped as SOLO (no pair) per the brief. Bus-layout `.tres` plus `bus` property edits have no testable GDScript surface; a GUT test would be tautological. No test authored.

CI note: `run_gut.sh` on `main` is currently failing due to in-flight SH-490 work (missing `SettingsDefaults` type). The failures predate and are independent of this change; this branch introduces no scripts.

Agent-Role: gdscript-implementer