### PR TITLE
Add OpenCode project config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ Thumbs.db
 # live-update smoke PR touch, safe to revert
 
 .godotiq/
+
+# OpenCode local config (personal memory pointer, machine-specific)
+.opencode/

--- a/.mcp.json
+++ b/.mcp.json
@@ -14,7 +14,7 @@
         "godotiq"
       ],
       "env": {
-        "GODOTIQ_PROJECT_ROOT": "/home/josh/gamedev/volley-vendetta",
+        "GODOTIQ_PROJECT_ROOT": "/home/josh/gamedev/volley",
         "GODOTIQ_ADDON_HOST": "172.30.160.1"
       }
     }

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md"
+  ],
+  "mcp": {
+    "godotiq": {
+      "type": "local",
+      "command": [
+        "uvx",
+        "godotiq"
+      ],
+      "enabled": true,
+      "environment": {
+        "GODOTIQ_PROJECT_ROOT": "/home/josh/gamedev/volley",
+        "GODOTIQ_ADDON_HOST": "172.30.160.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Wires OpenCode alongside the existing Claude setup so the repo can be driven by either. OpenCode reads its MCP servers from opencode.json rather than .mcp.json, so this adds an equivalent config: the AGENTS.md instruction and the GodotIQ server, mirrored into OpenCode's schema.

While here, the GodotIQ project root was pointing at a worktree that no longer exists (volley-vendetta); both the new config and the old .mcp.json now point at the main tree.

The personal memory-bank pointer is deliberately kept out of the committed config. A relative path to a sister repo would hard-error for anyone who does not have it checked out, so that pointer lives in a gitignored .opencode/ local config instead. Playwright is intentionally not carried over to the OpenCode config.

No new secrets: the model API key is an environment reference, not a value.