### PR TITLE
Disable OpenCode session sharing

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "share": "disabled",
   "instructions": [
     "AGENTS.md"
   ],


### PR DESCRIPTION
Locks OpenCode session sharing to disabled for this project. The default is manual (sharing only on an explicit /share), but manual still allows publishing a session to a public opncd.ai URL one command away. Given the private memory bank and the studio context that sessions can quote, this removes the possibility entirely rather than relying on never running the command by accident.

It is a restriction, safe to commit, and protects collaborators running OpenCode on the repo too.

No new secrets.