### PR TITLE
chore: allow volley-ai external directory access

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -4,6 +4,12 @@
   "instructions": [
     "AGENTS.md"
   ],
+  "permission": {
+    "external_directory": {
+      "/home/josh/gamedev/volley-ai/**": "allow",
+      "*": "ask"
+    }
+  },
   "mcp": {
     "godotiq": {
       "type": "local",


### PR DESCRIPTION
Add external_directory permission to always-allow accessing /home/josh/gamedev/volley-ai/.**