### PR TITLE
Disable native task; fix external_directory ordering

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,9 +1,17 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "share": "disabled",
+  "tools": {
+    "task": false
+  },
   "instructions": [
     "AGENTS.md"
   ],
+  "permission": {
+    "external_directory": {
+      "/home/josh/gamedev/volley-ai/**": "allow"
+    }
+  },
   "mcp": {
     "godotiq": {
       "type": "local",


### PR DESCRIPTION
Two OpenCode config fixes:

**Disable the native task tool.** The dispatcher kept reaching for OpenCode's built-in task tool over the swarm-dispatch plugin (sequential + blocking, no codenames, no reporting). tools.task: false removes the weaker default, so swarm_dispatch is the only fan-out path. Verified: the model reports task unavailable, swarm_dispatch still works.

**Fix external_directory rule ordering.** Permission rules are last-match-wins, so the *:ask catch-all (added after the volley-ai allow) was winning for volley-ai paths too, denying the dispatcher from running the memory-forest lint script in the sister repo. Dropped the catch-all; volley-ai/** is allowed, everything else uses the default. Verified: the lint script now runs.

No new secrets.