### PR TITLE
chore: permission gates, MCP servers, external dir ordering

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,13 +1,35 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "share": "disabled",
+  "tools": {
+    "task": false
+  },
   "instructions": [
     "AGENTS.md"
   ],
   "permission": {
+    "bash": {
+      "rm -rf *": "deny",
+      "rm *": "ask"
+    },
+    "linear_save_issue": "ask",
+    "linear_save_project": "ask",
+    "linear_save_comment": "ask",
+    "linear_save_document": "ask",
+    "linear_save_milestone": "ask",
+    "linear_save_initiative": "ask",
+    "linear_save_status_update": "ask",
+    "linear_delete_status_update": "ask",
+    "linear_create_issue_label": "ask",
+    "linear_delete_comment": "ask",
+    "linear_create_attachment": "ask",
+    "linear_create_attachment_from_upload": "ask",
+    "linear_delete_attachment": "ask",
     "external_directory": {
+      "*": "ask",
       "/home/josh/gamedev/volley-ai/**": "allow",
-      "*": "ask"
+      "/tmp/opencode-swarm-reports/**": "allow",
+      "/tmp/**": "allow"
     }
   },
   "mcp": {
@@ -22,6 +44,22 @@
         "GODOTIQ_PROJECT_ROOT": "/home/josh/gamedev/volley",
         "GODOTIQ_ADDON_HOST": "172.30.160.1"
       }
+    },
+    "linear": {
+      "type": "remote",
+      "url": "https://mcp.linear.app/mcp",
+      "headers": {
+        "Authorization": "Bearer {env:LINEAR_API_KEY}"
+      }
+    },
+    "context7": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
Add ask gates on Linear write ops and rm. Fix external_directory ordering (broad first). Add Linear and Context7 MCP servers. Add /tmp external directory access.