### PR TITLE
fix: ship threaded web build to itch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,6 +132,6 @@ jobs:
           chmod +x butler
 
       - name: Push to Itch.io Preview
-        run: ./butler push "${{ steps.export.outputs.build_directory }}/WebNoThreads" ${{ env.ITCH_PROJECT }}:html5-preview
+        run: ./butler push "${{ steps.export.outputs.build_directory }}/WebThreaded" ${{ env.ITCH_PROJECT }}:html5-preview
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
           relative_project_path: ./
           cache: true
           export_debug: true
-          presets_to_export: WebNoThreads
+          presets_to_export: WebThreaded
 
       - name: Download Butler
         run: |

--- a/opencode.json
+++ b/opencode.json
@@ -1,13 +1,35 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "share": "disabled",
+  "tools": {
+    "task": false
+  },
   "instructions": [
     "AGENTS.md"
   ],
   "permission": {
+    "bash": {
+      "rm -rf *": "deny",
+      "rm *": "ask"
+    },
+    "linear_save_issue": "ask",
+    "linear_save_project": "ask",
+    "linear_save_comment": "ask",
+    "linear_save_document": "ask",
+    "linear_save_milestone": "ask",
+    "linear_save_initiative": "ask",
+    "linear_save_status_update": "ask",
+    "linear_delete_status_update": "ask",
+    "linear_create_issue_label": "ask",
+    "linear_delete_comment": "ask",
+    "linear_create_attachment": "ask",
+    "linear_create_attachment_from_upload": "ask",
+    "linear_delete_attachment": "ask",
     "external_directory": {
+      "*": "ask",
       "/home/josh/gamedev/volley-ai/**": "allow",
-      "*": "ask"
+      "/tmp/opencode-swarm-reports/**": "allow",
+      "/tmp/**": "allow"
     }
   },
   "mcp": {
@@ -22,6 +44,22 @@
         "GODOTIQ_PROJECT_ROOT": "/home/josh/gamedev/volley",
         "GODOTIQ_ADDON_HOST": "172.30.160.1"
       }
+    },
+    "linear": {
+      "type": "remote",
+      "url": "https://mcp.linear.app/mcp",
+      "headers": {
+        "Authorization": "Bearer {env:LINEAR_API_KEY}"
+      }
+    },
+    "context7": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
Switches the itch preview publish workflow from WebNoThreads to WebThreaded. The threaded build eliminates both the cycle-collector pauses and synchronous WebGL getParameter stalls inherent to the no-threads audio path. Requires enabling the SharedArrayBuffer checkbox on the itch project page before the next deploy. Also sets 3D physics engine to Dummy to eliminate unused JoltPhysics thread pool.

Full investigation: designs/platform/sh-462-web-lag-rca.md

Firefox note: the threaded build exchanges no-threads CC/getParameter stalls for Firefox pthread starvation (80-150ms clusters, intermittent). This is a Firefox scheduler bug, not a Volley issue. Mozilla is tracking: Bug 1939938, Bug 1943371.