### PR TITLE
fix: guard null court_config.physics in exports

### DIFF
--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -81,6 +81,8 @@ func _ready() -> void:
 		_item_manager = ItemManager
 	if court_config == null:
 		court_config = load("res://scripts/core/court_config.gd").new()
+	if court_config.physics == null:
+		court_config.physics = load("res://scripts/core/court_physics.gd").new()
 
 	ball_world_max_speed = court_config.world_max_speed()
 	min_speed = Stats.resolve(GameRules.base.ball_speed_min, &"ball_speed_min", _item_manager)


### PR DESCRIPTION
court_config.tres has no physics property. In exported builds this resolves to null, breaking the ball arc (straight line into the sky). Add a null guard in ball._ready() that creates the default CourtPhysics.