### PR TITLE
fix: guard court_config.physics in _enter_arc

### DIFF
--- a/resources/court_config.tres
+++ b/resources/court_config.tres
@@ -1,7 +1,14 @@
 [gd_resource type="Resource" script_class="CourtConfig" format=3 uid="uid://b66666sh366cc"]
 
 [ext_resource type="Script" uid="uid://c4ayxy1m7fhfn" path="res://scripts/core/court_config.gd" id="1_courtcfg"]
+[ext_resource type="Script" uid="uid://euer3rnvxfi3" path="res://scripts/core/court_physics.gd" id="2_physics"]
+
+[sub_resource type="Resource" id="CourtPhysics"]
+script = ExtResource("2_physics")
+arc_bend = 600.0
+arc_height_max = 220.0
 
 [resource]
 script = ExtResource("1_courtcfg")
+physics = SubResource("CourtPhysics")
 court_width = 600.0

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -81,8 +81,6 @@ func _ready() -> void:
 		_item_manager = ItemManager
 	if court_config == null:
 		court_config = load("res://scripts/core/court_config.gd").new()
-	if court_config.physics == null:
-		court_config.physics = load("res://scripts/core/court_physics.gd").new()
 
 	ball_world_max_speed = court_config.world_max_speed()
 	min_speed = Stats.resolve(GameRules.base.ball_speed_min, &"ball_speed_min", _item_manager)
@@ -133,6 +131,8 @@ func _update_play_state() -> void:
 func _enter_arc() -> void:
 	# No engine gravity above the bound; the court's arc rule supplies the downward bend instead.
 	gravity_scale = 0.0
+	if court_config.physics == null:
+		court_config.physics = load("res://scripts/core/court_physics.gd").new()
 	_arc_acceleration = court_config.physics.arc_acceleration(-linear_velocity.y)
 	set_play_state(PlayState.PLAY_ARC)
 


### PR DESCRIPTION
BallTracker.attach() overwrites ball.court_config after _ready(), undoing the null guard there. Move the guard into _enter_arc() where it actually runs at crash time.