### PR TITLE
feat: raise physics tick to 120Hz and retune AI for doubled rate

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -85,6 +85,7 @@ camera_right={
 
 [physics]
 
+common/physics_ticks_per_second=120
 3d/physics_engine="Dummy"
 2d/layer_names/layer_1="world"
 2d/layer_names/layer_2="items"

--- a/resources/partner_ai_config.tres
+++ b/resources/partner_ai_config.tres
@@ -4,6 +4,6 @@
 
 [resource]
 script = ExtResource("1")
-reaction_delay_frames = 8
+reaction_delay_frames = 16
 speed_scale = 1.2
 noise = 10.0

--- a/resources/shop/shop_drag_tuning.tres
+++ b/resources/shop/shop_drag_tuning.tres
@@ -6,5 +6,5 @@
 script = ExtResource("1_tuning")
 drag_threshold_px = 2.0
 settle_velocity_threshold = 4.0
-settle_frames_required = 6
+settle_frames_required = 12
 max_lifetime_s = 4.0

--- a/scripts/core/paddle_ai_config.gd
+++ b/scripts/core/paddle_ai_config.gd
@@ -3,7 +3,7 @@ extends Resource
 
 @export_group("Tracking")
 ## Frames of latency between seeing the ball and reacting.
-@export var reaction_delay_frames: int = 10
+@export var reaction_delay_frames: int = 20
 ## Movement speed as a multiplier of paddle speed. Below 1.0 = slower, above 1.0 = faster.
 @export var speed_scale: float = 0.75
 
@@ -14,10 +14,10 @@ extends Resource
 
 @export_group("Feel")
 ## Lerp factor for velocity changes while tracking (0 = frozen, 1 = instant).
-@export_range(0.01, 1.0) var velocity_smoothing: float = 0.08
+@export_range(0.01, 1.0) var velocity_smoothing: float = 0.04
 ## Drift speed as a fraction of tracking speed when ball is moving away.
 @export var center_drift_scale: float = 0.25
 ## Lerp factor for drift velocity changes.
-@export_range(0.01, 1.0) var center_drift_smoothing: float = 0.05
+@export_range(0.01, 1.0) var center_drift_smoothing: float = 0.025
 ## Pixels within which the paddle stops tracking to prevent jitter.
 @export var snap_threshold: float = 8.0

--- a/scripts/shop/shop_drag_tuning.gd
+++ b/scripts/shop/shop_drag_tuning.gd
@@ -10,7 +10,7 @@ extends Resource
 @export var settle_velocity_threshold: float = 4.0
 
 ## Consecutive slow frames required before notify_body_settled fires.
-@export var settle_frames_required: int = 6
+@export var settle_frames_required: int = 12
 
 ## Hard time cap; a runaway body resolves on this even if velocity never falls below the threshold.
 @export var max_lifetime_s: float = 4.0

--- a/scripts/shop/shop_item_drop.gd
+++ b/scripts/shop/shop_item_drop.gd
@@ -23,7 +23,7 @@ func _physics_process(delta: float) -> void:
 		return
 
 	var velocity_threshold: float = tuning.settle_velocity_threshold if tuning != null else 4.0
-	var frames_required: int = tuning.settle_frames_required if tuning != null else 6
+	var frames_required: int = tuning.settle_frames_required if tuning != null else 12
 	var lifetime_cap: float = tuning.max_lifetime_s if tuning != null else 4.0
 
 	_elapsed += delta

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -12,7 +12,7 @@ const PADDLE_HALF_HEIGHT: float = 27.0
 # Large enough that descent (1200 px/s over ~440 px) and the horizontal walk
 # (200 px at 400 px/s) each finish in a single step; the controller clamps.
 const VIRTUAL_DELTA: float = 0.6
-const MAX_STEPS: int = 32
+const MAX_STEPS: int = 64
 
 var _paddle: Paddle
 var _controller: TimeoutController


### PR DESCRIPTION
Doubles physics_ticks_per_second from the default 60 to 120 via project.godot. Halves frame-dependent AI smoothing values and doubles reaction delay frame counts so the real-time feel matches the 60Hz baseline.

- project.godot: common/physics_ticks_per_second = 120
- PaddleAIConfig defaults: reaction_delay_frames 10→20, velocity_smoothing 0.08→0.04, center_drift_smoothing 0.05→0.025
- partner_ai_config.tres: reaction_delay_frames 8→16
- test_timeout_controller.gd: MAX_STEPS 32→64 (displacement per move_and_slide call halved at 120Hz)