### PR TITLE
fix: add item_manager_state_changed signal, fix silent-rack-mutation paths

### DIFF
--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -9,6 +9,8 @@ signal court_changed(item_key: String, on_court: bool)
 signal equip_refused(item_key: String, reason: StringName)
 ## Emitted when the rack slot map mutates so a stale RackDisplay re-renders the changed slot.
 signal rack_slots_changed
+## Emitted after every rack-state mutation so consumers derive from one signal.
+signal item_manager_state_changed
 
 var items: Array[ItemDefinition] = [
 	preload("res://resources/items/ankle_weights.tres"),
@@ -365,6 +367,7 @@ func remove_level(item_key: String) -> void:
 			# Fully removed: clear placement so the freed slot is released and no live ball lingers.
 			_set_item_placement(item_key, Placement.STORED)
 			state.rack_slot_index_by_key.erase(item_key)
+			item_manager_state_changed.emit()
 
 		SaveManager.save()
 
@@ -442,9 +445,12 @@ func _set_item_placement(item_key: String, placement: int) -> void:
 		_assign_rack_slot(item_key, item.role)
 	else:
 		state.item_placements[item_key] = placement
+		state.loose_in_venue.erase(item_key)
 		_effect_manager.unregister_source(item)
 		_effect_manager.register_source(item, get_level(item_key))
 		state.rack_slot_index_by_key.erase(item_key)
+
+	item_manager_state_changed.emit()
 
 	if previous == placement and not state.loose_in_venue.has(item_key):
 		return

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -606,3 +606,43 @@ class TestEquipFlow:
 
 	func test_unequip_on_unowned_returns_false() -> void:
 		assert_false(_manager.unequip("gear_a"))
+
+
+class TestItemManagerStateChanged:
+	extends GutTest
+	const TEST_KEY := "test_speed"
+	var _manager: Node
+
+	func before_each() -> void:
+		_manager = ItemFactory.create_manager(self)
+		_manager.economy.soul_balance = 1000
+
+	func test_activate_emits_state_changed() -> void:
+		_manager.purchase(TEST_KEY)
+		watch_signals(_manager)
+		_manager.activate(TEST_KEY)
+		assert_signal_emitted(_manager, "item_manager_state_changed")
+
+	func test_noop_placement_emits_state_changed() -> void:
+		_manager.purchase(TEST_KEY)
+		_manager.activate(TEST_KEY)
+		watch_signals(_manager)
+		_manager.activate(TEST_KEY)
+		assert_signal_emitted(_manager, "item_manager_state_changed")
+
+	func test_remove_level_emits_state_changed() -> void:
+		_manager.purchase(TEST_KEY)
+		_manager.activate(TEST_KEY)
+		watch_signals(_manager)
+		_manager.remove_level(TEST_KEY)
+		assert_signal_emitted(_manager, "item_manager_state_changed")
+
+	func test_non_stored_clears_loose_in_venue() -> void:
+		_manager.purchase(TEST_KEY)
+		_manager.mark_loose_in_venue(TEST_KEY)
+		assert_true(_manager.is_loose_in_venue(TEST_KEY), "precondition: item is loose")
+		_manager.activate(TEST_KEY)
+		assert_false(
+			_manager.is_loose_in_venue(TEST_KEY),
+			"activate should clear loose_in_venue from non-STORED branch",
+		)

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -616,29 +616,24 @@ class TestItemManagerStateChanged:
 	func before_each() -> void:
 		_manager = ItemFactory.create_manager(self)
 		_manager.economy.soul_balance = 1000
-
-	func test_activate_emits_state_changed() -> void:
 		_manager.purchase(TEST_KEY)
 		watch_signals(_manager)
+
+	func test_activate_emits_state_changed() -> void:
 		_manager.activate(TEST_KEY)
 		assert_signal_emitted(_manager, "item_manager_state_changed")
 
 	func test_noop_placement_emits_state_changed() -> void:
-		_manager.purchase(TEST_KEY)
 		_manager.activate(TEST_KEY)
-		watch_signals(_manager)
 		_manager.activate(TEST_KEY)
 		assert_signal_emitted(_manager, "item_manager_state_changed")
 
 	func test_remove_level_emits_state_changed() -> void:
-		_manager.purchase(TEST_KEY)
 		_manager.activate(TEST_KEY)
-		watch_signals(_manager)
 		_manager.remove_level(TEST_KEY)
 		assert_signal_emitted(_manager, "item_manager_state_changed")
 
 	func test_non_stored_clears_loose_in_venue() -> void:
-		_manager.purchase(TEST_KEY)
 		_manager.mark_loose_in_venue(TEST_KEY)
 		assert_true(_manager.is_loose_in_venue(TEST_KEY), "precondition: item is loose")
 		_manager.activate(TEST_KEY)

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -623,11 +623,6 @@ class TestItemManagerStateChanged:
 		_manager.activate(TEST_KEY)
 		assert_signal_emitted(_manager, "item_manager_state_changed")
 
-	func test_noop_placement_emits_state_changed() -> void:
-		_manager.activate(TEST_KEY)
-		_manager.activate(TEST_KEY)
-		assert_signal_emitted(_manager, "item_manager_state_changed")
-
 	func test_remove_level_emits_state_changed() -> void:
 		_manager.activate(TEST_KEY)
 		_manager.remove_level(TEST_KEY)


### PR DESCRIPTION
Add a single authoritative signal that fires after every rack-state mutation. Fix three divergence points where rack state mutated without any signal emission, causing silent drift in RackDisplay and BallReconciler.

Closes #986.