### PR TITLE
chore: deny python in bash permission gates

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -23,6 +23,7 @@
       "git branch *-D *": "deny",
       "rm -rf *": "deny",
       "rm *": "ask",
+      "python*": "deny",
       "*linear.app/graphql*issueCreate*": "ask",
       "*linear.app/graphql*issueUpdate*": "ask"
     },


### PR DESCRIPTION
Blocks python usage via opencode.json bash permission gates. Linear API calls should use the MCP tools instead.