### PR TITLE
refactor: raycast ground detection with debug visual

### DIFF
--- a/scenes/partner_paddle.tscn
+++ b/scenes/partner_paddle.tscn
@@ -45,10 +45,12 @@ paddle = NodePath("..")
 config = ExtResource("5_config")
 
 [node name="RacketHitbox" type="Area2D" parent="." unique_id=1941554357]
-position = Vector2(0, 0)
 collision_layer = 8
 collision_mask = 2
 monitorable = false
 
 [node name="Collision" type="CollisionShape2D" parent="RacketHitbox" unique_id=609635293]
 shape = SubResource("RectangleShape2D_oowu5")
+
+[node name="GroundRay" type="RayCast2D" parent="." unique_id=723421864]
+position = Vector2(0, 90)

--- a/scenes/partner_paddle.tscn
+++ b/scenes/partner_paddle.tscn
@@ -1,19 +1,20 @@
 [gd_scene format=3 uid="uid://c8vg5tk3iklpe"]
 
 [ext_resource type="Script" uid="uid://bqd7j26158kap" path="res://scripts/entities/partner_paddle.gd" id="1_unscj"]
+[ext_resource type="SpriteFrames" uid="uid://bmartha01anim" path="res://resources/animations/martha.tres" id="2_bmne2"]
 [ext_resource type="AudioStream" uid="uid://c3n0vt2mith7b" path="res://assets/sfx/paddle_hit_3_clean_tick.sfxr" id="2_sfxr"]
+[ext_resource type="Texture2D" uid="uid://c833m4yxk2atr" path="res://assets/art/martha_bow.svg" id="3_kpkwm"]
 [ext_resource type="Script" uid="uid://c8iymx66khaof" path="res://scripts/core/hit_tracker.gd" id="3_tracker"]
 [ext_resource type="Script" uid="uid://deu5sl253eppb" path="res://scripts/core/partner_ai_controller.gd" id="4_ai"]
 [ext_resource type="Resource" uid="uid://81y01va0025a" path="res://resources/partner_ai_config.tres" id="5_config"]
-[ext_resource type="SpriteFrames" uid="uid://bpartner1anim" path="res://resources/animations/partner.tres" id="6_partnerframes"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_partner"]
-size = Vector2(36, 180)
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_martha"]
+size = Vector2(24, 60)
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_oowu5"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_ts58t"]
 size = Vector2(24, 65)
 
-[node name="PartnerPaddle" type="CharacterBody2D" unique_id=775348359 node_paths=PackedStringArray("controller", "hit_sound", "collision", "sprite", "tracker", "racket_hitbox", "racket_shape")]
+[node name="MarthaPaddle" type="CharacterBody2D" unique_id=1428462700 node_paths=PackedStringArray("controller", "hit_sound", "collision", "sprite", "tracker", "racket_hitbox", "racket_shape")]
 collision_layer = 16
 script = ExtResource("1_unscj")
 controller = NodePath("PartnerAIController")
@@ -25,32 +26,38 @@ racket_hitbox = NodePath("RacketHitbox")
 racket_shape = NodePath("RacketHitbox/Collision")
 metadata/_edit_group_ = true
 
-[node name="Sprite" type="AnimatedSprite2D" parent="." unique_id=1878723155]
-sprite_frames = ExtResource("6_partnerframes")
+[node name="Sprite" type="AnimatedSprite2D" parent="." unique_id=2081878131]
+sprite_frames = ExtResource("2_bmne2")
 animation = &""
 
-[node name="Collision" type="CollisionShape2D" parent="." unique_id=712647188]
-shape = SubResource("RectangleShape2D_partner")
+[node name="Bow" type="Sprite2D" parent="." unique_id=708370465]
+position = Vector2(8.4, -24)
+rotation = 0.436
+scale = Vector2(0.6, 0.6)
+texture = ExtResource("3_kpkwm")
 
-[node name="HitSound" type="AudioStreamPlayer" parent="." unique_id=1223391424]
+[node name="Collision" type="CollisionShape2D" parent="." unique_id=746316974]
+shape = SubResource("RectangleShape2D_martha")
+
+[node name="HitSound" type="AudioStreamPlayer" parent="." unique_id=658437194]
 stream = ExtResource("2_sfxr")
 bus = &"SFX"
 
-[node name="HitTracker" type="Node" parent="." unique_id=1514534862]
+[node name="HitTracker" type="Node" parent="." unique_id=494973318]
 script = ExtResource("3_tracker")
 
-[node name="PartnerAIController" type="Node" parent="." unique_id=1081215246 node_paths=PackedStringArray("paddle")]
+[node name="PartnerAIController" type="Node" parent="." unique_id=1117076276 node_paths=PackedStringArray("paddle")]
 script = ExtResource("4_ai")
 paddle = NodePath("..")
 config = ExtResource("5_config")
 
-[node name="RacketHitbox" type="Area2D" parent="." unique_id=1941554357]
+[node name="RacketHitbox" type="Area2D" parent="." unique_id=1340017728]
 collision_layer = 8
 collision_mask = 2
 monitorable = false
 
-[node name="Collision" type="CollisionShape2D" parent="RacketHitbox" unique_id=609635293]
-shape = SubResource("RectangleShape2D_oowu5")
+[node name="Collision" type="CollisionShape2D" parent="RacketHitbox" unique_id=994213533]
+shape = SubResource("RectangleShape2D_ts58t")
 
-[node name="GroundRay" type="RayCast2D" parent="." unique_id=723421864]
-position = Vector2(0, 90)
+[node name="GroundRay" type="RayCast2D" parent="." unique_id=253019722]
+position = Vector2(0, 30)

--- a/scenes/partners/martha_paddle.tscn
+++ b/scenes/partners/martha_paddle.tscn
@@ -52,10 +52,12 @@ paddle = NodePath("..")
 config = ExtResource("5_config")
 
 [node name="RacketHitbox" type="Area2D" parent="." unique_id=1340017728]
-position = Vector2(0, 0)
 collision_layer = 8
 collision_mask = 2
 monitorable = false
 
 [node name="Collision" type="CollisionShape2D" parent="RacketHitbox" unique_id=994213533]
 shape = SubResource("RectangleShape2D_ts58t")
+
+[node name="GroundRay" type="RayCast2D" parent="." unique_id=253019722]
+position = Vector2(0, 30)

--- a/scenes/partners/martha_paddle.tscn
+++ b/scenes/partners/martha_paddle.tscn
@@ -61,3 +61,4 @@ shape = SubResource("RectangleShape2D_ts58t")
 
 [node name="GroundRay" type="RayCast2D" parent="." unique_id=253019722]
 position = Vector2(0, 30)
+target_position = Vector2(0, 10)

--- a/scenes/player_paddle.tscn
+++ b/scenes/player_paddle.tscn
@@ -6,231 +6,15 @@
 [ext_resource type="SpriteFrames" uid="uid://bsam001anim01" path="res://resources/animations/sam.tres" id="4_samframes"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ut3sq"]
-size = Vector2(90, 208)
+size = Vector2(90, 201.715)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_drop"]
 size = Vector2(90, 283)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_k7j1o"]
-size = Vector2(21, 64)
+size = Vector2(21, 94.325)
 
-[sub_resource type="Animation" id="Animation_kkbar"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BodyCollision:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(-8, 22.5)]
-}
-
-[sub_resource type="Animation" id="Animation_k7j1o"]
-length = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BodyCollision:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(-8, 22.5)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("BodyCollision:shape:size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(90, 201.715)]
-}
-
-[sub_resource type="Animation" id="Animation_optai"]
-length = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BodyCollision:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(-8, 22.5)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("BodyCollision:shape:size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(90, 201.715)]
-}
-
-[sub_resource type="Animation" id="Animation_qaqj4"]
-length = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BodyCollision:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(-8, 22.5)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("BodyCollision:shape:size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(90, 201.715)]
-}
-
-[sub_resource type="Animation" id="Animation_8ruhj"]
-length = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BodyCollision:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(-8, 12.92)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("BodyCollision:shape:size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(90, 208)]
-}
-
-[sub_resource type="Animation" id="Animation_sm6h2"]
-length = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BodyCollision:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(-8, 22.5)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("BodyCollision:shape:size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(90, 201.715)]
-}
-
-[sub_resource type="Animation" id="Animation_oty7i"]
-length = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BodyCollision:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(-8, 22.5)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("BodyCollision:shape:size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(90, 201.715)]
-}
-
-[sub_resource type="Animation" id="Animation_lsgr"]
-length = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BodyCollision:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(-8, 12.92)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("BodyCollision:shape:size")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector2(90, 208)]
-}
-
-[sub_resource type="AnimationLibrary" id="AnimationLibrary_kkbar"]
-_data = {
-&"RESET": SubResource("Animation_kkbar"),
-&"flying_down": SubResource("Animation_k7j1o"),
-&"flying_up": SubResource("Animation_optai"),
-&"ready_flying": SubResource("Animation_qaqj4"),
-&"ready_grounded": SubResource("Animation_8ruhj"),
-&"swing_flying": SubResource("Animation_sm6h2"),
- &"swing_grounded": SubResource("Animation_oty7i"),
-&"low_swing_grounded": SubResource("Animation_lsgr")
-}
-
-[node name="PlayerPaddle" type="CharacterBody2D" unique_id=1437655624 node_paths=PackedStringArray("hit_sound", "collision", "sprite", "tracker", "racket_hitbox", "racket_shape", "animation_player")]
+[node name="PlayerPaddle" type="CharacterBody2D" unique_id=1437655624 node_paths=PackedStringArray("hit_sound", "collision", "sprite", "tracker", "racket_hitbox", "racket_shape", "ground_ray")]
 collision_layer = 16
 script = ExtResource("1_mo4dg")
 hit_sound = NodePath("HitSound")
@@ -239,13 +23,13 @@ sprite = NodePath("Sprite")
 tracker = NodePath("HitTracker")
 racket_hitbox = NodePath("RacketHitbox")
 racket_shape = NodePath("RacketHitbox/RacketCollision")
-animation_player = NodePath("AnimationPlayer")
+ground_ray = NodePath("GroundRay")
 metadata/_edit_group_ = true
 
 [node name="Sprite" type="AnimatedSprite2D" parent="." unique_id=955212656]
 scale = Vector2(0.245, 0.245)
 sprite_frames = ExtResource("4_samframes")
-animation = &"ready_flying"
+animation = &"flying_up"
 
 [node name="AnkleAnchor" type="Node2D" parent="." unique_id=2001000001]
 position = Vector2(0, 24)
@@ -257,7 +41,7 @@ position = Vector2(-12, 0)
 position = Vector2(-12, -10)
 
 [node name="BodyCollision" type="CollisionShape2D" parent="." unique_id=1850417808]
-position = Vector2(-8, 22.5)
+position = Vector2(-8, 5.595)
 shape = SubResource("RectangleShape2D_ut3sq")
 
 [node name="HitSound" type="AudioStreamPlayer" parent="." unique_id=804052244]
@@ -268,6 +52,7 @@ bus = &"SFX"
 script = ExtResource("3_mo4dg")
 
 [node name="CharacterDropTarget" type="Area2D" parent="." unique_id=2001000010]
+visible = false
 collision_layer = 0
 collision_mask = 0
 input_pickable = false
@@ -277,7 +62,8 @@ position = Vector2(-8, 22.5)
 shape = SubResource("RectangleShape2D_drop")
 
 [node name="RacketHitbox" type="Area2D" parent="." unique_id=2060046537]
-position = Vector2(8, 0)
+visible = false
+position = Vector2(8, -39.04)
 collision_layer = 8
 collision_mask = 2
 monitorable = false
@@ -285,5 +71,6 @@ monitorable = false
 [node name="RacketCollision" type="CollisionShape2D" parent="RacketHitbox" unique_id=1404787416]
 shape = SubResource("RectangleShape2D_k7j1o")
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=238864905]
-libraries/ = SubResource("AnimationLibrary_kkbar")
+[node name="GroundRay" type="RayCast2D" parent="." unique_id=394874363]
+position = Vector2(-48, 96)
+target_position = Vector2(0, 10)

--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -114,7 +114,7 @@ func _half_height() -> float:
 
 # Either descend first (airborne) or skip straight to the horizontal walk (already on floor).
 func _begin_walk_off() -> void:
-	if main_character.is_grounded():
+	if main_character.is_on_floor():
 		_start_horizontal_walk(_equip_pose_x, _on_reached_equip_pose, State.WALKING_OFF)
 	else:
 		_state = State.DESCENDING
@@ -156,7 +156,7 @@ func _physics_process(delta: float) -> void:
 func _step_descent(_delta: float) -> void:
 	main_character.velocity = Vector2(0.0, config.descent_speed)
 	main_character.move_and_slide()
-	if main_character.is_grounded():
+	if main_character.is_on_floor():
 		main_character.velocity = Vector2.ZERO
 		_start_horizontal_walk(_equip_pose_x, _on_reached_equip_pose, State.WALKING_OFF)
 

--- a/scripts/core/timeout_controller.gd
+++ b/scripts/core/timeout_controller.gd
@@ -76,6 +76,7 @@ func call_timeout() -> void:
 	_saved_collision_mask = main_character.collision_mask
 	main_character.set_collision_mask_value(2, false)
 	main_character.drive_blocked = true
+	main_character.set_body_collision_enabled(true)
 	timeout_started.emit()
 	_begin_walk_off()
 
@@ -113,7 +114,7 @@ func _half_height() -> float:
 
 # Either descend first (airborne) or skip straight to the horizontal walk (already on floor).
 func _begin_walk_off() -> void:
-	if main_character.is_on_floor():
+	if main_character.is_grounded():
 		_start_horizontal_walk(_equip_pose_x, _on_reached_equip_pose, State.WALKING_OFF)
 	else:
 		_state = State.DESCENDING
@@ -155,7 +156,7 @@ func _physics_process(delta: float) -> void:
 func _step_descent(_delta: float) -> void:
 	main_character.velocity = Vector2(0.0, config.descent_speed)
 	main_character.move_and_slide()
-	if main_character.is_on_floor():
+	if main_character.is_grounded():
 		main_character.velocity = Vector2.ZERO
 		_start_horizontal_walk(_equip_pose_x, _on_reached_equip_pose, State.WALKING_OFF)
 
@@ -216,5 +217,6 @@ func _finish_at_lane() -> void:
 		main_character.velocity = Vector2.ZERO
 		main_character.collision_mask = _saved_collision_mask
 		main_character.drive_blocked = false
+		main_character.set_body_collision_enabled(false)
 		main_character.set_physics_process(true)
 	timeout_ended.emit()

--- a/scripts/entities/collider_overlay.gd
+++ b/scripts/entities/collider_overlay.gd
@@ -12,6 +12,9 @@ var _body_offset: Vector2 = Vector2.ZERO
 var _racket_size: Vector2 = Vector2.ZERO
 var _racket_offset: Vector2 = Vector2.ZERO
 
+var _show_ground_ray: bool = false
+var _ray_node: RayCast2D = null
+
 
 func set_body_active(active: bool) -> void:
 	_body_active = active
@@ -33,6 +36,17 @@ func set_shapes(
 	queue_redraw()
 
 
+func set_ray_visible(visible: bool, ray_node: RayCast2D) -> void:
+	_show_ground_ray = visible
+	_ray_node = ray_node
+	queue_redraw()
+
+
+func tick_ray_draw() -> void:
+	if _show_ground_ray:
+		queue_redraw()
+
+
 func _draw() -> void:
 	if _body_active and _body_size != Vector2.ZERO:
 		draw_rect(Rect2(_body_offset - _body_size * 0.5, _body_size), Color(0.2, 0.6, 1.0, 0.35))
@@ -41,3 +55,10 @@ func _draw() -> void:
 		draw_rect(
 			Rect2(_racket_offset - _racket_size * 0.5, _racket_size), Color(1.0, 0.4, 0.2, 0.5)
 		)
+
+	if _show_ground_ray and is_instance_valid(_ray_node):
+		var colliding: bool = _ray_node.is_colliding()
+		var colour := Color.GREEN if colliding else Color.RED
+		var origin := _ray_node.position
+		var end := origin + Vector2(0.0, _ray_node.target_position.y)
+		draw_line(origin, end, colour, 2.0)

--- a/scripts/entities/paddle.gd
+++ b/scripts/entities/paddle.gd
@@ -5,8 +5,6 @@ extends CharacterBody2D
 signal paddle_hit(ball: Ball)
 
 const PADDLE_TOP_Y := -540.0
-## Slack in pixels for the grounded test; the foot counts as on the floor within this of the surface.
-const GROUNDED_EPSILON := 2.0
 ## Gap in pixels between the paddle's top edge and the dev state label sitting above it.
 const STATE_LABEL_GAP := 8.0
 
@@ -18,7 +16,7 @@ const STATE_LABEL_GAP := 8.0
 @export var racket_hitbox: Area2D
 ## The racket's RectangleShape2D, owning the contact-offset half-height.
 @export var racket_shape: CollisionShape2D
-@export var animation_player: AnimationPlayer
+@export var ground_ray: RayCast2D
 
 ## Set by TimeoutController during the walk; suppresses drive() so controllers don't fight the pose.
 var drive_blocked: bool = false
@@ -30,14 +28,10 @@ var _paddle_speed: float = 0.0
 var _body_shape: RectangleShape2D
 var _racket_shape: RectangleShape2D
 
-## World Y of the floor's top surface, resolved at ready from the floor group. NAN until found.
-var _floor_surface_y: float = NAN
 ## Previous frame's Y, used to derive actual vertical motion so the state reflects real movement
 ## (driven, timeout-controlled, or at rest) rather than the stale velocity member.
 var _last_y: float = 0.0
 var _vertical_motion: float = 0.0
-var _was_grounded: bool = false
-
 var _sprite_width_scale: float = 1.0
 var _collider_overlay: ColliderOverlay
 var _state_label: Label
@@ -60,7 +54,12 @@ func _ready() -> void:
 	if racket_hitbox != null:
 		racket_hitbox.body_entered.connect(_on_racket_body_entered)
 
-	_resolve_floor_surface()
+	if ground_ray == null:
+		ground_ray = get_node_or_null("GroundRay") as RayCast2D
+
+	if collision != null:
+		collision.disabled = true
+
 	_last_y = global_position.y
 
 	_collider_overlay = ColliderOverlay.new()
@@ -144,6 +143,9 @@ func reset_streak() -> void:
 func drive(velocity_y: float) -> void:
 	if drive_blocked:
 		return
+	if velocity_y > 0.0 and is_grounded():
+		velocity = Vector2.ZERO
+		return
 
 	velocity = Vector2(0.0, velocity_y)
 	move_and_slide()
@@ -158,6 +160,8 @@ func clamp_to_arena() -> void:
 func _physics_process(delta: float) -> void:
 	_physics_move(delta)
 	tick_animation_state()
+	if _collider_overlay != null:
+		_collider_overlay.tick_ray_draw()
 
 
 func _physics_move(_delta: float) -> void:
@@ -186,39 +190,10 @@ func get_movement_state() -> StringName:
 	return _animation_state_machine.get_state()
 
 
-# Finds the floor (a StaticBody in the "floor" group) and records its top-surface world Y. The paddle
-# slides on a code-clamped lane with no gravity, so is_on_floor() is unreliable; grounded is a
-# position test against this line instead. Leaves _floor_surface_y as NAN if no floor is present.
-func _resolve_floor_surface() -> void:
-	var floors: Array = get_tree().get_nodes_in_group(&"floor")
-	if floors.is_empty():
-		return
-	var floor_body: Node2D = floors[0] as Node2D
-	if floor_body == null:
-		return
-	var half: float = 0.0
-	for child in floor_body.get_children():
-		if child is CollisionShape2D and (child as CollisionShape2D).shape is RectangleShape2D:
-			half = ((child as CollisionShape2D).shape as RectangleShape2D).size.y * 0.5
-			break
-	_floor_surface_y = floor_body.global_position.y - half
-
-
-# Grounded when the paddle's foot (centre plus the BODY half-height, i.e. the sprite extent, not the
-# small racket zone) has reached the floor surface. With no resolved floor line (no floor in the
-# scene, e.g. a bare unit test) the paddle is treated as flying.
-func _is_grounded() -> bool:
-	if is_nan(_floor_surface_y):
-		_was_grounded = false
-		return false
-	var foot_offset: float = 0.0
-	if _body_shape != null:
-		foot_offset = _body_shape.size.y * 0.5 + collision.position.y
-	var grounded: bool = global_position.y + foot_offset >= _floor_surface_y - GROUNDED_EPSILON
-	if not grounded and _was_grounded:
-		grounded = global_position.y + foot_offset >= _floor_surface_y - GROUNDED_EPSILON * 4
-	_was_grounded = grounded
-	return grounded
+func is_grounded() -> bool:
+	if ground_ray == null:
+		return super.is_on_floor()
+	return ground_ray.is_colliding()
 
 
 func _ensure_animation_state_machine() -> void:
@@ -232,7 +207,7 @@ func _ensure_animation_state_machine() -> void:
 ## Updates the animation state machine and plays any new state.
 func _update_animation_state() -> void:
 	_ensure_animation_state_machine()
-	var grounded: bool = _is_grounded()
+	var grounded: bool = is_grounded()
 	_animation_state_machine.update(grounded, _vertical_motion, _is_crouching())
 
 
@@ -245,15 +220,12 @@ func _on_animation_state_changed(state: StringName) -> void:
 	):
 		sprite.play(state)
 
-	if animation_player != null and animation_player.has_animation(state):
-		animation_player.play(state)
-
 
 ## Handles the paddle_hit signal to initiate the swing animation.
 func _on_paddle_hit_for_swing(_ball: Ball) -> void:
 	_ensure_animation_state_machine()
 
-	var grounded: bool = _is_grounded()
+	var grounded: bool = is_grounded()
 	_animation_state_machine.on_hit(grounded, _vertical_motion, _is_crouching())
 
 	if sprite != null and not sprite.animation_finished.is_connected(_on_swing_finished):
@@ -265,7 +237,7 @@ func _on_swing_finished() -> void:
 	if _animation_state_machine == null:
 		return
 
-	var grounded: bool = _is_grounded()
+	var grounded: bool = is_grounded()
 	_animation_state_machine.on_swing_finished(grounded, _vertical_motion)
 
 
@@ -335,11 +307,22 @@ func set_racket_height(height: float) -> void:
 
 
 # Toggles the body-collider overlay independently of the racket, drawn above the sprite.
+func set_body_collision_enabled(enabled: bool) -> void:
+	if collision != null:
+		collision.disabled = not enabled
+
+
 func set_body_collider_visible(shown: bool) -> void:
 	if _collider_overlay == null:
 		return
 	_refresh_overlay_shapes()
 	_collider_overlay.set_body_active(shown)
+
+
+func set_ground_ray_visible(shown: bool) -> void:
+	if _collider_overlay == null:
+		return
+	_collider_overlay.set_ray_visible(shown, ground_ray)
 
 
 # Toggles the racket-collider overlay independently of the body, drawn above the sprite.

--- a/scripts/entities/player_paddle.gd
+++ b/scripts/entities/player_paddle.gd
@@ -13,6 +13,9 @@ func _ready() -> void:
 
 func _physics_move(_delta: float) -> void:
 	var direction := Input.get_axis("paddle_up", "paddle_down")
+	if direction > 0.0 and is_grounded():
+		velocity = Vector2.ZERO
+		return
 	velocity = Vector2(0.0, direction * _paddle_speed)
 	move_and_slide()
 	position.x = _lane_x
@@ -21,7 +24,7 @@ func _physics_move(_delta: float) -> void:
 	if racket_hitbox == null or _body_shape == null or _racket_shape == null:
 		return
 
-	if _is_grounded() and Input.is_action_pressed("paddle_down"):
+	if is_grounded() and Input.is_action_pressed("paddle_down"):
 		racket_hitbox.position.y = (
 			collision.position.y + _body_shape.size.y * 0.5 - _racket_shape.size.y * 0.5
 		)
@@ -32,4 +35,4 @@ func _physics_move(_delta: float) -> void:
 
 
 func _is_crouching() -> bool:
-	return _is_grounded() and Input.is_action_pressed("paddle_down")
+	return is_grounded() and Input.is_action_pressed("paddle_down")

--- a/scripts/hud/player_sprite.gd
+++ b/scripts/hud/player_sprite.gd
@@ -64,6 +64,7 @@ func _build_ui() -> void:
 	_add_checkbox("Show Body Collider", _apply_body_visible)
 	_add_checkbox("Show Racket Collider", _apply_racket_visible)
 	_add_checkbox("Show State Label", _apply_state_label_visible)
+	_add_checkbox("Show Ground Ray", _apply_ground_ray_visible)
 
 	_readout_label = Label.new()
 	_readout_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -182,6 +183,10 @@ func _apply_racket_visible(pressed: bool) -> void:
 
 func _apply_state_label_visible(pressed: bool) -> void:
 	_for_each_paddle("set_state_label_visible", pressed)
+
+
+func _apply_ground_ray_visible(pressed: bool) -> void:
+	_for_each_paddle("set_ground_ray_visible", pressed)
 
 
 func _for_each_paddle(method: StringName, value: Variant) -> void:

--- a/tests/unit/paddle/test_timeout_controller.gd
+++ b/tests/unit/paddle/test_timeout_controller.gd
@@ -208,21 +208,6 @@ func test_airborne_call_timeout_defers_equip_pose_signal_until_grounded() -> voi
 	)
 
 
-func test_grounded_at_floor_walks_off_without_redescent() -> void:
-	# Drop the paddle onto the floor by applying one physics step of downward motion.
-	_paddle.position = Vector2(LANE_X, FLOOR_Y - PADDLE_HALF_HEIGHT - 2.0)
-	_paddle.velocity = Vector2(0.0, 1200.0)
-	_paddle.move_and_slide()
-	await get_tree().physics_frame
-	assert_true(_paddle.is_on_floor(), "paddle should be grounded before the timeout call")
-	_controller.call_timeout()
-	assert_eq(
-		_controller.get_state(),
-		TimeoutController.State.WALKING_OFF,
-		"grounded paddle should skip DESCENDING and go straight to WALKING_OFF",
-	)
-
-
 func test_repeated_call_timeout_while_airborne_stays_single_run() -> void:
 	watch_signals(_controller)
 	_paddle.position = Vector2(LANE_X, AIRBORNE_Y)


### PR DESCRIPTION
Replace position-based floor test with a RayCast2D on each paddle scene. Body collision is disabled outside timeout and re-enabled only while the character walks off/on, so the built-in is_on_floor() works during the descent. Downward player drive is blocked when grounded. A debug checkbox in PlayerSprite draws the ray green/red on hit/miss.