### PR TITLE
ci: push LFS objects to GitHub LFS on preview deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Push LFS objects to GitHub LFS
         continue-on-error: true
         run: |
-          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin $(git lfs ls-files -l | awk '{print $1}')
+          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin "$(git lfs ls-files -l | awk '{print $1}')"
 
       - name: Cache Godot import artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 30
     environment: preview
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -43,6 +43,11 @@ jobs:
         run: |
           git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
           git lfs pull --include="assets/**"
+
+      - name: Push LFS objects to GitHub LFS
+        continue-on-error: true
+        run: |
+          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin $(git lfs ls-files -l | awk '{print $1}')
 
       - name: Cache Godot import artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
The deploy-preview job now pushes all LFS-tracked objects by OID to GitHub's native LFS storage after pulling from the private LFS proxy. This enables GitHub's web diff to render sprite image content inline during PR review.

The new step uses `continue-on-error: true` so an LFS push failure does not block the preview deploy. The job permissions are elevated from `contents: read` to `contents: write` to allow the push through the GITHUB_TOKEN credential helper configured by `actions/checkout`.

No new secrets are introduced; auth uses the existing GITHUB_TOKEN.

**Manual follow-up**: set the LFS storage budget on this repo to $0 to cap any potential overages from large pushes (Settings > Billing > Git LFS Data).