### PR TITLE
chore: remove LFS push from publish.yml

### DIFF
--- a/.github/workflows/asset-gate.yml
+++ b/.github/workflows/asset-gate.yml
@@ -48,4 +48,4 @@ jobs:
         run: |
           git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
           git lfs pull --include="assets/**"
-          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin "$(git lfs ls-files -l | awk '{print $1}')"
+          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin $(git lfs ls-files -l | awk '{print $1}')

--- a/.github/workflows/asset-gate.yml
+++ b/.github/workflows/asset-gate.yml
@@ -1,4 +1,4 @@
-name: Asset size gate
+name: Asset gate
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
   merge_group:
 
 concurrency:
-  group: asset-size-${{ github.ref }}
+  group: asset-gate-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -20,19 +20,10 @@ jobs:
     name: check-asset-size
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-
-      - name: Push LFS objects to GitHub LFS
-        continue-on-error: true
-        run: |
-          git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
-          git lfs pull --include="assets/**"
-          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin "$(git lfs ls-files -l | awk '{print $1}')"
 
       - name: Check asset sizes
         run: |
@@ -42,3 +33,19 @@ jobs:
             base_sha="${{ github.event.pull_request.base.sha }}"
           fi
           bash ci/check_asset_size.sh --diff "$base_sha"
+
+  push-lfs-preview:
+    name: push-lfs-preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Push LFS objects to GitHub LFS
+        continue-on-error: true
+        run: |
+          git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
+          git lfs pull --include="assets/**"
+          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin "$(git lfs ls-files -l | awk '{print $1}')"

--- a/.github/workflows/asset-gate.yml
+++ b/.github/workflows/asset-gate.yml
@@ -48,4 +48,4 @@ jobs:
         run: |
           git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
           git lfs pull --include="assets/**"
-          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin $(git lfs ls-files -l | awk '{print $1}')
+          git lfs ls-files -l | awk '{print $1}' | xargs git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin

--- a/.github/workflows/asset-size.yml
+++ b/.github/workflows/asset-size.yml
@@ -21,11 +21,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+
+      - name: Push LFS objects to GitHub LFS
+        continue-on-error: true
+        run: |
+          git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
+          git lfs pull --include="assets/**"
+          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin "$(git lfs ls-files -l | awk '{print $1}')"
 
       - name: Check asset sizes
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 30
     environment: preview
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -43,11 +43,6 @@ jobs:
         run: |
           git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
           git lfs pull --include="assets/**"
-
-      - name: Push LFS objects to GitHub LFS
-        continue-on-error: true
-        run: |
-          git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin "$(git lfs ls-files -l | awk '{print $1}')"
 
       - name: Cache Godot import artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
Asset-gate workflow now handles LFS push to GitHub on PR branches. publish.yml only runs on main pushes where objects are already in GitHub LFS from the PR workflow.