### PR TITLE
feat: PR asset preview bot (WebP comments)

### DIFF
--- a/.github/workflows/asset-gate.yml
+++ b/.github/workflows/asset-gate.yml
@@ -33,19 +33,3 @@ jobs:
             base_sha="${{ github.event.pull_request.base.sha }}"
           fi
           bash ci/check_asset_size.sh --diff "$base_sha"
-
-  push-lfs-preview:
-    name: push-lfs-preview
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Push LFS objects to GitHub LFS
-        continue-on-error: true
-        run: |
-          git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
-          git lfs pull --include="assets/**"
-          git lfs ls-files -l | awk '{print $1}' | xargs git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin

--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -77,7 +77,7 @@ jobs:
             --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("PR asset preview")) | .id' | head -1)
 
           if [ -n "$comment_id" ]; then
-            gh api "repos/${{ github.repository }}/pulls/comments/$comment_id" -X PATCH \
+            gh api "repos/${{ github.repository }}/issues/comments/$comment_id" -X PATCH \
               -f body="**PR asset preview** (updated ${{ github.sha:0:7 }}):
         ${body}"
           else

--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -1,0 +1,87 @@
+name: PR asset preview
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "assets/**"
+
+concurrency:
+  group: pr-asset-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: post-preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install tools
+        run: sudo apt update && sudo apt install -y webp
+
+      - name: Find changed assets
+        id: changed
+        run: |
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- 'assets/**/*.png' > /tmp/changed.txt
+          echo "count=$(wc -l < /tmp/changed.txt)" >> "$GITHUB_OUTPUT"
+          cat /tmp/changed.txt
+
+      - name: Generate previews
+        if: steps.changed.outputs.count != '0'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: https://effe9646943c4ead286bad9d06e16e74.r2.cloudflarestorage.com
+          AWS_REGION: auto
+        run: |
+          mkdir -p /tmp/previews
+
+          while read -r file; do
+            name=$(basename "$file" .png)
+            cwebp -q 80 -m 6 -mt "$file" -o "/tmp/previews/${name}.webp"
+
+            key="pr-previews/${{ github.event.pull_request.number }}/${name}.webp"
+            aws s3 cp "/tmp/previews/${name}.webp" "s3://volley-assets/${key}" \
+              --acl public-read \
+              --content-type image/webp
+
+            echo "https://volley-assets.effe9646943c4ead286bad9d06e16e74.r2.cloudflarestorage.com/${key}" >> /tmp/urls.txt
+          done < /tmp/changed.txt
+
+          cat /tmp/urls.txt
+
+      - name: Post preview comment
+        if: steps.changed.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          body=""
+          while read -r url; do
+            name=$(basename "$url" .webp)
+            body="${body}![${name}](${url})|"
+          done < /tmp/urls.txt
+
+          body=$(echo "$body" | sed 's/|$//; s/|/\n/g')
+
+          # Find and update existing preview comment, or create new one
+          comment_id=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("PR asset preview")) | .id' | head -1)
+
+          if [ -n "$comment_id" ]; then
+            gh api "repos/${{ github.repository }}/pulls/comments/$comment_id" -X PATCH \
+              -f body="**PR asset preview** (updated ${{ github.sha:0:7 }}):
+        ${body}"
+          else
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --body "**PR asset preview** (${{ github.sha:0:7 }}):
+        ${body}"
+          fi


### PR DESCRIPTION
Replaces the GitHub LFS push approach with a PR comment bot.\n\nChanged assets are converted to WebP and posted as inline preview images in a PR comment. Updates existing comment on new pushes.\n\n- asset-gate.yml: removed push-lfs-preview job\n- pr-asset-preview.yml: new workflow\n  - Triggers on PR with assets/** changes\n  - Converts changed PNGs to WebP via cwebp\n  - Uploads to R2 with public-read\n  - Posts/updates PR comment with inline images\n\nBefore merging: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY secrets must be configured in repo settings.