### PR TITLE
feat: enforce LFS upload on push via lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -54,3 +54,11 @@ pre-commit:
     pip-audit:
       glob: "requirements-dev.txt"
       run: pip-audit --requirement requirements-dev.txt --strict
+
+pre-push:
+  commands:
+    lfs-push:
+      run: git lfs push origin HEAD
+      skip:
+        - merge
+        - rebase


### PR DESCRIPTION
Adds pre-push hook that runs git lfs push origin HEAD on every push. Blocks pushes that lack the LFS upload key. Skips merge and rebase.