### PR TITLE
chore: remove LFS push from asset-gate

### DIFF
--- a/.github/workflows/asset-gate.yml
+++ b/.github/workflows/asset-gate.yml
@@ -33,22 +33,3 @@ jobs:
             base_sha="${{ github.event.pull_request.base.sha }}"
           fi
           bash ci/check_asset_size.sh --diff "$base_sha"
-
-  push-lfs-preview:
-    name: push-lfs-preview
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Push LFS objects to GitHub LFS
-        run: |
-          git config lfs.url "https://volley:${{ secrets.LFS_DOWNLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
-          git lfs pull --include="assets/**"
-          git lfs ls-files -l | awk '{print $1}' | while read -r oid; do
-            if [ -f ".git/lfs/objects/${oid:0:2}/${oid:2:2}/$oid" ]; then
-              printf "%s\n" "$oid"
-            fi
-          done | xargs -r git -c lfs.url=https://github.com/shuck-dev/volley.git/info/lfs lfs push --object-id origin


### PR DESCRIPTION
PR #1017 removed the push-lfs-preview job but a merge conflict resolution accidentally kept it. This removes it properly.