### PR TITLE
fix: serve preview images from R2 instead of base64

### DIFF
--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -66,6 +66,9 @@ jobs:
             key="pr-previews/${{ github.event.pull_request.number }}/${name}.webp"
             url="https://volley-lfs-proxy.volcanoem.workers.dev/${key}"
 
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --body "$(printf '**`%s`**\n![%s](%s)' "$file" "$name" "$url")"
+            body="$(
+              printf '**`%s`**\n' "$file"
+              printf '![%s](%s)' "$name" "$url"
+            )"
+            gh pr comment ${{ github.event.pull_request.number }} --body "$body"
           done < /tmp/changed.txt

--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -40,18 +40,37 @@ jobs:
           git config lfs.url "https://volley:${{ secrets.LFS_UPLOAD_KEY }}@volley-lfs-proxy.volcanoem.workers.dev"
           git lfs pull --include="assets/**"
 
-      - name: Post previews
+      - name: Generate and upload previews
         if: steps.changed.outputs.count != '0'
         env:
-          GH_TOKEN: ${{ github.token }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: https://effe9646943c4ead286bad9d06e16e74.r2.cloudflarestorage.com
+          AWS_REGION: auto
         run: |
           while read -r file; do
             name=$(basename "$file" .png)
             webp="/tmp/${name}.webp"
             cwebp -q 80 -m 6 -mt "$file" -o "$webp" -quiet
 
-            data=$(base64 -w0 "$webp")
-            body="**\`${file}\`**\n![](data:image/webp;base64,${data})"
+            key="pr-previews/${{ github.event.pull_request.number }}/${name}.webp"
+            aws s3 cp "$webp" "s3://volley-assets/${key}" \
+              --acl public-read \
+              --content-type image/webp
 
-            gh pr comment ${{ github.event.pull_request.number }} --body "$body"
+            echo "https://volley-assets.effe9646943c4ead286bad9d06e16e74.r2.cloudflarestorage.com/${key}" >> /tmp/urls.txt
+          done < /tmp/changed.txt
+
+      - name: Post preview comments
+        if: steps.changed.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          while read -r file; do
+            name=$(basename "$file" .png)
+            key="pr-previews/${{ github.event.pull_request.number }}/${name}.webp"
+            url="https://volley-assets.effe9646943c4ead286bad9d06e16e74.r2.cloudflarestorage.com/${key}"
+
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --body "**\`${file}\`**\n![${name}](${url})"
           done < /tmp/changed.txt

--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -42,11 +42,6 @@ jobs:
 
       - name: Generate and upload previews
         if: steps.changed.outputs.count != '0'
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_ENDPOINT_URL: https://effe9646943c4ead286bad9d06e16e74.r2.cloudflarestorage.com
-          AWS_REGION: auto
         run: |
           while read -r file; do
             name=$(basename "$file" .png)
@@ -54,11 +49,11 @@ jobs:
             cwebp -q 80 -m 6 -mt "$file" -o "$webp" -quiet
 
             key="pr-previews/${{ github.event.pull_request.number }}/${name}.webp"
-            aws s3 cp "$webp" "s3://volley-assets/${key}" \
-              --acl public-read \
-              --content-type image/webp
-
-            echo "https://volley-assets.effe9646943c4ead286bad9d06e16e74.r2.cloudflarestorage.com/${key}" >> /tmp/urls.txt
+            curl -sf -X PUT \
+              -H "Authorization: Basic $(echo -n "volley:${{ secrets.LFS_UPLOAD_KEY }}" | base64 -w0)" \
+              -H "Content-Type: image/webp" \
+              --data-binary "@${webp}" \
+              "https://volley-lfs-proxy.volcanoem.workers.dev/${key}"
           done < /tmp/changed.txt
 
       - name: Post preview comments
@@ -69,7 +64,7 @@ jobs:
           while read -r file; do
             name=$(basename "$file" .png)
             key="pr-previews/${{ github.event.pull_request.number }}/${name}.webp"
-            url="https://volley-assets.effe9646943c4ead286bad9d06e16e74.r2.cloudflarestorage.com/${key}"
+            url="https://volley-lfs-proxy.volcanoem.workers.dev/${key}"
 
             gh pr comment ${{ github.event.pull_request.number }} \
               --body "**\`${file}\`**\n![${name}](${url})"

--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -49,7 +49,7 @@ jobs:
             cwebp -q 80 -m 6 -mt "$file" -o "$webp" -quiet
 
             key="pr-previews/${{ github.event.pull_request.number }}/${name}.webp"
-            curl -sf -X PUT \
+            curl -sSf -X PUT \
               -H "Authorization: Basic $(echo -n "volley:${{ secrets.LFS_UPLOAD_KEY }}" | base64 -w0)" \
               -H "Content-Type: image/webp" \
               --data-binary "@${webp}" \
@@ -67,5 +67,5 @@ jobs:
             url="https://volley-lfs-proxy.volcanoem.workers.dev/${key}"
 
             gh pr comment ${{ github.event.pull_request.number }} \
-              --body "**\`${file}\`**\n![${name}](${url})"
+              --body "$(printf '**`%s`**\n![%s](%s)' "$file" "$name" "$url")"
           done < /tmp/changed.txt

--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -66,9 +66,6 @@ jobs:
             key="pr-previews/${{ github.event.pull_request.number }}/${name}.webp"
             url="https://volley-lfs-proxy.volcanoem.workers.dev/${key}"
 
-            body="$(
-              printf '**`%s`**\n' "$file"
-              printf '![%s](%s)' "$name" "$url"
-            )"
+            body="**\`${file}\`**"$'\n'"![${name}](${url})"
             gh pr comment ${{ github.event.pull_request.number }} --body "$body"
           done < /tmp/changed.txt


### PR DESCRIPTION
Base64 data URIs are stripped from GitHub comments. Uploads WebP previews to R2 public-read bucket and references via URL instead.