### PR TITLE
fix: pin preview comments to file level

### DIFF
--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -74,5 +74,5 @@ jobs:
               -F commit_id="$commit_id" \
               -F path="$file" \
               -F body="$body" \
-              -F position=1
+              -F subject_type=file
           done < /tmp/changed.txt


### PR DESCRIPTION
Uses subject_type=file instead of position=1 so comments anchor to the file rather than a specific diff line.