### PR TITLE
docs: per-state racket position via Marker2D

### DIFF
--- a/designs/01-prototype/INDEX.md
+++ b/designs/01-prototype/INDEX.md
@@ -8,12 +8,15 @@ The public demo on itch.io. Core loop, first-pass assets, playable by strangers.
 | 01 | [HUD Pass](01-hud-pass.md) |
 | 02 | [Ball Scaling](02-ball-scaling.md) |
 | 03 | [Idle Progression](03-idle-progression.md) |
+|    | - [Save Versioning](tech/03-save-versioning.md) |
 | 04 | [Upgrade Shop](04-upgrade-shop.md) |
 | 05 | [Upgrade Shop Mechanics](05-upgrade-shop-mechanics.md) |
 | 06 | **Items** |
 |    | - [Items (design)](design/items.md) |
 |    | - [Starter Items (design)](design/starter-items.md) |
 |    | - [Item Effect Blocks (tech)](tech/05-item-effects.md) |
+|    | - [Gear (tech)](tech/gear.md) |
+|    | - [Effect System (tech)](tech/effect-system.md) |
 | 07 | [Effect System](../effect-system/README.md) |
 | 08 | **The Venue and Its Systems** |
 |    | - [The Venue](08-venue.md) |
@@ -38,9 +41,22 @@ The public demo on itch.io. Core loop, first-pass assets, playable by strangers.
 | 17 | [Partner AI](17-partner-ai.md) |
 | 18 | [Partner Upgrade Strategy](design/partner-upgrade-strategy.md) |
 | 19 | [Minified Paddle](19-minified-paddle.md) |
+|    | - [Paddle Bounce](tech/03-paddle-bounce.md) |
+|    | - [Paddle Animation Collision (spike)](tech/2026-06-06-paddle-animation-collision-spike.md) |
+|    | - [Paddle Sprite Sizing Decouple](tech/2026-06-10-paddle-sprite-sizing-decouple.md) |
+|    | - [Racket Position Per State](tech/2026-06-22-racket-position-per-state.md) |
 | 20 | [Ball Speed Tiers and Physics Ceiling](20-ball-speed-tiers.md) |
 | 20a | [Ball Speed Tier Progression](20a-ball-speed-tier-progression.md) |
 | 21 | [Ball Lifecycle](tech/02-ball-lifecycle.md) |
 |    | - [Surface Physics Ownership (spike)](tech/2026-06-03-surface-physics-ownership-spike.md) |
+|    | - [Ball State Ownership (spike)](tech/ball-state-ownership-spike.md) |
+|    | - [Rack State Ownership](tech/rack-state-ownership.md) |
+|    | - [Physics Layer Map](tech/2026-06-10-physics-layer-map.md) |
 | 22 | [Levitation Progression](design/levitation-progression.md) |
 | 23 | [Soul](design/soul.md) |
+| 24 | **Spikes and RCA** |
+|    | - [Settings Screen (spike)](tech/2026-06-11-settings-screen-spike.md) |
+|    | - [Asset Versioning (spike)](tech/2026-06-11-asset-versioning-spike.md) |
+|    | - [LFS Proxy Architecture](tech/2026-06-12-lfs-proxy-architecture.md) |
+|    | - [Web Lag RCA](tech/sh-462-web-lag-rca.md) |
+|    | - [Threaded Web Export](tech/threaded-web-export.md) |

--- a/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
+++ b/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
@@ -8,72 +8,43 @@ reach, the collider question reopens for that state alone."
 
 ## Decision
 
-Marker2D child nodes under a `RacketPositions` container in the paddle scene,
-one per animation state that needs a distinct racket position. On state change,
-copy the matching marker's local position to `racket_hitbox.position`. States
-without a marker fall back to the scene-authored RacketHitbox position.
+A single `LowRacketAnchor` Marker2D child defines the low-swing racket position.
+The scene-authored RacketHitbox position is the default for every other state.
+On state change, the paddle switches between the two: the low anchor when the
+state is crouch or low-swing, the default otherwise.
 
 The per-frame Y-override in `player_paddle.gd._physics_move` is removed
-entirely. The racket position is set once on state transition, not recomputed
-every physics tick.
+entirely. The racket position is set on state transition, not recomputed every
+physics tick.
 
 ## Why Marker2D
 
-**Visual.** The designer selects a marker in the scene tree, sees a cross-gizmo
-in the 2D viewport, and drags it to where the racket should sit for that state.
-No number guessing, no animation scrubbing, no resource-file round trips.
+**Visual.** The designer selects the anchor in the scene tree, sees a cross-gizmo
+in the 2D viewport, and drags it to where the racket should sit during a low
+swing. No number guessing.
 
 **Precedent.** The paddle scene already uses Node2D anchors as positional
 references: `AnkleAnchor` at `[0, 24]`, `GripAnchor` at `[-12, 0]`,
-`WristAnchor` at `[-12, -10]`. The `RacketPositions` container extends the same
-pattern.
-
-**Hook fits naturally.** `_on_animation_state_changed` already fires on every
-state transition via the paddle animation state machine. Adding a racket-position
-lookup there is a two-line addition with no structural refactoring.
+`WristAnchor` at `[-12, -10]`. `LowRacketAnchor` extends the same pattern.
 
 **Dev panel survives.** The existing `set_racket_position_x` and
 `set_racket_position_y` on `paddle.gd` store an additive offset applied on top
-of the per-state marker position. Each state transition recomputes
-`racket_hitbox.position = marker.position + offset`, preserving the offset
-across states. The spinboxes that appeared broken for Y (the `_physics_move`
-override was writing over them every frame) now work as live fine-tune controls.
-
-## Why not the alternatives
-
-| Approach | Rejected because |
-|---|---|
-| `@export` dictionary per state | Not visually tunable. The designer types coordinates blind in the inspector, no viewport feedback. |
-| AnimationPlayer on RacketHitbox position | Duplicates the SpriteFrames animation infrastructure. Seven animation states require two systems kept in sync. A new state means updating both. Adds a timeline for what is fundamentally a single-position-per-state problem. |
-| Custom Resource with Vector2 per state | Another file type to manage. Still no viewport visual. Over-engineered for seven positions. |
+of the anchor position. Each state transition recomputes
+`racket_hitbox.position = anchor_position + offset`, preserving the offset
+across states.
 
 ## Scene shape
 
 ```
 PlayerPaddle (CharacterBody2D)
 ├── Sprite (AnimatedSprite2D)
-├── RacketPositions (Node2D)
-│   ├── RPos_ready_grounded (RacketPositionMarker)
-│   ├── RPos_ready_flying (RacketPositionMarker)
-│   ├── RPos_flying_up (RacketPositionMarker)
-│   ├── RPos_flying_down (RacketPositionMarker)
-│   ├── RPos_swing_grounded (RacketPositionMarker)
-│   ├── RPos_low_swing_grounded (RacketPositionMarker)
-│   └── RPos_swing_flying (RacketPositionMarker)
+├── LowRacketAnchor (RacketPositionMarker)
 ├── RacketHitbox (Area2D)
 │   └── RacketCollision (CollisionShape2D)
 ├── ...existing nodes...
 ```
 
-All seven markers exist in the scene. States that share the default position
-can omit their marker; the code falls back to the scene-authored RacketHitbox
-position. The container keeps the tree tidy.
-
 ## Editor tool
-
-The Marker2D crosshair alone does not show the RacketHitbox extents. An editor
-tool renders the collision shape so the designer sees the actual hitzone while
-dragging.
 
 A custom `RacketPositionMarker` class extends `Marker2D` with `@tool`:
 
@@ -88,22 +59,27 @@ func _draw() -> void:
 	draw_rect(Rect2(-collision_size * 0.5, collision_size), Color.RED, false, 2.0)
 ```
 
-- `collision_size` is set to match the RacketCollision RectangleShape2D.
-- `_draw()` fires in the editor; the rectangle follows the marker around as the
-  designer drags it.
-- The colour and line weight are editor-only visualisation; they do not appear
-  at runtime.
-- The markers in the scene shape above use `RacketPositionMarker` instead of
-  raw `Marker2D`.
+- `collision_size` matches the RacketCollision RectangleShape2D.
+- `_draw()` fires in the editor; the rectangle follows the marker.
+- Colour and line weight are editor-only; they do not appear at runtime.
 
 ## Code shape
 
-`player_paddle.gd` overrides a new virtual `_apply_racket_position(state)` on
-the base class. The override collects Marker2D children from `RacketPositions`
-at `_ready`, maps them by state name, and on each call copies the matching
-marker's `position` to `racket_hitbox.position`.
+`player_paddle.gd` overrides a virtual `_apply_racket_position(state)` on
+`paddle.gd`. The override switches the racket position between the low anchor
+and the default based on the state's crouch/lowness:
 
-The base class `paddle.gd` calls `_apply_racket_position(state)` from
+```
+func _apply_racket_position(state: StringName) -> void:
+	if state in _low_states:
+		racket_hitbox.position = low_anchor.position
+	else:
+		racket_hitbox.position = _default_racket_pos
+	racket_hitbox.position += _dev_offset
+	_refresh_overlay_shapes()
+```
+
+The base class calls `_apply_racket_position(state)` from
 `_on_animation_state_changed` after the sprite animation plays. The default
 implementation is a no-op; partner paddles inherit it unchanged.
 

--- a/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
+++ b/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
@@ -1,0 +1,89 @@
+# Racket hitbox position per animation state
+
+Resolves SH-518 (visual tuning of the racket collision zone during Sam's
+low-swing pose). Continues `2026-06-06-paddle-animation-collision-spike.md`,
+which decided the CharacterBody2D body collider stays fixed across states.
+That decision stands. This doc addresses a separate shape: the RacketHitbox
+Area2D, the mid-body zone that detects the ball and feeds the return-angle
+calculus. That zone shifts with the crouch pose and the prior decision did not
+cover it.
+
+## Decision
+
+Marker2D child nodes under a `RacketPositions` container in the paddle scene,
+one per animation state that needs a distinct racket position. On state change,
+copy the matching marker's local position to `racket_hitbox.position`. States
+without a marker fall back to the scene-authored RacketHitbox position.
+
+The per-frame Y-override in `player_paddle.gd._physics_move` is removed
+entirely. The racket position is set once on state transition, not recomputed
+every physics tick.
+
+## Why Marker2D
+
+**Visual.** The designer selects a marker in the scene tree, sees a cross-gizmo
+in the 2D viewport, and drags it to where the racket should sit for that state.
+No number guessing, no animation scrubbing, no resource-file round trips.
+
+**Precedent.** The paddle scene already uses Node2D anchors as positional
+references: `AnkleAnchor` at `[0, 24]`, `GripAnchor` at `[-12, 0]`,
+`WristAnchor` at `[-12, -10]`. The `RacketPositions` container extends the same
+pattern.
+
+**Hook fits naturally.** `_on_animation_state_changed` already fires on every
+state transition via the paddle animation state machine. Adding a racket-position
+lookup there is a two-line addition with no structural refactoring.
+
+**Dev panel survives.** The existing `set_racket_position_x` and
+`set_racket_position_y` on `paddle.gd` become additive offsets applied on top
+of the per-state position. The spinboxes that appeared broken for Y (the
+`_physics_move` override was writing over them every frame) now work as live
+fine-tune controls.
+
+## Why not the alternatives
+
+| Approach | Rejected because |
+|---|---|
+| `@export` dictionary per state | Not visually tunable. The designer types coordinates blind in the inspector, no viewport feedback. |
+| AnimationPlayer on RacketHitbox position | Duplicates the SpriteFrames animation infrastructure. Seven animation states require two systems kept in sync. A new state means updating both. Adds a timeline for what is fundamentally a single-position-per-state problem. |
+| Custom Resource with Vector2 per state | Another file type to manage. Still no viewport visual. Over-engineered for seven positions. |
+
+## Scene shape
+
+```
+PlayerPaddle (CharacterBody2D)
+├── Sprite (AnimatedSprite2D)
+├── RacketPositions (Node2D)
+│   ├── RPos_ready_grounded (Marker2D)
+│   ├── RPos_ready_flying (Marker2D)
+│   ├── RPos_flying_up (Marker2D)
+│   ├── RPos_flying_down (Marker2D)
+│   ├── RPos_swing_grounded (Marker2D)
+│   ├── RPos_low_swing_grounded (Marker2D)
+│   └── RPos_swing_flying (Marker2D)
+├── RacketHitbox (Area2D)
+│   └── RacketCollision (CollisionShape2D)
+├── ...existing nodes...
+```
+
+All seven markers exist in the scene. States that share the default position
+can omit their marker; the code falls back to the scene-authored RacketHitbox
+position. The container keeps the tree tidy.
+
+## Code shape
+
+`player_paddle.gd` overrides a new virtual `_apply_racket_position(state)` on
+the base class. The override collects Marker2D children from `RacketPositions`
+at `_ready`, maps them by state name, and on each call copies the matching
+marker's `position` to `racket_hitbox.position`.
+
+The base class `paddle.gd` calls `_apply_racket_position(state)` from
+`_on_animation_state_changed` after the sprite animation plays. The default
+implementation is a no-op; partner paddles inherit it unchanged.
+
+`_base_racket_y` and the crouch-position formula in `_physics_move` are
+removed. The racket position is no longer touched in the physics loop.
+
+## Implementation
+
+SH-xxx (child of SH-518).

--- a/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
+++ b/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
@@ -1,12 +1,8 @@
 # Racket hitbox position per animation state
 
-Resolves SH-518 (visual tuning of the racket collision zone during Sam's
-low-swing pose). Continues `2026-06-06-paddle-animation-collision-spike.md`,
-which decided the CharacterBody2D body collider stays fixed across states.
-That decision stands. This doc addresses a separate shape: the RacketHitbox
-Area2D, the mid-body zone that detects the ball and feeds the return-angle
-calculus. That zone shifts with the crouch pose and the prior decision did not
-cover it.
+Resolves SH-518. The racket hitbox (RacketHitbox Area2D, the mid-body zone
+that detects the ball) shifts with Sam's crouch pose. The body collider stays
+fixed per `2026-06-06-paddle-animation-collision-spike.md`.
 
 ## Decision
 

--- a/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
+++ b/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
@@ -1,8 +1,10 @@
 # Racket hitbox position per animation state
 
-Resolves SH-518. The racket hitbox (RacketHitbox Area2D, the mid-body zone
-that detects the ball) shifts with Sam's crouch pose. The body collider stays
-fixed per `2026-06-06-paddle-animation-collision-spike.md`.
+The racket hitbox (RacketHitbox Area2D, the mid-body zone that detects the
+ball) shifts with Sam's crouch pose. The CharacterBody2D body collider stays
+fixed per `2026-06-06-paddle-animation-collision-spike.md`. The prior spike
+anticipated this in passing: "if a future ready pose ever extends the paddle's
+reach, the collider question reopens for that state alone."
 
 ## Decision
 
@@ -31,10 +33,11 @@ state transition via the paddle animation state machine. Adding a racket-positio
 lookup there is a two-line addition with no structural refactoring.
 
 **Dev panel survives.** The existing `set_racket_position_x` and
-`set_racket_position_y` on `paddle.gd` become additive offsets applied on top
-of the per-state position. The spinboxes that appeared broken for Y (the
-`_physics_move` override was writing over them every frame) now work as live
-fine-tune controls.
+`set_racket_position_y` on `paddle.gd` store an additive offset applied on top
+of the per-state marker position. Each state transition recomputes
+`racket_hitbox.position = marker.position + offset`, preserving the offset
+across states. The spinboxes that appeared broken for Y (the `_physics_move`
+override was writing over them every frame) now work as live fine-tune controls.
 
 ## Why not the alternatives
 
@@ -50,13 +53,13 @@ fine-tune controls.
 PlayerPaddle (CharacterBody2D)
 ├── Sprite (AnimatedSprite2D)
 ├── RacketPositions (Node2D)
-│   ├── RPos_ready_grounded (Marker2D)
-│   ├── RPos_ready_flying (Marker2D)
-│   ├── RPos_flying_up (Marker2D)
-│   ├── RPos_flying_down (Marker2D)
-│   ├── RPos_swing_grounded (Marker2D)
-│   ├── RPos_low_swing_grounded (Marker2D)
-│   └── RPos_swing_flying (Marker2D)
+│   ├── RPos_ready_grounded (RacketPositionMarker)
+│   ├── RPos_ready_flying (RacketPositionMarker)
+│   ├── RPos_flying_up (RacketPositionMarker)
+│   ├── RPos_flying_down (RacketPositionMarker)
+│   ├── RPos_swing_grounded (RacketPositionMarker)
+│   ├── RPos_low_swing_grounded (RacketPositionMarker)
+│   └── RPos_swing_flying (RacketPositionMarker)
 ├── RacketHitbox (Area2D)
 │   └── RacketCollision (CollisionShape2D)
 ├── ...existing nodes...
@@ -65,6 +68,33 @@ PlayerPaddle (CharacterBody2D)
 All seven markers exist in the scene. States that share the default position
 can omit their marker; the code falls back to the scene-authored RacketHitbox
 position. The container keeps the tree tidy.
+
+## Editor tool
+
+The Marker2D crosshair alone does not show the RacketHitbox extents. An editor
+tool renders the collision shape so the designer sees the actual hitzone while
+dragging.
+
+A custom `RacketPositionMarker` class extends `Marker2D` with `@tool`:
+
+```
+@tool
+class_name RacketPositionMarker
+extends Marker2D
+
+@export var collision_size := Vector2(20, 20)
+
+func _draw() -> void:
+	draw_rect(Rect2(-collision_size * 0.5, collision_size), Color.RED, false, 2.0)
+```
+
+- `collision_size` is set to match the RacketCollision RectangleShape2D.
+- `_draw()` fires in the editor; the rectangle follows the marker around as the
+  designer drags it.
+- The colour and line weight are editor-only visualisation; they do not appear
+  at runtime.
+- The markers in the scene shape above use `RacketPositionMarker` instead of
+  raw `Marker2D`.
 
 ## Code shape
 
@@ -80,6 +110,7 @@ implementation is a no-op; partner paddles inherit it unchanged.
 `_base_racket_y` and the crouch-position formula in `_physics_move` are
 removed. The racket position is no longer touched in the physics loop.
 
-## Implementation
+## Out of scope
 
-SH-xxx (child of SH-518).
+Restitution physics, `Paddle.get_half_height()`, and the body collider shape.
+Those stay one fixed authored collider per the prior decision.

--- a/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
+++ b/designs/01-prototype/tech/2026-06-22-racket-position-per-state.md
@@ -1,52 +1,28 @@
 # Racket hitbox position per animation state
 
-The racket hitbox (RacketHitbox Area2D, the mid-body zone that detects the
-ball) shifts with Sam's crouch pose. The CharacterBody2D body collider stays
-fixed per `2026-06-06-paddle-animation-collision-spike.md`. The prior spike
-anticipated this in passing: "if a future ready pose ever extends the paddle's
-reach, the collider question reopens for that state alone."
+The racket hitbox shifts with Sam's crouch pose. The body collider stays fixed
+per `2026-06-06-paddle-animation-collision-spike.md`.
 
 ## Decision
 
 A single `LowRacketAnchor` Marker2D child defines the low-swing racket position.
-The scene-authored RacketHitbox position is the default for every other state.
-On state change, the paddle switches between the two: the low anchor when the
-state is crouch or low-swing, the default otherwise.
+The scene-authored RacketHitbox position is the default. On state change the
+paddle switches between the two.
 
-The per-frame Y-override in `player_paddle.gd._physics_move` is removed
-entirely. The racket position is set on state transition, not recomputed every
-physics tick.
+The per-frame Y-override in `player_paddle.gd._physics_move` is removed. The
+racket position is set on state transition, not every physics tick.
 
 ## Why Marker2D
 
-**Visual.** The designer selects the anchor in the scene tree, sees a cross-gizmo
-in the 2D viewport, and drags it to where the racket should sit during a low
-swing. No number guessing.
-
-**Precedent.** The paddle scene already uses Node2D anchors as positional
-references: `AnkleAnchor` at `[0, 24]`, `GripAnchor` at `[-12, 0]`,
-`WristAnchor` at `[-12, -10]`. `LowRacketAnchor` extends the same pattern.
-
-**Dev panel survives.** The existing `set_racket_position_x` and
-`set_racket_position_y` on `paddle.gd` store an additive offset applied on top
-of the anchor position. Each state transition recomputes
-`racket_hitbox.position = anchor_position + offset`, preserving the offset
-across states.
-
-## Scene shape
-
-```
-PlayerPaddle (CharacterBody2D)
-├── Sprite (AnimatedSprite2D)
-├── LowRacketAnchor (RacketPositionMarker)
-├── RacketHitbox (Area2D)
-│   └── RacketCollision (CollisionShape2D)
-├── ...existing nodes...
-```
+The paddle scene already uses Node2D anchors (`AnkleAnchor`, `GripAnchor`,
+`WristAnchor`). `LowRacketAnchor` extends the same pattern. The designer drags
+the cross-gizmo in the 2D viewport to where the racket should sit during a low
+swing.
 
 ## Editor tool
 
-A custom `RacketPositionMarker` class extends `Marker2D` with `@tool`:
+A `@tool` Marker2D subclass draws the collision rectangle so the designer sees
+the actual hitzone while dragging:
 
 ```
 @tool
@@ -59,15 +35,24 @@ func _draw() -> void:
 	draw_rect(Rect2(-collision_size * 0.5, collision_size), Color.RED, false, 2.0)
 ```
 
-- `collision_size` matches the RacketCollision RectangleShape2D.
-- `_draw()` fires in the editor; the rectangle follows the marker.
-- Colour and line weight are editor-only; they do not appear at runtime.
+`collision_size` matches the RacketCollision RectangleShape2D. The draw is
+editor-only; it does not appear at runtime.
+
+## Scene shape
+
+```
+PlayerPaddle (CharacterBody2D)
+├── Sprite (AnimatedSprite2D)
+├── LowRacketAnchor (RacketPositionMarker)
+├── RacketHitbox (Area2D)
+│   └── RacketCollision (CollisionShape2D)
+├── ...
+```
 
 ## Code shape
 
 `player_paddle.gd` overrides a virtual `_apply_racket_position(state)` on
-`paddle.gd`. The override switches the racket position between the low anchor
-and the default based on the state's crouch/lowness:
+`paddle.gd`. The override switches between the low anchor and the default:
 
 ```
 func _apply_racket_position(state: StringName) -> void:
@@ -80,13 +65,7 @@ func _apply_racket_position(state: StringName) -> void:
 ```
 
 The base class calls `_apply_racket_position(state)` from
-`_on_animation_state_changed` after the sprite animation plays. The default
-implementation is a no-op; partner paddles inherit it unchanged.
+`_on_animation_state_changed` after the sprite animation plays. Partner paddles
+inherit the no-op default.
 
-`_base_racket_y` and the crouch-position formula in `_physics_move` are
-removed. The racket position is no longer touched in the physics loop.
-
-## Out of scope
-
-Restitution physics, `Paddle.get_half_height()`, and the body collider shape.
-Those stay one fixed authored collider per the prior decision.
+`_base_racket_y` and the crouch formula in `_physics_move` are removed.


### PR DESCRIPTION
Adds the spike decision doc: Marker2D nodes under a RacketPositions container in the paddle scene, one per animation state. Resolves SH-518. An implementation PR follows as a child ticket.