### PR TITLE
chore: add inline comments to opencode.json deny/ask reasons

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,6 +28,8 @@ pre-commit:
       glob: "*.json"
       exclude:
         - "addons/**"
+        # JSONC with // comments; jq cannot parse it.
+        - "opencode.json"
       run: for f in {staged_files}; do jq --indent 2 . "$f" > "$f.tmp" && mv "$f.tmp" "$f"; done
       stage_fixed: true
     gdformat:

--- a/opencode.json
+++ b/opencode.json
@@ -10,22 +10,33 @@
   "permission": {
     "webfetch": "deny",
     "bash": {
+      // Josh owns the merge, close, and release lifecycle.
       "gh pr merge*": "deny",
       "gh pr close*": "deny",
       "gh release delete*": "deny",
       "gh release create*": "deny",
+      // Rewrites history; ask first.
       "git rebase*": "ask",
       "*git rebase*": "ask",
+      // Banned history-rewrite commands.
       "git filter-branch*": "deny",
       "*git filter-branch*": "deny",
+      // Rewrites the remote; need consent.
       "git push *--force*": "ask",
       "*git push *--force*": "ask",
+      // Merge instead to avoid silent conflicts.
       "git pull *--rebase*": "deny",
+      // Force-delete branches; use worktree cleanup instead.
       "git branch *-D *": "deny",
+      // Destructive recursive delete.
       "rm -rf *": "deny",
+      // File deletion; confirm each.
       "rm *": "ask",
+      // Use MCP tools instead.
       "python*": "deny",
+      // Blocked, never poll.
       "*sleep *": "deny",
+      // Use the Linear MCP tool instead.
       "*linear.app/graphql*issueCreate*": "ask",
       "*linear.app/graphql*issueUpdate*": "ask"
     },


### PR DESCRIPTION
Each deny/ask entry in the bash permission block now carries a one-line comment
explaining the restriction. These are the reasons the rules exist: ownership
boundaries, destructive-ops guards, and MCP-tool alternatives.

The lefthook jq-format hook now excludes opencode.json because it uses JSONC
`//` comments that jq cannot parse.

Agent-Role: infra-implementer