### PR TITLE
chore: deny gh issue * from all agents

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -14,6 +14,8 @@
       "gh pr close*": "deny",
       "gh release delete*": "deny",
       "gh release create*": "deny",
+      "gh issue *": "deny",
+      "*gh issue*": "deny",
       "git rebase*": "ask",
       "*git rebase*": "ask",
       "git filter-branch*": "deny",


### PR DESCRIPTION
Bash permission block now denies `gh issue *` and `*gh issue*` globally, so no agent (including subagents and minions) can create or close GitHub issues.