### PR TITLE
chore: block git add -f in bash permissions

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -25,6 +25,9 @@
       // Banned history-rewrite commands.
       "git filter-branch*": "deny",
       "*git filter-branch*": "deny",
+      // Force-adding gitignored files.
+      "git add *-f*": "deny",
+      "*git add *-f*": "deny",
       // Rewrites the remote; need consent.
       "git push *--force*": "ask",
       "*git push *--force*": "ask",


### PR DESCRIPTION
Denies both `git add -f` and `*git add -f*` patterns. Force-adding gitignored files to the tree should not happen.

Agent-Role: dispatcher