### PR TITLE
docs: tiered restock pools for ball shop

### DIFF
--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -20,13 +20,13 @@ Balls are not unique. Duplicates work identically to the first copy. All duplica
 
 Pluck is unique, one purchase.
 
-| Tier | Restock | Balls |
-|---|---|---|
-| Common | 50% | Standard ball |
-| Scarce | 20% | Goop, Comeback |
-| Rare | 5% | Cadence, Cheater |
+| Tier | Restock |
+|---|---|
+| Common | 50% |
+| Scarce | 20% |
+| Rare | 5% |
 
-Old ball always shows. Within a tier, balls split the pool equally.
+Within a tier, balls split the pool equally. Old ball always shows.
 
 ## Ball upgrade model
 

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -14,7 +14,7 @@ Balls are not unique. Duplicates work identically to the first copy. All duplica
 | Standard ball | 10 | Common | 50% |
 | Goop | 80 | Scarce | 20% |
 | Comeback | 100 | Scarce | 20% |
-| Cadence | 100 | Scarce | 20% |
+| Cadence | 100 | Rare | 5% |
 | Cheater | 120 | Rare | 5% |
 | Pluck | 60 | Unique | |
 

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -8,17 +8,17 @@ Each hit banks 1 soul immediately and increments the burst counter. On consolida
 
 Balls are not unique. Duplicates work identically to the first copy. All duplicates cost 2× per copy. First rotation is a mix of standard balls like tennis, baseball, golf.
 
-| Ball | Base cost |
-|---|---|
-| Old ball | Free |
-| Tennis ball | 10 |
-| Goop | 80 |
-| Comeback | 100 |
-| Cadence | 100 |
-| Cheater | 120 |
-| Pluck | 60 |
+| Ball | Base cost | Tier | Restock |
+|---|---|---|---|
+| Old ball | Free | | 100% |
+| Standard ball | 10 | Common | 50% |
+| Goop | 80 | Scarce | 20% |
+| Comeback | 100 | Scarce | 20% |
+| Cadence | 100 | Scarce | 20% |
+| Cheater | 120 | Rare | 5% |
+| Pluck | 60 | Unique | |
 
-Pluck is unique, one purchase.
+Pluck is unique, one purchase. Common, Scarce, and Rare tiers weight restock probability. Scarce balls split their pool equally. Old ball always shows.
 
 ## Ball upgrade model
 
@@ -119,7 +119,7 @@ graph TD
 
 | Item        | Mechanic |
 |-------------|----------|
-| Tennis ball | Rally loop (hit, miss, consolidate) |
+| Standard ball | Rally loop (hit, miss, consolidate) |
 | Goop        | Multi-ball management, merging |
 | Comeback    | Positioning shapes ball path |
 | Cheater     | Reading the ball in flight, unpredictability |

--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -8,17 +8,25 @@ Each hit banks 1 soul immediately and increments the burst counter. On consolida
 
 Balls are not unique. Duplicates work identically to the first copy. All duplicates cost 2× per copy. First rotation is a mix of standard balls like tennis, baseball, golf.
 
-| Ball | Base cost | Tier | Restock |
-|---|---|---|---|
-| Old ball | Free | | 100% |
-| Standard ball | 10 | Common | 50% |
-| Goop | 80 | Scarce | 20% |
-| Comeback | 100 | Scarce | 20% |
-| Cadence | 100 | Rare | 5% |
-| Cheater | 120 | Rare | 5% |
-| Pluck | 60 | Unique | |
+| Ball | Base cost | Tier |
+|---|---|---|
+| Old ball | Free | |
+| Standard ball | 10 | Common |
+| Goop | 80 | Scarce |
+| Comeback | 100 | Scarce |
+| Cadence | 100 | Rare |
+| Cheater | 120 | Rare |
+| Pluck | 60 | Unique |
 
-Pluck is unique, one purchase. Common, Scarce, and Rare tiers weight restock probability. Scarce balls split their pool equally. Old ball always shows.
+Pluck is unique, one purchase.
+
+| Tier | Restock | Balls |
+|---|---|---|
+| Common | 50% | Standard ball |
+| Scarce | 20% | Goop, Comeback |
+| Rare | 5% | Cadence, Cheater |
+
+Old ball always shows. Within a tier, balls split the pool equally.
 
 ## Ball upgrade model
 


### PR DESCRIPTION
Adds Common, Scarce, and Rare tier restock pools to the ball shop economy, backed by research on MTG booster, Genshin gacha, and Pokemon TCG rarity distributions.

Common (50%): Standard ball. Scarce (20%): Goop, Comeback. Rare (5%): Cadence, Cheater. Old ball always shows. Within a tier, balls split the pool equally.

Agent-Role: dispatcher