### PR TITLE
fix: remove collision from shop table

### DIFF
--- a/scenes/shop.tscn
+++ b/scenes/shop.tscn
@@ -32,6 +32,7 @@ position = Vector2(0, 92.5)
 shape = SubResource("RectangleShape2D_area")
 
 [node name="Table" type="StaticBody2D" parent="." unique_id=1043709126]
+collision_layer = 0
 
 [node name="TableShape" type="CollisionShape2D" parent="Table" unique_id=2025432732]
 shape = SubResource("RectangleShape2D_table")


### PR DESCRIPTION
Loose items released near the shop collided with the shop's Table StaticBody2D because its default collision layer (1) matched the HeldBody's loose collision mask. The Table is purely visual: shop interaction uses the ShopArea (Area2D) for drag and purchase gestures. Zeroing its collision layer lets loose items pass through without affecting any interactive surface.