### PR TITLE
fix: reorder drop targets so rack accepts before court

### DIFF
--- a/designs/01-prototype/design/starter-items.md
+++ b/designs/01-prototype/design/starter-items.md
@@ -8,25 +8,17 @@ Each hit banks 1 soul immediately and increments the burst counter. On consolida
 
 Balls are not unique. Duplicates work identically to the first copy. All duplicates cost 2× per copy. First rotation is a mix of standard balls like tennis, baseball, golf.
 
-| Ball | Base cost | Tier |
-|---|---|---|
-| Old ball | Free | |
-| Standard ball | 10 | Common |
-| Goop | 80 | Scarce |
-| Comeback | 100 | Scarce |
-| Cadence | 100 | Rare |
-| Cheater | 120 | Rare |
-| Pluck | 60 | Unique |
+| Ball | Base cost |
+|---|---|
+| Old ball | Free |
+| Tennis ball | 10 |
+| Goop | 80 |
+| Comeback | 100 |
+| Cadence | 100 |
+| Cheater | 120 |
+| Pluck | 60 |
 
 Pluck is unique, one purchase.
-
-| Tier | Restock |
-|---|---|
-| Common | 50% |
-| Scarce | 20% |
-| Rare | 5% |
-
-Within a tier, balls split the pool equally. Old ball always shows.
 
 ## Ball upgrade model
 
@@ -127,7 +119,7 @@ graph TD
 
 | Item        | Mechanic |
 |-------------|----------|
-| Standard ball | Rally loop (hit, miss, consolidate) |
+| Tennis ball | Rally loop (hit, miss, consolidate) |
 | Goop        | Multi-ball management, merging |
 | Comeback    | Positioning shapes ball path |
 | Cheater     | Reading the ball in flight, unpredictability |

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -647,7 +647,7 @@ func set_character_drop_target(area: Area2D, paddle: Node = null) -> void:
 	_register_builtin_targets(area, paddle)
 
 
-## Priority order: court strict projection first, character equip, role-aware racks, venue catch-all last.
+## Priority order: character equip, role-aware racks, court projection, venue catch-all last.
 func _register_builtin_targets(
 	character_area: Area2D = null, character_paddle: Node = null
 ) -> void:
@@ -656,10 +656,10 @@ func _register_builtin_targets(
 	_character_target = null
 
 	for target: DropTarget in [
-		_make_court_target(),
 		_make_character_target(character_area, character_paddle),
 		_make_rack_target(rack_drop_target, &"ball"),
 		_make_rack_target(gear_rack_drop_target, &"equipment"),
+		_make_court_target(),
 		_make_venue_target(),
 	]:
 		if target == null:


### PR DESCRIPTION
Drop target priority was court first, releasing over the rack always routed to court. Reordered to character, rack, court, venue.