### PR TITLE
fix: resolve GUT font UID warnings

### DIFF
--- a/addons/gut/fonts/AnonymousPro-Regular.ttf.uid
+++ b/addons/gut/fonts/AnonymousPro-Regular.ttf.uid
@@ -1,0 +1,1 @@
+uid://by3oq52ycm1xm

--- a/addons/gut/fonts/CourierPrime-Regular.ttf.uid
+++ b/addons/gut/fonts/CourierPrime-Regular.ttf.uid
@@ -1,0 +1,1 @@
+uid://dk6q5pvle82jv

--- a/addons/gut/gui/GutSceneTheme.tres
+++ b/addons/gut/gui/GutSceneTheme.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Theme" load_steps=2 format=3 uid="uid://cstkhwkpajvqu"]
+[gd_resource type="Theme" format=3 uid="uid://cstkhwkpajvqu"]
 
-[ext_resource type="FontFile" uid="uid://c6c7gnx36opr0" path="res://addons/gut/fonts/AnonymousPro-Regular.ttf" id="1_df57p"]
+[ext_resource type="FontFile" uid="uid://by3oq52ycm1xm" path="res://addons/gut/fonts/AnonymousPro-Regular.ttf" id="1_df57p"]
 
 [resource]
 default_font = ExtResource("1_df57p")

--- a/addons/gut/gui/MinGui.tscn
+++ b/addons/gut/gui/MinGui.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://cnqqdfsn80ise"]
+[gd_scene format=3 uid="uid://cnqqdfsn80ise"]
 
 [ext_resource type="Theme" uid="uid://cstkhwkpajvqu" path="res://addons/gut/gui/GutSceneTheme.tres" id="1_farmq"]
-[ext_resource type="FontFile" uid="uid://bnh0lslf4yh87" path="res://addons/gut/fonts/CourierPrime-Regular.ttf" id="2_a2e2l"]
+[ext_resource type="FontFile" uid="uid://dk6q5pvle82jv" path="res://addons/gut/fonts/CourierPrime-Regular.ttf" id="2_a2e2l"]
 [ext_resource type="Script" uid="uid://blvhsbnsvfyow" path="res://addons/gut/gui/gut_gui.gd" id="2_eokrf"]
 [ext_resource type="PackedScene" uid="uid://bvrqqgjpyouse" path="res://addons/gut/gui/ResizeHandle.tscn" id="4_xrhva"]
 

--- a/addons/gut/gui/NormalGui.tscn
+++ b/addons/gut/gui/NormalGui.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://duxblir3vu8x7"]
+[gd_scene format=3 uid="uid://duxblir3vu8x7"]
 
 [ext_resource type="Theme" uid="uid://cstkhwkpajvqu" path="res://addons/gut/gui/GutSceneTheme.tres" id="1_5hlsm"]
 [ext_resource type="Script" uid="uid://blvhsbnsvfyow" path="res://addons/gut/gui/gut_gui.gd" id="2_fue6q"]
-[ext_resource type="FontFile" uid="uid://bnh0lslf4yh87" path="res://addons/gut/fonts/CourierPrime-Regular.ttf" id="2_u5uc1"]
+[ext_resource type="FontFile" uid="uid://dk6q5pvle82jv" path="res://addons/gut/fonts/CourierPrime-Regular.ttf" id="2_u5uc1"]
 [ext_resource type="PackedScene" uid="uid://bvrqqgjpyouse" path="res://addons/gut/gui/ResizeHandle.tscn" id="4_2r8a8"]
 
 [node name="Large" type="Panel"]


### PR DESCRIPTION
Regenerate missing font UID files and scene references for GUT addon. Fixes AnonymousPro and CourierPrime UID warnings on every test run.