### PR TITLE
fix: add rack.refresh() so test_hide_slot_for assertions fire

### DIFF
--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -141,6 +141,8 @@ func test_hide_slot_for_hides_only_the_matching_item() -> void:
 	manager.take(beta.key)
 	await get_tree().process_frame
 
+	rack.refresh()
+	await get_tree().process_frame
 	rack.hide_slot_for(alpha.key)
 
 	for child in rack.slot_container.get_children():


### PR DESCRIPTION
test_hide_slot_for_hides_only_the_matching_item was marked risky because slot_container had no slot children. Added rack.refresh() before hide_slot_for so the assertions actually execute.