### PR TITLE
fix: add floor collision back for outside-court bounds

### DIFF
--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -7,12 +7,16 @@
 [ext_resource type="Script" uid="uid://s5unp15ypwlr" path="res://scripts/core/venue_camera.gd" id="5_wttuf"]
 [ext_resource type="PackedScene" uid="uid://dnx2do12mtfyp" path="res://scenes/workshop.tscn" id="6_s1xkn"]
 [ext_resource type="Script" uid="uid://dqv0f22hkxsa2" path="res://scripts/core/venue_bound_debug_draw.gd" id="7_bound"]
+[ext_resource type="PhysicsMaterial" uid="uid://bldc0c7o5o2o4" path="res://resources/ball/play.tres" id="8_qo0oe"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_s1xkn"]
 size = Vector2(4000, 40)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_j16ra"]
 size = Vector2(40, 4000)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_o1mbd"]
+size = Vector2(5840, 20)
 
 [node name="Venue" type="Control" unique_id=160510095 node_paths=PackedStringArray("shop", "court")]
 layout_mode = 3
@@ -116,3 +120,10 @@ z_index = -850
 position = Vector2(0, 159)
 color = Color(0.15, 0.1, 0.08, 1)
 polygon = PackedVector2Array(-2920, 405, 2920, 405, 1297.7778, -50, -1297.7778, -50)
+
+[node name="FloorCollision" type="StaticBody2D" parent="VenueFloor" unique_id=935009470]
+position = Vector2(0, 400)
+physics_material_override = ExtResource("8_qo0oe")
+
+[node name="CollisionShape" type="CollisionShape2D" parent="VenueFloor/FloorCollision" unique_id=1701255113]
+shape = SubResource("RectangleShape2D_o1mbd")


### PR DESCRIPTION
SH-544. VenueFloor lost its collision body when converted to visual Node2D. Adds FloorCollision (StaticBody2D at y=400) with 5840x20 CollisionShape2D and ball physics material, matching CourtFloor dimensions.