### PR TITLE
chore: remove orphaned .uid sidecars

### DIFF
--- a/scripts/items/effect/outcomes/raise_floor_speed_outcome.gd.uid
+++ b/scripts/items/effect/outcomes/raise_floor_speed_outcome.gd.uid
@@ -1,1 +1,0 @@
-uid://cylsxmmdpflw1

--- a/tests/unit/items/test_cadence.gd.uid
+++ b/tests/unit/items/test_cadence.gd.uid
@@ -1,1 +1,0 @@
-uid://bnt1swk4cu8uw

--- a/tests/unit/items/test_raise_floor_speed_outcome.gd.uid
+++ b/tests/unit/items/test_raise_floor_speed_outcome.gd.uid
@@ -1,1 +1,0 @@
-uid://c1ygwqylakfpd

--- a/tests/unit/items/test_spare.gd.uid
+++ b/tests/unit/items/test_spare.gd.uid
@@ -1,1 +1,0 @@
-uid://cabl1pjyabo7i

--- a/tests/unit/paddle/test_partner_paddle.gd.uid
+++ b/tests/unit/paddle/test_partner_paddle.gd.uid
@@ -1,1 +1,0 @@
-uid://dkcgnp2i7okjv


### PR DESCRIPTION
Removes five orphaned .uid sidecar files whose source .gd files were deleted in PR #1094.