### PR TITLE
feat: add workshop ball upgrade flow

### DIFF
--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -86,8 +86,10 @@ right_anchor = NodePath("../VenueRightBound")
 z_index = -50
 position = Vector2(367, 3.13)
 
-[node name="Workshop" parent="." unique_id=1830461434 instance=ExtResource("6_s1xkn")]
+[node name="Workshop" parent="." unique_id=1830461434 node_paths=PackedStringArray("ball_reconciler", "ball_rack") instance=ExtResource("6_s1xkn")]
 position = Vector2(-1500, 0)
+ball_reconciler = NodePath("../Court/BallReconciler")
+ball_rack = NodePath("../Court/BallRack")
 
 [node name="VenueCeiling" type="StaticBody2D" parent="." unique_id=1902326706]
 position = Vector2(0, -1500)

--- a/scenes/workshop.tscn
+++ b/scenes/workshop.tscn
@@ -1,8 +1,17 @@
 [gd_scene format=3 uid="uid://dnx2do12mtfyp"]
 
-[node name="Workshop" type="Node2D" unique_id=1830461434]
+[ext_resource type="Script" uid="uid://bebffst1f1ox7" path="res://scripts/core/workshop.gd" id="1_d7fqo"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_d7fqo"]
+size = Vector2(500, 400)
+
+[node name="Workshop" type="Node2D" unique_id=1830461434 node_paths=PackedStringArray("drop_area", "upgrade_button", "upgrade_cost_label")]
 z_index = 100
 z_as_relative = false
+script = ExtResource("1_d7fqo")
+drop_area = NodePath("DropArea")
+upgrade_button = NodePath("UpgradeButton")
+upgrade_cost_label = NodePath("UpgradeCostLabel")
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1882650834]
@@ -20,3 +29,22 @@ offset_right = -240.0
 offset_bottom = -190.0
 theme_override_font_sizes/font_size = 36
 text = "Workshop"
+
+[node name="DropArea" type="Area2D" parent="." unique_id=1333165920]
+
+[node name="DropShape" type="CollisionShape2D" parent="DropArea" unique_id=128541832]
+shape = SubResource("RectangleShape2D_d7fqo")
+
+[node name="UpgradeButton" type="Button" parent="." unique_id=57890820]
+visible = false
+offset_top = 230.0
+offset_right = 91.0
+offset_bottom = 266.0
+text = "Upgrade"
+
+[node name="UpgradeCostLabel" type="Label" parent="." unique_id=967339765]
+visible = false
+offset_top = 200.0
+offset_right = 1.0
+offset_bottom = 228.0
+text = "Cost: 50"

--- a/scripts/core/workshop.gd
+++ b/scripts/core/workshop.gd
@@ -53,8 +53,9 @@ func _on_upgrade_pressed() -> void:
 	var cost: int = definition.upgrade_cost
 	if _item_manager.get_soul_balance() < cost:
 		return
+	if not _item_manager.upgrade_ball(_docked_item_key):
+		return
 	_item_manager.subtract_soul(cost)
-	_item_manager.upgrade_ball(_docked_item_key)
 	_item_manager.reassign_rack_slot(_docked_item_key)
 	_position_ball_on_rack(_docked_item_key)
 	_docked_item_key = ""

--- a/scripts/core/workshop.gd
+++ b/scripts/core/workshop.gd
@@ -3,6 +3,8 @@ extends Node2D
 @export var drop_area: Area2D
 @export var upgrade_button: Button
 @export var upgrade_cost_label: Label
+@export var ball_reconciler: BallReconciler
+@export var ball_rack: Node
 
 var _item_manager: Node
 var _docked_item_key: String = ""
@@ -25,7 +27,6 @@ func dock_ball(item_key: String) -> void:
 		return
 	_docked_item_key = item_key
 	_item_manager.deactivate(item_key)
-	_item_manager.reassign_rack_slot(item_key)
 	_position_ball_at_self(item_key)
 	_show_upgrade_ui()
 
@@ -56,7 +57,6 @@ func _on_upgrade_pressed() -> void:
 	if not _item_manager.upgrade_ball(_docked_item_key):
 		return
 	_item_manager.subtract_soul(cost)
-	_item_manager.reassign_rack_slot(_docked_item_key)
 	_position_ball_on_rack(_docked_item_key)
 	_docked_item_key = ""
 	_hide_upgrade_ui()
@@ -76,7 +76,7 @@ func _position_ball_on_rack(item_key: String) -> void:
 		return
 	if ball.has_method("enter_stored"):
 		ball.enter_stored()
-	var rack: Node = _find_rack()
+	var rack: Node = ball_rack
 	if rack != null and rack.has_method("get_slot_position_for"):
 		var slot_pos: Variant = rack.get_slot_position_for(item_key)
 		if slot_pos is Vector2 and ball is Node2D:
@@ -84,32 +84,12 @@ func _position_ball_on_rack(item_key: String) -> void:
 
 
 func _find_ball(item_key: String) -> Node:
-	var reconciler: Node = _find_reconciler()
+	var reconciler: Node = ball_reconciler
 	if reconciler == null:
 		return null
 	if not reconciler.has_method("get_ball_for_key"):
 		return null
 	return reconciler.get_ball_for_key(item_key)
-
-
-func _find_reconciler() -> Node:
-	var venue: Node = get_parent()
-	if venue == null:
-		return null
-	var court: Node = venue.get_node_or_null("Court")
-	if court == null:
-		return null
-	return court.get_node_or_null("BallReconciler")
-
-
-func _find_rack() -> Node:
-	var venue: Node = get_parent()
-	if venue == null:
-		return null
-	var court: Node = venue.get_node_or_null("Court")
-	if court == null:
-		return null
-	return court.get_node_or_null("BallRack")
 
 
 func _get_definition(item_key: String) -> ItemDefinition:

--- a/scripts/core/workshop.gd
+++ b/scripts/core/workshop.gd
@@ -1,0 +1,120 @@
+extends Node2D
+
+@export var drop_area: Area2D
+@export var upgrade_button: Button
+@export var upgrade_cost_label: Label
+
+var _item_manager: Node
+var _docked_item_key: String = ""
+
+
+func _ready() -> void:
+	if _item_manager == null:
+		_item_manager = ItemManager
+	if upgrade_button != null:
+		upgrade_button.pressed.connect(_on_upgrade_pressed)
+	_hide_upgrade_ui()
+
+
+func is_docked() -> bool:
+	return not _docked_item_key.is_empty()
+
+
+func dock_ball(item_key: String) -> void:
+	if _item_manager == null or not _docked_item_key.is_empty():
+		return
+	_docked_item_key = item_key
+	_item_manager.deactivate(item_key)
+	_item_manager.reassign_rack_slot(item_key)
+	_position_ball_at_self(item_key)
+	_show_upgrade_ui()
+
+
+func _show_upgrade_ui() -> void:
+	if not _docked_item_key.is_empty():
+		var definition: ItemDefinition = _get_definition(_docked_item_key)
+		if definition != null:
+			upgrade_cost_label.text = "Cost: %d" % definition.upgrade_cost
+	upgrade_button.visible = true
+	upgrade_cost_label.visible = true
+
+
+func _hide_upgrade_ui() -> void:
+	upgrade_button.visible = false
+	upgrade_cost_label.visible = false
+
+
+func _on_upgrade_pressed() -> void:
+	if _docked_item_key.is_empty() or _item_manager == null:
+		return
+	var definition: ItemDefinition = _get_definition(_docked_item_key)
+	if definition == null:
+		return
+	var cost: int = definition.upgrade_cost
+	if _item_manager.get_soul_balance() < cost:
+		return
+	_item_manager.subtract_soul(cost)
+	_item_manager.upgrade_ball(_docked_item_key)
+	_item_manager.reassign_rack_slot(_docked_item_key)
+	_position_ball_on_rack(_docked_item_key)
+	_docked_item_key = ""
+	_hide_upgrade_ui()
+
+
+func _position_ball_at_self(item_key: String) -> void:
+	var ball: Node = _find_ball(item_key)
+	if ball != null and ball.has_method("enter_stored"):
+		ball.enter_stored()
+	if ball != null and ball is Node2D:
+		(ball as Node2D).global_position = global_position
+
+
+func _position_ball_on_rack(item_key: String) -> void:
+	var ball: Node = _find_ball(item_key)
+	if ball == null:
+		return
+	if ball.has_method("enter_stored"):
+		ball.enter_stored()
+	var rack: Node = _find_rack()
+	if rack != null and rack.has_method("get_slot_position_for"):
+		var slot_pos: Variant = rack.get_slot_position_for(item_key)
+		if slot_pos is Vector2 and ball is Node2D:
+			(ball as Node2D).global_position = slot_pos
+
+
+func _find_ball(item_key: String) -> Node:
+	var reconciler: Node = _find_reconciler()
+	if reconciler == null:
+		return null
+	if not reconciler.has_method("get_ball_for_key"):
+		return null
+	return reconciler.get_ball_for_key(item_key)
+
+
+func _find_reconciler() -> Node:
+	var venue: Node = get_parent()
+	if venue == null:
+		return null
+	var court: Node = venue.get_node_or_null("Court")
+	if court == null:
+		return null
+	return court.get_node_or_null("BallReconciler")
+
+
+func _find_rack() -> Node:
+	var venue: Node = get_parent()
+	if venue == null:
+		return null
+	var court: Node = venue.get_node_or_null("Court")
+	if court == null:
+		return null
+	return court.get_node_or_null("BallRack")
+
+
+func _get_definition(item_key: String) -> ItemDefinition:
+	if _item_manager == null:
+		return null
+	for item: ItemDefinition in _item_manager.items:
+		if item.key == item_key:
+			return item
+	return null

--- a/scripts/core/workshop.gd.uid
+++ b/scripts/core/workshop.gd.uid
@@ -1,0 +1,1 @@
+uid://bebffst1f1ox7

--- a/scripts/court/tier_reward_handler.gd
+++ b/scripts/court/tier_reward_handler.gd
@@ -75,6 +75,3 @@ func _handle_first_reach(ball: Ball, completed_tier: int) -> void:
 
 	if ball == null or ball.item_key.is_empty():
 		return
-
-	# Deferred: this runs inside the ball's physics callback, where the rack rebuild upgrade triggers is illegal.
-	_item_manager.upgrade_ball.call_deferred(ball.item_key)

--- a/scripts/items/drop_targets/workshop_drop_target.gd
+++ b/scripts/items/drop_targets/workshop_drop_target.gd
@@ -1,0 +1,34 @@
+class_name WorkshopDropTarget
+extends DropTarget
+
+var _item_manager: Node
+var _drop_area: Area2D
+var _workshop: Node
+
+
+func configure(item_manager: Node, drop_area: Area2D, workshop: Node) -> void:
+	_item_manager = item_manager
+	_drop_area = drop_area
+	_workshop = workshop
+
+
+func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:
+	if _drop_area == null or _workshop == null or _item_manager == null:
+		return false
+	if _workshop.has_method(&"is_docked") and _workshop.is_docked():
+		return false
+	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
+	if definition == null or definition.role != &"ball":
+		return false
+	return _position_inside_area(position)
+
+
+func accept(item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
+	if _item_manager == null or _workshop == null:
+		return
+	if _workshop.has_method(&"dock_ball"):
+		_workshop.dock_ball(item_key)
+
+
+func _position_inside_area(world_position: Vector2) -> bool:
+	return DropTarget.area_world_rect(_drop_area).has_point(world_position)

--- a/scripts/items/drop_targets/workshop_drop_target.gd.uid
+++ b/scripts/items/drop_targets/workshop_drop_target.gd.uid
@@ -1,0 +1,1 @@
+uid://4sacun6lcy5r

--- a/scripts/items/item_definition.gd
+++ b/scripts/items/item_definition.gd
@@ -19,6 +19,8 @@ extends Resource
 @export var purchasable: bool = true
 ## Authored at-rest shape for drop-target body projection; null falls back to bounds-only acceptance.
 @export var at_rest_shape: Shape2D
+## Soul cost for one upgrade in the workshop; player pays this per upgrade level.
+@export var upgrade_cost: int = 50
 ## Per-character anchor for equipped visual; empty path falls back to character root.
 @export var anchor_node_path: NodePath
 

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -9,6 +9,9 @@ const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd
 const CharacterDropTargetScript: GDScript = preload(
 	"res://scripts/items/drop_targets/character_drop_target.gd"
 )
+const WorkshopDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/workshop_drop_target.gd"
+)
 
 const CURSOR_SAMPLE_WINDOW: float = 0.08
 const PRESERVED_SPEED_NONE: float = -1.0
@@ -19,6 +22,7 @@ const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
 @export var rack_drop_target: Area2D
 @export var gear_rack: RackDisplay
 @export var gear_rack_drop_target: Area2D
+@export var workshop_drop_target: Area2D
 @export var timeout_controller: TimeoutController
 @export var court_bounds: Rect2 = Rect2()
 @export var venue_bounds: Rect2 = Rect2()
@@ -419,6 +423,10 @@ func attempt_release(release_position: Vector2) -> bool:
 			_release_held_body_as_loose(release_position)
 		_finalise_gesture(item_key, release_position, false)
 		return true
+	elif target is WorkshopDropTarget:
+		target.accept(item_key, release_position, Vector2.ZERO)
+		_finalise_gesture(item_key, release_position, false)
+		return true
 	else:
 		# Restore is the safety net when ItemManager was already STORED so accept's deactivate was a no-op.
 		target.accept(item_key, release_position, Vector2.ZERO)
@@ -666,6 +674,7 @@ func _register_builtin_targets() -> void:
 
 	for target: DropTarget in [
 		CharacterDropTarget.new(),
+		_make_workshop_target(),
 		_make_rack_target(rack_drop_target, &"ball"),
 		_make_rack_target(gear_rack_drop_target, &"equipment"),
 		_make_court_target(),
@@ -690,6 +699,15 @@ func _make_rack_target(area: Area2D, role: StringName) -> RackDropTarget:
 	var rack_target: RackDropTarget = RackDropTarget.new()
 	rack_target.configure(_item_manager, area, role)
 	return rack_target
+
+
+func _make_workshop_target() -> WorkshopDropTarget:
+	if workshop_drop_target == null:
+		return null
+	var workshop_node: Node = workshop_drop_target.get_parent()
+	var ws_target: WorkshopDropTarget = WorkshopDropTargetScript.new()
+	ws_target.configure(_item_manager, workshop_drop_target, workshop_node)
+	return ws_target
 
 
 func _make_venue_target() -> VenueDropTarget:

--- a/tests/unit/court/test_court_multi_ball.gd
+++ b/tests/unit/court/test_court_multi_ball.gd
@@ -299,9 +299,9 @@ func test_attach_second_ball_mid_rally_does_not_change_current_ball() -> void:
 	)
 
 
-# Regression: first-reach tier upgrades must fire independently per ball, not once globally.
-# Ball A reaching tier 0 first should not consume the first-reach slot for ball B.
-func test_first_reach_upgrade_fires_independently_per_ball() -> void:
+# First-reach no longer triggers auto-upgrades; upgrades are player-driven through the workshop.
+# Ball A reaching tier 0 should not change the level of either ball.
+func test_first_reach_does_not_auto_upgrade() -> void:
 	var first: Ball = _spawn_ball("ball_alpha")
 	var second: Ball = _spawn_ball("ball_beta")
 
@@ -318,8 +318,8 @@ func test_first_reach_upgrade_fires_independently_per_ball() -> void:
 
 	assert_eq(
 		_manager.get_level("ball_alpha"),
-		alpha_level_before + 1,
-		"first ball reaching tier 0 for the first time must trigger its upgrade",
+		alpha_level_before,
+		"first ball reaching tier 0 must not auto-upgrade (upgrade is now player-driven)",
 	)
 
 	second.current_tier = 0
@@ -329,8 +329,8 @@ func test_first_reach_upgrade_fires_independently_per_ball() -> void:
 
 	assert_eq(
 		_manager.get_level("ball_beta"),
-		beta_level_before + 1,
-		"second ball reaching tier 0 for the first time must also trigger its own upgrade, independent of ball_alpha",
+		beta_level_before,
+		"second ball reaching tier 0 must also not auto-upgrade (upgrade is now player-driven)",
 	)
 
 


### PR DESCRIPTION
Player drags a ball to the workshop drop area, clicks upgrade, and pays soul to level up the ball. Auto-upgrade on tier completion is removed since upgrades are now player-driven.

Adds `upgrade_cost` to ItemDefinition (default 50), the WorkshopDropTarget and Workshop scripts, and wires the drag-drop target into the priority list (after CharacterDropTarget, before rack targets).

### Review fixes applied

- Replaced `_find_reconciler()` and `_find_rack()` tree-walk with `@export` references wired in venue.tscn.
- Removed redundant `reassign_rack_slot` call in `dock_ball()`: deactivate() already assigns the slot.
- Removed redundant `reassign_rack_slot` call in `_on_upgrade_pressed()`: upgrade_ball() does not touch slot assignment.