### PR TITLE
feat: track ball consolidations, gate workshop upgrades behind thresholds

### DIFF
--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -86,8 +86,10 @@ right_anchor = NodePath("../VenueRightBound")
 z_index = -50
 position = Vector2(367, 3.13)
 
-[node name="Workshop" parent="." unique_id=1830461434 instance=ExtResource("6_s1xkn")]
+[node name="Workshop" parent="." unique_id=1830461434 node_paths=PackedStringArray("ball_reconciler", "ball_rack") instance=ExtResource("6_s1xkn")]
 position = Vector2(-1500, 0)
+ball_reconciler = NodePath("../Court/BallReconciler")
+ball_rack = NodePath("../Court/BallRack")
 
 [node name="VenueCeiling" type="StaticBody2D" parent="." unique_id=1902326706]
 position = Vector2(0, -1500)

--- a/scripts/core/workshop.gd
+++ b/scripts/core/workshop.gd
@@ -3,6 +3,8 @@ extends Node2D
 @export var drop_area: Area2D
 @export var upgrade_button: Button
 @export var upgrade_cost_label: Label
+@export var ball_reconciler: BallReconciler
+@export var ball_rack: Node
 
 var _item_manager: Node
 var _docked_item_key: String = ""
@@ -25,7 +27,6 @@ func dock_ball(item_key: String) -> void:
 		return
 	_docked_item_key = item_key
 	_item_manager.deactivate(item_key)
-	_item_manager.reassign_rack_slot(item_key)
 	_position_ball_at_self(item_key)
 	_show_upgrade_ui()
 
@@ -50,13 +51,14 @@ func _on_upgrade_pressed() -> void:
 	var definition: ItemDefinition = _get_definition(_docked_item_key)
 	if definition == null:
 		return
+	if not _item_manager.can_upgrade(_docked_item_key):
+		return
 	var cost: int = definition.upgrade_cost
 	if _item_manager.get_soul_balance() < cost:
 		return
 	if not _item_manager.upgrade_ball(_docked_item_key):
 		return
 	_item_manager.subtract_soul(cost)
-	_item_manager.reassign_rack_slot(_docked_item_key)
 	_position_ball_on_rack(_docked_item_key)
 	_docked_item_key = ""
 	_hide_upgrade_ui()
@@ -76,7 +78,7 @@ func _position_ball_on_rack(item_key: String) -> void:
 		return
 	if ball.has_method("enter_stored"):
 		ball.enter_stored()
-	var rack: Node = _find_rack()
+	var rack: Node = ball_rack
 	if rack != null and rack.has_method("get_slot_position_for"):
 		var slot_pos: Variant = rack.get_slot_position_for(item_key)
 		if slot_pos is Vector2 and ball is Node2D:
@@ -84,32 +86,12 @@ func _position_ball_on_rack(item_key: String) -> void:
 
 
 func _find_ball(item_key: String) -> Node:
-	var reconciler: Node = _find_reconciler()
+	var reconciler: Node = ball_reconciler
 	if reconciler == null:
 		return null
 	if not reconciler.has_method("get_ball_for_key"):
 		return null
 	return reconciler.get_ball_for_key(item_key)
-
-
-func _find_reconciler() -> Node:
-	var venue: Node = get_parent()
-	if venue == null:
-		return null
-	var court: Node = venue.get_node_or_null("Court")
-	if court == null:
-		return null
-	return court.get_node_or_null("BallReconciler")
-
-
-func _find_rack() -> Node:
-	var venue: Node = get_parent()
-	if venue == null:
-		return null
-	var court: Node = venue.get_node_or_null("Court")
-	if court == null:
-		return null
-	return court.get_node_or_null("BallRack")
 
 
 func _get_definition(item_key: String) -> ItemDefinition:

--- a/scripts/court/tier_reward_handler.gd
+++ b/scripts/court/tier_reward_handler.gd
@@ -59,6 +59,10 @@ func on_tier_advanced(ball: Ball, new_tier: int) -> void:
 		ball.increment_soul_multiplier(1.0)
 
 	_item_manager.process_event(&"on_consolidation")
+
+	if ball != null and not ball.item_key.is_empty():
+		_item_manager.record_consolidation(ball.item_key)
+
 	consolidation_fired.emit()
 
 

--- a/scripts/items/item_definition.gd
+++ b/scripts/items/item_definition.gd
@@ -21,6 +21,10 @@ extends Resource
 @export var at_rest_shape: Shape2D
 ## Soul cost for one upgrade in the workshop; player pays this per upgrade level.
 @export var upgrade_cost: int = 50
+## Consolidations needed to reach the second upgrade tier.
+@export var consolidations_to_l2: int = 5
+## Consolidations needed to reach the third upgrade tier.
+@export var consolidations_to_l3: int = 10
 ## Per-character anchor for equipped visual; empty path falls back to character root.
 @export var anchor_node_path: NodePath
 

--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -372,6 +372,37 @@ func adopt_authored(item_key: String) -> void:
 		_set_item_placement(item_key, _natural_target(_get_item(item_key)))
 
 
+## Records one consolidation for a ball. Increments the per-ball counter used by the workshop gate.
+func record_consolidation(item_key: String) -> void:
+	if state == null:
+		return
+	var item := _get_item(item_key)
+	if item == null or item.role != &"ball":
+		return
+	state.ball_consolidations[item_key] = state.ball_consolidations.get(item_key, 0) + 1
+
+
+## Returns the number of recorded consolidations for a ball.
+func get_consolidations(item_key: String) -> int:
+	return state.ball_consolidations.get(item_key, 0)
+
+
+## Returns true when the consolidation threshold for the next upgrade level is met.
+func can_upgrade(item_key: String) -> bool:
+	var item := _get_item(item_key)
+	if item == null or item.role != &"ball":
+		return false
+	var current_level := get_level(item_key)
+	if current_level <= 0 or current_level >= item.max_level:
+		return false
+	var consolidations := get_consolidations(item_key)
+	if current_level == 1 and consolidations >= item.consolidations_to_l2:
+		return true
+	if current_level == 2 and consolidations >= item.consolidations_to_l3:
+		return true
+	return false
+
+
 ## Bumps an owned ball item by one level (capped at max_level), refreshing its effects.
 ## Returns true when the level increased. Intended for tier-completion ball upgrades.
 func upgrade_ball(item_key: String) -> bool:

--- a/scripts/progression/item_state.gd
+++ b/scripts/progression/item_state.gd
@@ -16,6 +16,9 @@ var rack_slot_index_by_key: Dictionary[String, int] = {}
 ## Loose drag-token items keyed by item key, value is their drop position.
 var loose_in_venue: Dictionary[String, Vector2] = {}
 
+## Consolidation count per ball key. Gates workshop upgrades behind thresholds.
+var ball_consolidations: Dictionary[String, int] = {}
+
 
 func clear() -> void:
 	item_levels = {}
@@ -24,6 +27,7 @@ func clear() -> void:
 	ball_play_states = {}
 	rack_slot_index_by_key = {}
 	loose_in_venue = {}
+	ball_consolidations = {}
 
 
 func to_save_dict() -> Dictionary:
@@ -34,6 +38,7 @@ func to_save_dict() -> Dictionary:
 		"ball_play_states": ball_play_states,
 		"rack_slot_index_by_key": rack_slot_index_by_key,
 		"loose_in_venue": _serialize_positions(loose_in_venue),
+		"ball_consolidations": ball_consolidations,
 	}
 
 
@@ -44,6 +49,7 @@ func apply_save_dict(data: Dictionary) -> void:
 	ball_play_states = _to_typed_int_dict(data.get("ball_play_states", {}))
 	rack_slot_index_by_key = _to_typed_int_dict(data.get("rack_slot_index_by_key", {}))
 	loose_in_venue = _parse_positions(data.get("loose_in_venue", {}))
+	ball_consolidations = _to_typed_int_dict(data.get("ball_consolidations", {}))
 
 
 static func _to_typed_int_dict(raw: Dictionary) -> Dictionary[String, int]:

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -550,6 +550,56 @@ class TestEquipFlow:
 		assert_false(_manager.unequip("gear_a"))
 
 
+class TestConsolidationCounter:
+	extends GutTest
+	const BALL_KEY := "test_ball"
+	const EQUIP_KEY := "test_speed"
+	var _manager: Node
+
+	func before_each() -> void:
+		_manager = ItemFactory.create_manager(self)
+		var ball_item := ItemDefinition.new()
+		ball_item.key = BALL_KEY
+		ball_item.role = &"ball"
+		ball_item.base_cost = 100
+		ball_item.cost_scaling = 2.0
+		ball_item.max_level = 3
+		ball_item.consolidations_to_l2 = 3
+		ball_item.consolidations_to_l3 = 6
+		ball_item.effects = []
+		_manager.items.append(ball_item)
+		_manager.economy.soul_balance = 10000
+
+	func test_record_consolidation_increments_counter() -> void:
+		ItemFactory.give(_manager, BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		assert_eq(_manager.get_consolidations(BALL_KEY), 1)
+		_manager.record_consolidation(BALL_KEY)
+		assert_eq(_manager.get_consolidations(BALL_KEY), 2)
+
+	func test_can_upgrade_returns_false_below_threshold() -> void:
+		ItemFactory.give(_manager, BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		assert_false(_manager.can_upgrade(BALL_KEY))
+
+	func test_can_upgrade_returns_true_when_threshold_met() -> void:
+		ItemFactory.give(_manager, BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		assert_true(_manager.can_upgrade(BALL_KEY))
+
+	func test_can_upgrade_returns_false_at_max_level() -> void:
+		ItemFactory.give(_manager, BALL_KEY, 3)
+		_manager.state.ball_consolidations[BALL_KEY] = 10
+		assert_false(_manager.can_upgrade(BALL_KEY))
+
+	func test_record_consolidation_skips_non_ball_role() -> void:
+		_manager.record_consolidation(EQUIP_KEY)
+		assert_eq(_manager.get_consolidations(EQUIP_KEY), 0)
+
+
 class TestItemManagerStateChanged:
 	extends GutTest
 	const TEST_KEY := "test_speed"


### PR DESCRIPTION
Track a consolidation counter per ball that increments on every tier completion. The workshop upgrade button now requires meeting the consolidation threshold (configurable per item definition as `consolidations_to_l2` and `consolidations_to_l3`) before the soul cost gate.