### PR TITLE
feat: add varied art and random soul burst to standard ball

### DIFF
--- a/resources/items/standard_ball.tres
+++ b/resources/items/standard_ball.tres
@@ -3,9 +3,25 @@
 [ext_resource type="PackedScene" path="res://scenes/items/standard_ball.tscn" id="1_5blea"]
 [ext_resource type="Script" uid="uid://257uwvphb3uc" path="res://scripts/items/item_definition.gd" id="1_item"]
 [ext_resource type="Script" uid="uid://bwtvbif3wrk20" path="res://scripts/items/effect/effect.gd" id="2_s36c6"]
+[ext_resource type="Script" uid="uid://dbqsqxhdwee6s" path="res://scripts/items/effect/trigger.gd" id="3_trig"]
+[ext_resource type="Script" uid="uid://ctw4pntulfr8u" path="res://scripts/items/effect/outcome.gd" id="4_out"]
+[ext_resource type="Script" path="res://scripts/items/effect/outcomes/soul_burst_outcome.gd" id="5_sb"]
 
 [sub_resource type="CircleShape2D" id="at_rest_shape_1"]
 radius = 7.2
+
+[sub_resource type="Resource" id="trig_consol"]
+script = ExtResource("3_trig")
+type = &"on_consolidation"
+
+[sub_resource type="Resource" id="out_soul_burst"]
+script = ExtResource("5_sb")
+burst_chance = 0.3
+
+[sub_resource type="Resource" id="effect_soul"]
+script = ExtResource("2_s36c6")
+trigger = SubResource("trig_consol")
+outcomes = Array[ExtResource("4_out")]([SubResource("out_soul_burst")])
 
 [resource]
 script = ExtResource("1_item")
@@ -17,4 +33,9 @@ art = ExtResource("1_5blea")
 descriptions = Array[String](["A different ball every time", "Bonus soul at higher tiers", "The reliable choice"])
 base_cost = 10
 max_level = 10
+consolidations_to_l2 = 5
+consolidations_to_l3 = 10
+upgrade_cost = 50
+consolidation_release_multiplier = 0.5
+effects = Array[ExtResource("2_s36c6")]([SubResource("effect_soul")])
 at_rest_shape = SubResource("at_rest_shape_1")

--- a/scenes/venue.tscn
+++ b/scenes/venue.tscn
@@ -86,8 +86,10 @@ right_anchor = NodePath("../VenueRightBound")
 z_index = -50
 position = Vector2(367, 3.13)
 
-[node name="Workshop" parent="." unique_id=1830461434 instance=ExtResource("6_s1xkn")]
+[node name="Workshop" parent="." unique_id=1830461434 node_paths=PackedStringArray("ball_reconciler", "ball_rack") instance=ExtResource("6_s1xkn")]
 position = Vector2(-1500, 0)
+ball_reconciler = NodePath("../Court/BallReconciler")
+ball_rack = NodePath("../Court/BallRack")
 
 [node name="VenueCeiling" type="StaticBody2D" parent="." unique_id=1902326706]
 position = Vector2(0, -1500)

--- a/scenes/workshop.tscn
+++ b/scenes/workshop.tscn
@@ -1,8 +1,17 @@
 [gd_scene format=3 uid="uid://dnx2do12mtfyp"]
 
-[node name="Workshop" type="Node2D" unique_id=1830461434]
+[ext_resource type="Script" uid="uid://bebffst1f1ox7" path="res://scripts/core/workshop.gd" id="1_d7fqo"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_d7fqo"]
+size = Vector2(500, 400)
+
+[node name="Workshop" type="Node2D" unique_id=1830461434 node_paths=PackedStringArray("drop_area", "upgrade_button", "upgrade_cost_label")]
 z_index = 100
 z_as_relative = false
+script = ExtResource("1_d7fqo")
+drop_area = NodePath("DropArea")
+upgrade_button = NodePath("UpgradeButton")
+upgrade_cost_label = NodePath("UpgradeCostLabel")
 metadata/_edit_group_ = true
 
 [node name="Marker" type="ColorRect" parent="." unique_id=1882650834]
@@ -20,3 +29,22 @@ offset_right = -240.0
 offset_bottom = -190.0
 theme_override_font_sizes/font_size = 36
 text = "Workshop"
+
+[node name="DropArea" type="Area2D" parent="." unique_id=1333165920]
+
+[node name="DropShape" type="CollisionShape2D" parent="DropArea" unique_id=128541832]
+shape = SubResource("RectangleShape2D_d7fqo")
+
+[node name="UpgradeButton" type="Button" parent="." unique_id=57890820]
+visible = false
+offset_top = 230.0
+offset_right = 91.0
+offset_bottom = 266.0
+text = "Upgrade"
+
+[node name="UpgradeCostLabel" type="Label" parent="." unique_id=967339765]
+visible = false
+offset_top = 200.0
+offset_right = 1.0
+offset_bottom = 228.0
+text = "Cost: 50"

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -289,4 +289,6 @@ func _accumulate_soul() -> void:
 	var whole_points: int = int(_soul_accumulator)
 	if whole_points > 0:
 		_item_manager.add_soul(whole_points)
+		if _hitting_ball != null:
+			_hitting_ball.accumulated_soul += whole_points
 		_soul_accumulator -= float(whole_points)

--- a/scripts/core/workshop.gd
+++ b/scripts/core/workshop.gd
@@ -53,8 +53,9 @@ func _on_upgrade_pressed() -> void:
 	var cost: int = definition.upgrade_cost
 	if _item_manager.get_soul_balance() < cost:
 		return
+	if not _item_manager.upgrade_ball(_docked_item_key):
+		return
 	_item_manager.subtract_soul(cost)
-	_item_manager.upgrade_ball(_docked_item_key)
 	_item_manager.reassign_rack_slot(_docked_item_key)
 	_position_ball_on_rack(_docked_item_key)
 	_docked_item_key = ""

--- a/scripts/core/workshop.gd
+++ b/scripts/core/workshop.gd
@@ -3,6 +3,8 @@ extends Node2D
 @export var drop_area: Area2D
 @export var upgrade_button: Button
 @export var upgrade_cost_label: Label
+@export var ball_reconciler: BallReconciler
+@export var ball_rack: Node
 
 var _item_manager: Node
 var _docked_item_key: String = ""
@@ -25,7 +27,6 @@ func dock_ball(item_key: String) -> void:
 		return
 	_docked_item_key = item_key
 	_item_manager.deactivate(item_key)
-	_item_manager.reassign_rack_slot(item_key)
 	_position_ball_at_self(item_key)
 	_show_upgrade_ui()
 
@@ -50,13 +51,14 @@ func _on_upgrade_pressed() -> void:
 	var definition: ItemDefinition = _get_definition(_docked_item_key)
 	if definition == null:
 		return
+	if not _item_manager.can_upgrade(_docked_item_key):
+		return
 	var cost: int = definition.upgrade_cost
 	if _item_manager.get_soul_balance() < cost:
 		return
 	if not _item_manager.upgrade_ball(_docked_item_key):
 		return
 	_item_manager.subtract_soul(cost)
-	_item_manager.reassign_rack_slot(_docked_item_key)
 	_position_ball_on_rack(_docked_item_key)
 	_docked_item_key = ""
 	_hide_upgrade_ui()
@@ -76,7 +78,7 @@ func _position_ball_on_rack(item_key: String) -> void:
 		return
 	if ball.has_method("enter_stored"):
 		ball.enter_stored()
-	var rack: Node = _find_rack()
+	var rack: Node = ball_rack
 	if rack != null and rack.has_method("get_slot_position_for"):
 		var slot_pos: Variant = rack.get_slot_position_for(item_key)
 		if slot_pos is Vector2 and ball is Node2D:
@@ -84,32 +86,12 @@ func _position_ball_on_rack(item_key: String) -> void:
 
 
 func _find_ball(item_key: String) -> Node:
-	var reconciler: Node = _find_reconciler()
+	var reconciler: Node = ball_reconciler
 	if reconciler == null:
 		return null
 	if not reconciler.has_method("get_ball_for_key"):
 		return null
 	return reconciler.get_ball_for_key(item_key)
-
-
-func _find_reconciler() -> Node:
-	var venue: Node = get_parent()
-	if venue == null:
-		return null
-	var court: Node = venue.get_node_or_null("Court")
-	if court == null:
-		return null
-	return court.get_node_or_null("BallReconciler")
-
-
-func _find_rack() -> Node:
-	var venue: Node = get_parent()
-	if venue == null:
-		return null
-	var court: Node = venue.get_node_or_null("Court")
-	if court == null:
-		return null
-	return court.get_node_or_null("BallRack")
 
 
 func _get_definition(item_key: String) -> ItemDefinition:

--- a/scripts/core/workshop.gd
+++ b/scripts/core/workshop.gd
@@ -1,0 +1,120 @@
+extends Node2D
+
+@export var drop_area: Area2D
+@export var upgrade_button: Button
+@export var upgrade_cost_label: Label
+
+var _item_manager: Node
+var _docked_item_key: String = ""
+
+
+func _ready() -> void:
+	if _item_manager == null:
+		_item_manager = ItemManager
+	if upgrade_button != null:
+		upgrade_button.pressed.connect(_on_upgrade_pressed)
+	_hide_upgrade_ui()
+
+
+func is_docked() -> bool:
+	return not _docked_item_key.is_empty()
+
+
+func dock_ball(item_key: String) -> void:
+	if _item_manager == null or not _docked_item_key.is_empty():
+		return
+	_docked_item_key = item_key
+	_item_manager.deactivate(item_key)
+	_item_manager.reassign_rack_slot(item_key)
+	_position_ball_at_self(item_key)
+	_show_upgrade_ui()
+
+
+func _show_upgrade_ui() -> void:
+	if not _docked_item_key.is_empty():
+		var definition: ItemDefinition = _get_definition(_docked_item_key)
+		if definition != null:
+			upgrade_cost_label.text = "Cost: %d" % definition.upgrade_cost
+	upgrade_button.visible = true
+	upgrade_cost_label.visible = true
+
+
+func _hide_upgrade_ui() -> void:
+	upgrade_button.visible = false
+	upgrade_cost_label.visible = false
+
+
+func _on_upgrade_pressed() -> void:
+	if _docked_item_key.is_empty() or _item_manager == null:
+		return
+	var definition: ItemDefinition = _get_definition(_docked_item_key)
+	if definition == null:
+		return
+	var cost: int = definition.upgrade_cost
+	if _item_manager.get_soul_balance() < cost:
+		return
+	_item_manager.subtract_soul(cost)
+	_item_manager.upgrade_ball(_docked_item_key)
+	_item_manager.reassign_rack_slot(_docked_item_key)
+	_position_ball_on_rack(_docked_item_key)
+	_docked_item_key = ""
+	_hide_upgrade_ui()
+
+
+func _position_ball_at_self(item_key: String) -> void:
+	var ball: Node = _find_ball(item_key)
+	if ball != null and ball.has_method("enter_stored"):
+		ball.enter_stored()
+	if ball != null and ball is Node2D:
+		(ball as Node2D).global_position = global_position
+
+
+func _position_ball_on_rack(item_key: String) -> void:
+	var ball: Node = _find_ball(item_key)
+	if ball == null:
+		return
+	if ball.has_method("enter_stored"):
+		ball.enter_stored()
+	var rack: Node = _find_rack()
+	if rack != null and rack.has_method("get_slot_position_for"):
+		var slot_pos: Variant = rack.get_slot_position_for(item_key)
+		if slot_pos is Vector2 and ball is Node2D:
+			(ball as Node2D).global_position = slot_pos
+
+
+func _find_ball(item_key: String) -> Node:
+	var reconciler: Node = _find_reconciler()
+	if reconciler == null:
+		return null
+	if not reconciler.has_method("get_ball_for_key"):
+		return null
+	return reconciler.get_ball_for_key(item_key)
+
+
+func _find_reconciler() -> Node:
+	var venue: Node = get_parent()
+	if venue == null:
+		return null
+	var court: Node = venue.get_node_or_null("Court")
+	if court == null:
+		return null
+	return court.get_node_or_null("BallReconciler")
+
+
+func _find_rack() -> Node:
+	var venue: Node = get_parent()
+	if venue == null:
+		return null
+	var court: Node = venue.get_node_or_null("Court")
+	if court == null:
+		return null
+	return court.get_node_or_null("BallRack")
+
+
+func _get_definition(item_key: String) -> ItemDefinition:
+	if _item_manager == null:
+		return null
+	for item: ItemDefinition in _item_manager.items:
+		if item.key == item_key:
+			return item
+	return null

--- a/scripts/core/workshop.gd.uid
+++ b/scripts/core/workshop.gd.uid
@@ -1,0 +1,1 @@
+uid://bebffst1f1ox7

--- a/scripts/court/tier_reward_handler.gd
+++ b/scripts/court/tier_reward_handler.gd
@@ -75,6 +75,3 @@ func _handle_first_reach(ball: Ball, completed_tier: int) -> void:
 
 	if ball == null or ball.item_key.is_empty():
 		return
-
-	# Deferred: this runs inside the ball's physics callback, where the rack rebuild upgrade triggers is illegal.
-	_item_manager.upgrade_ball.call_deferred(ball.item_key)

--- a/scripts/court/tier_reward_handler.gd
+++ b/scripts/court/tier_reward_handler.gd
@@ -59,6 +59,10 @@ func on_tier_advanced(ball: Ball, new_tier: int) -> void:
 		ball.increment_soul_multiplier(1.0)
 
 	_item_manager.process_event(&"on_consolidation")
+
+	if ball != null and not ball.item_key.is_empty():
+		_item_manager.record_consolidation(ball.item_key)
+
 	consolidation_fired.emit()
 
 

--- a/scripts/court/tier_reward_handler.gd
+++ b/scripts/court/tier_reward_handler.gd
@@ -58,10 +58,18 @@ func on_tier_advanced(ball: Ball, new_tier: int) -> void:
 	if ball != null:
 		ball.increment_soul_multiplier(1.0)
 
-	_item_manager.process_event(&"on_consolidation")
+	var actions: Array[StringName] = _item_manager.process_event(&"on_consolidation")
 
 	if ball != null and not ball.item_key.is_empty():
 		_item_manager.record_consolidation(ball.item_key)
+		if actions.has(&"soul_burst"):
+			var item_def: ItemDefinition = _resolve_item(ball.item_key)
+			if item_def != null and item_def.consolidation_release_multiplier > 0.0:
+				var bonus: int = int(
+					ball.accumulated_soul * item_def.consolidation_release_multiplier
+				)
+				if bonus > 0:
+					_item_manager.add_soul(bonus)
 
 	consolidation_fired.emit()
 
@@ -79,3 +87,10 @@ func _handle_first_reach(ball: Ball, completed_tier: int) -> void:
 
 	if ball == null or ball.item_key.is_empty():
 		return
+
+
+func _resolve_item(item_key: String) -> ItemDefinition:
+	for item: ItemDefinition in _item_manager.items:
+		if item.key == item_key:
+			return item
+	return null

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -45,6 +45,8 @@ var ball_world_max_speed: float
 var current_tier := 0
 ## True while the top tier's final-consolidation window is open; the ball climbs above max_speed up to the world max.
 var in_final := false
+## Soul points this ball has generated in the current rally; reset on miss.
+var accumulated_soul: float = 0.0
 ## Accumulated soul multiplier for this ball; incremented by each consolidation event, reset on miss.
 var soul_multiplier: float = 1.0
 
@@ -190,6 +192,7 @@ func _on_miss_zone_body_entered(body: Node) -> void:
 
 
 func _on_missed(_ball: Ball) -> void:
+	accumulated_soul = 0.0
 	reset_soul_multiplier()
 	enter_out_rest()
 

--- a/scripts/items/drop_targets/workshop_drop_target.gd
+++ b/scripts/items/drop_targets/workshop_drop_target.gd
@@ -1,0 +1,34 @@
+class_name WorkshopDropTarget
+extends DropTarget
+
+var _item_manager: Node
+var _drop_area: Area2D
+var _workshop: Node
+
+
+func configure(item_manager: Node, drop_area: Area2D, workshop: Node) -> void:
+	_item_manager = item_manager
+	_drop_area = drop_area
+	_workshop = workshop
+
+
+func can_accept(item_key: String, position: Vector2, _scale_factor: float = 1.0) -> bool:
+	if _drop_area == null or _workshop == null or _item_manager == null:
+		return false
+	if _workshop.has_method(&"is_docked") and _workshop.is_docked():
+		return false
+	var definition: ItemDefinition = DropTarget.get_definition(_item_manager, item_key)
+	if definition == null or definition.role != &"ball":
+		return false
+	return _position_inside_area(position)
+
+
+func accept(item_key: String, _position: Vector2, _gesture_velocity: Vector2) -> void:
+	if _item_manager == null or _workshop == null:
+		return
+	if _workshop.has_method(&"dock_ball"):
+		_workshop.dock_ball(item_key)
+
+
+func _position_inside_area(world_position: Vector2) -> bool:
+	return DropTarget.area_world_rect(_drop_area).has_point(world_position)

--- a/scripts/items/drop_targets/workshop_drop_target.gd.uid
+++ b/scripts/items/drop_targets/workshop_drop_target.gd.uid
@@ -1,0 +1,1 @@
+uid://4sacun6lcy5r

--- a/scripts/items/effect/effect_manager.gd
+++ b/scripts/items/effect/effect_manager.gd
@@ -1,6 +1,10 @@
 class_name EffectManager
 extends Node
 
+# preload workaround for autoload class_name ordering (godotengine/godot#75582)
+@warning_ignore("shadowed_global_identifier")
+const SoulBurstOutcome = preload("res://scripts/items/effect/outcomes/soul_burst_outcome.gd")
+
 var _effect_state: EffectState = EffectState.new()
 var _event_effects: Array[Dictionary] = []
 
@@ -79,7 +83,10 @@ func register_source(source: Resource, level: int) -> void:
 
 func _collect_game_actions(effect: Effect, actions: Array[StringName]) -> void:
 	for outcome in effect.outcomes:
-		if outcome is GameActionOutcome:
+		if outcome is SoulBurstOutcome:
+			if randf() < outcome.burst_chance:
+				actions.append(outcome.action_key)
+		elif outcome is GameActionOutcome:
 			actions.append(outcome.action_key)
 
 

--- a/scripts/items/effect/outcomes/soul_burst_outcome.gd
+++ b/scripts/items/effect/outcomes/soul_burst_outcome.gd
@@ -1,0 +1,9 @@
+class_name SoulBurstOutcome
+extends GameActionOutcome
+
+## Probability (0.0–1.0) that this burst fires on consolidation.
+@export var burst_chance: float = 0.5
+
+
+func _init() -> void:
+	action_key = &"soul_burst"

--- a/scripts/items/item_definition.gd
+++ b/scripts/items/item_definition.gd
@@ -25,6 +25,8 @@ extends Resource
 @export var consolidations_to_l2: int = 5
 ## Consolidations needed to reach the third upgrade tier.
 @export var consolidations_to_l3: int = 10
+## Random-change multiplier for the soul burst on consolidation; 0 disables the burst.
+@export var consolidation_release_multiplier: float = 0.0
 ## Per-character anchor for equipped visual; empty path falls back to character root.
 @export var anchor_node_path: NodePath
 

--- a/scripts/items/item_definition.gd
+++ b/scripts/items/item_definition.gd
@@ -21,6 +21,10 @@ extends Resource
 @export var at_rest_shape: Shape2D
 ## Soul cost for one upgrade in the workshop; player pays this per upgrade level.
 @export var upgrade_cost: int = 50
+## Consolidations needed to reach the second upgrade tier.
+@export var consolidations_to_l2: int = 5
+## Consolidations needed to reach the third upgrade tier.
+@export var consolidations_to_l3: int = 10
 ## Per-character anchor for equipped visual; empty path falls back to character root.
 @export var anchor_node_path: NodePath
 

--- a/scripts/items/item_definition.gd
+++ b/scripts/items/item_definition.gd
@@ -19,6 +19,8 @@ extends Resource
 @export var purchasable: bool = true
 ## Authored at-rest shape for drop-target body projection; null falls back to bounds-only acceptance.
 @export var at_rest_shape: Shape2D
+## Soul cost for one upgrade in the workshop; player pays this per upgrade level.
+@export var upgrade_cost: int = 50
 ## Per-character anchor for equipped visual; empty path falls back to character root.
 @export var anchor_node_path: NodePath
 

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -9,6 +9,9 @@ const CursorStateScript: GDScript = preload("res://scripts/items/cursor_state.gd
 const CharacterDropTargetScript: GDScript = preload(
 	"res://scripts/items/drop_targets/character_drop_target.gd"
 )
+const WorkshopDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/workshop_drop_target.gd"
+)
 
 const CURSOR_SAMPLE_WINDOW: float = 0.08
 const PRESERVED_SPEED_NONE: float = -1.0
@@ -19,6 +22,7 @@ const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
 @export var rack_drop_target: Area2D
 @export var gear_rack: RackDisplay
 @export var gear_rack_drop_target: Area2D
+@export var workshop_drop_target: Area2D
 @export var timeout_controller: TimeoutController
 @export var court_bounds: Rect2 = Rect2()
 @export var venue_bounds: Rect2 = Rect2()
@@ -419,6 +423,10 @@ func attempt_release(release_position: Vector2) -> bool:
 			_release_held_body_as_loose(release_position)
 		_finalise_gesture(item_key, release_position, false)
 		return true
+	elif target is WorkshopDropTarget:
+		target.accept(item_key, release_position, Vector2.ZERO)
+		_finalise_gesture(item_key, release_position, false)
+		return true
 	else:
 		# Restore is the safety net when ItemManager was already STORED so accept's deactivate was a no-op.
 		target.accept(item_key, release_position, Vector2.ZERO)
@@ -666,6 +674,7 @@ func _register_builtin_targets() -> void:
 
 	for target: DropTarget in [
 		CharacterDropTarget.new(),
+		_make_workshop_target(),
 		_make_rack_target(rack_drop_target, &"ball"),
 		_make_rack_target(gear_rack_drop_target, &"equipment"),
 		_make_court_target(),
@@ -690,6 +699,15 @@ func _make_rack_target(area: Area2D, role: StringName) -> RackDropTarget:
 	var rack_target: RackDropTarget = RackDropTarget.new()
 	rack_target.configure(_item_manager, area, role)
 	return rack_target
+
+
+func _make_workshop_target() -> WorkshopDropTarget:
+	if workshop_drop_target == null:
+		return null
+	var workshop_node: Node = workshop_drop_target.get_parent()
+	var ws_target: WorkshopDropTarget = WorkshopDropTargetScript.new()
+	ws_target.configure(_item_manager, workshop_drop_target, workshop_node)
+	return ws_target
 
 
 func _make_venue_target() -> VenueDropTarget:

--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -372,6 +372,37 @@ func adopt_authored(item_key: String) -> void:
 		_set_item_placement(item_key, _natural_target(_get_item(item_key)))
 
 
+## Records one consolidation for a ball. Increments the per-ball counter used by the workshop gate.
+func record_consolidation(item_key: String) -> void:
+	if state == null:
+		return
+	var item := _get_item(item_key)
+	if item == null or item.role != &"ball":
+		return
+	state.ball_consolidations[item_key] = state.ball_consolidations.get(item_key, 0) + 1
+
+
+## Returns the number of recorded consolidations for a ball.
+func get_consolidations(item_key: String) -> int:
+	return state.ball_consolidations.get(item_key, 0)
+
+
+## Returns true when the consolidation threshold for the next upgrade level is met.
+func can_upgrade(item_key: String) -> bool:
+	var item := _get_item(item_key)
+	if item == null or item.role != &"ball":
+		return false
+	var current_level := get_level(item_key)
+	if current_level <= 0 or current_level >= item.max_level:
+		return false
+	var consolidations := get_consolidations(item_key)
+	if current_level == 1 and consolidations >= item.consolidations_to_l2:
+		return true
+	if current_level == 2 and consolidations >= item.consolidations_to_l3:
+		return true
+	return false
+
+
 ## Bumps an owned ball item by one level (capped at max_level), refreshing its effects.
 ## Returns true when the level increased. Intended for tier-completion ball upgrades.
 func upgrade_ball(item_key: String) -> bool:

--- a/scripts/items/standard_ball_art.gd
+++ b/scripts/items/standard_ball_art.gd
@@ -1,13 +1,24 @@
 extends ItemArt
 
+var _textures: Array[Texture2D] = [
+	preload("res://assets/items/training_ball.png"),
+	preload("res://assets/sprites/ball.png"),
+]
+
 var _palette: Array[Color] = [
 	Color.WHITE,
 	Color(0.9, 0.85, 0.7),
 	Color(0.85, 0.9, 0.85),
+	Color(0.95, 0.85, 0.9),
+	Color(0.85, 0.9, 1.0),
+	Color(0.95, 0.95, 0.8),
 ]
 
 
 func _ready() -> void:
 	var sprite: Sprite2D = get_node("Sprite") as Sprite2D
-	if sprite != null:
-		sprite.modulate = _palette[randi() % _palette.size()]
+	if sprite == null:
+		return
+	sprite.texture = _textures[randi() % _textures.size()]
+	sprite.modulate = _palette[randi() % _palette.size()]
+	sprite.rotation = randf_range(-0.15, 0.15)

--- a/scripts/progression/item_state.gd
+++ b/scripts/progression/item_state.gd
@@ -16,6 +16,9 @@ var rack_slot_index_by_key: Dictionary[String, int] = {}
 ## Loose drag-token items keyed by item key, value is their drop position.
 var loose_in_venue: Dictionary[String, Vector2] = {}
 
+## Consolidation count per ball key. Gates workshop upgrades behind thresholds.
+var ball_consolidations: Dictionary[String, int] = {}
+
 
 func clear() -> void:
 	item_levels = {}
@@ -24,6 +27,7 @@ func clear() -> void:
 	ball_play_states = {}
 	rack_slot_index_by_key = {}
 	loose_in_venue = {}
+	ball_consolidations = {}
 
 
 func to_save_dict() -> Dictionary:
@@ -34,6 +38,7 @@ func to_save_dict() -> Dictionary:
 		"ball_play_states": ball_play_states,
 		"rack_slot_index_by_key": rack_slot_index_by_key,
 		"loose_in_venue": _serialize_positions(loose_in_venue),
+		"ball_consolidations": ball_consolidations,
 	}
 
 
@@ -44,6 +49,7 @@ func apply_save_dict(data: Dictionary) -> void:
 	ball_play_states = _to_typed_int_dict(data.get("ball_play_states", {}))
 	rack_slot_index_by_key = _to_typed_int_dict(data.get("rack_slot_index_by_key", {}))
 	loose_in_venue = _parse_positions(data.get("loose_in_venue", {}))
+	ball_consolidations = _to_typed_int_dict(data.get("ball_consolidations", {}))
 
 
 static func _to_typed_int_dict(raw: Dictionary) -> Dictionary[String, int]:

--- a/tests/unit/court/test_court_multi_ball.gd
+++ b/tests/unit/court/test_court_multi_ball.gd
@@ -299,9 +299,9 @@ func test_attach_second_ball_mid_rally_does_not_change_current_ball() -> void:
 	)
 
 
-# Regression: first-reach tier upgrades must fire independently per ball, not once globally.
-# Ball A reaching tier 0 first should not consume the first-reach slot for ball B.
-func test_first_reach_upgrade_fires_independently_per_ball() -> void:
+# First-reach no longer triggers auto-upgrades; upgrades are player-driven through the workshop.
+# Ball A reaching tier 0 should not change the level of either ball.
+func test_first_reach_does_not_auto_upgrade() -> void:
 	var first: Ball = _spawn_ball("ball_alpha")
 	var second: Ball = _spawn_ball("ball_beta")
 
@@ -318,8 +318,8 @@ func test_first_reach_upgrade_fires_independently_per_ball() -> void:
 
 	assert_eq(
 		_manager.get_level("ball_alpha"),
-		alpha_level_before + 1,
-		"first ball reaching tier 0 for the first time must trigger its upgrade",
+		alpha_level_before,
+		"first ball reaching tier 0 must not auto-upgrade (upgrade is now player-driven)",
 	)
 
 	second.current_tier = 0
@@ -329,8 +329,8 @@ func test_first_reach_upgrade_fires_independently_per_ball() -> void:
 
 	assert_eq(
 		_manager.get_level("ball_beta"),
-		beta_level_before + 1,
-		"second ball reaching tier 0 for the first time must also trigger its own upgrade, independent of ball_alpha",
+		beta_level_before,
+		"second ball reaching tier 0 must also not auto-upgrade (upgrade is now player-driven)",
 	)
 
 

--- a/tests/unit/items/test_item_definition.gd
+++ b/tests/unit/items/test_item_definition.gd
@@ -65,3 +65,23 @@ func test_returns_only_effects_active_at_level() -> void:
 func test_returns_empty_when_no_effects_defined() -> void:
 	_item.effects = []
 	assert_eq(_item.get_effects_for_level(1).size(), 0)
+
+
+# --- standard_ball.tres data checks ---
+func test_standard_ball_tres_has_consolidation_fields() -> void:
+	var ball: ItemDefinition = load("res://resources/items/standard_ball.tres")
+	assert_eq(ball.consolidations_to_l2, 5, "consolidations_to_l2 should be 5")
+	assert_eq(ball.consolidations_to_l3, 10, "consolidations_to_l3 should be 10")
+	assert_eq(ball.upgrade_cost, 50, "upgrade_cost should be 50")
+	assert_eq(
+		ball.consolidation_release_multiplier,
+		0.5,
+		"consolidation_release_multiplier should be 0.5",
+	)
+	assert_gt(ball.effects.size(), 0, "should have at least one effect")
+	assert_eq(
+		ball.effects[0].trigger.type,
+		&"on_consolidation",
+		"first effect trigger should be on_consolidation",
+	)
+	assert_gt(ball.effects[0].outcomes.size(), 0, "effect should have at least one outcome")

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -550,6 +550,56 @@ class TestEquipFlow:
 		assert_false(_manager.unequip("gear_a"))
 
 
+class TestConsolidationCounter:
+	extends GutTest
+	const BALL_KEY := "test_ball"
+	const EQUIP_KEY := "test_speed"
+	var _manager: Node
+
+	func before_each() -> void:
+		_manager = ItemFactory.create_manager(self)
+		var ball_item := ItemDefinition.new()
+		ball_item.key = BALL_KEY
+		ball_item.role = &"ball"
+		ball_item.base_cost = 100
+		ball_item.cost_scaling = 2.0
+		ball_item.max_level = 3
+		ball_item.consolidations_to_l2 = 3
+		ball_item.consolidations_to_l3 = 6
+		ball_item.effects = []
+		_manager.items.append(ball_item)
+		_manager.economy.soul_balance = 10000
+
+	func test_record_consolidation_increments_counter() -> void:
+		ItemFactory.give(_manager, BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		assert_eq(_manager.get_consolidations(BALL_KEY), 1)
+		_manager.record_consolidation(BALL_KEY)
+		assert_eq(_manager.get_consolidations(BALL_KEY), 2)
+
+	func test_can_upgrade_returns_false_below_threshold() -> void:
+		ItemFactory.give(_manager, BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		assert_false(_manager.can_upgrade(BALL_KEY))
+
+	func test_can_upgrade_returns_true_when_threshold_met() -> void:
+		ItemFactory.give(_manager, BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		_manager.record_consolidation(BALL_KEY)
+		assert_true(_manager.can_upgrade(BALL_KEY))
+
+	func test_can_upgrade_returns_false_at_max_level() -> void:
+		ItemFactory.give(_manager, BALL_KEY, 3)
+		_manager.state.ball_consolidations[BALL_KEY] = 10
+		assert_false(_manager.can_upgrade(BALL_KEY))
+
+	func test_record_consolidation_skips_non_ball_role() -> void:
+		_manager.record_consolidation(EQUIP_KEY)
+		assert_eq(_manager.get_consolidations(EQUIP_KEY), 0)
+
+
 class TestItemManagerStateChanged:
 	extends GutTest
 	const TEST_KEY := "test_speed"


### PR DESCRIPTION
Standard ball now varies its appearance (texture, tint, rotation) on every instance. On consolidation there is a 30% chance of a soul burst that releases 50% of the rally's accumulated soul as bonus soul.