### PR TITLE
feat: duplicate pricing for ball shop rotation

### DIFF
--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -286,10 +286,10 @@ func unequip(item_key: String) -> bool:
 	return deactivate(item_key)
 
 
-## Returns total cost of an item at its current level
+## Returns total cost of an item at its current level; each subsequent copy costs double the previous.
 func calculate_cost(item_key: String) -> int:
 	var item: ItemDefinition = _get_item(item_key)
-	return int(item.base_cost * pow(item.cost_scaling, get_level(item_key)))
+	return int(item.base_cost * pow(2.0, get_level(item_key)))
 
 
 ## Returns true if the item is unowned and affordable. Used by drop targets.
@@ -349,7 +349,7 @@ func remove_level(item_key: String) -> void:
 	var current_level := get_level(item_key)
 	if current_level > 0:
 		var item := _get_item(item_key)
-		var refund := int(item.base_cost * pow(item.cost_scaling, current_level - 1))
+		var refund := int(item.base_cost * pow(2.0, current_level - 1))
 		_refund_soul(refund)
 		_set_level(item_key, current_level - 1)
 

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -321,6 +321,9 @@ func _notify_ball_settled(ball: Ball, settled_position: Vector2) -> void:
 			_release_ball_from_registry(reconciler, ball)
 			visible = true
 			return
+	else:
+		# Already owned: attempt upgrade via purchase; silent on failure (max level, broke).
+		_complete_purchase()
 
 	visible = false
 	# Mark as loose-in-venue so the rack filter hides the slot while the Ball rests on the venue floor.
@@ -377,7 +380,8 @@ func _start_drag() -> void:
 
 func _complete_purchase() -> bool:
 	if is_owned():
-		return false
+		# Already owned: attempt upgrade via purchase()
+		return _item_manager.purchase(item_definition.key)
 	if not can_be_owned():
 		return false
 	return _item_manager.take(item_definition.key)

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -65,6 +65,85 @@ class TestPurchase:
 		assert_signal_emitted_with_parameters(_manager, "item_level_changed", [TEST_KEY])
 
 
+class TestDuplicatePricing:
+	extends GutTest
+	const TEST_KEY := "test_speed"
+	var _manager: Node
+
+	func before_each() -> void:
+		_manager = ItemFactory.create_manager(self)
+
+	func test_cost_at_level_zero_is_base() -> void:
+		assert_eq(_manager.calculate_cost(TEST_KEY), 100)
+
+	func test_cost_at_level_one_is_double_base() -> void:
+		_manager.economy.soul_balance = 10000
+		_manager.purchase(TEST_KEY)
+		assert_eq(_manager.calculate_cost(TEST_KEY), 200)
+
+	func test_cost_at_level_two_is_quadruple_base() -> void:
+		_manager.economy.soul_balance = 10000
+		_manager.purchase(TEST_KEY)
+		_manager.purchase(TEST_KEY)
+		assert_eq(_manager.calculate_cost(TEST_KEY), 400)
+
+	func test_cost_at_level_three_is_eight_times_base() -> void:
+		_manager.economy.soul_balance = 10000
+		_manager.purchase(TEST_KEY)
+		_manager.purchase(TEST_KEY)
+		_manager.purchase(TEST_KEY)
+		assert_eq(_manager.calculate_cost(TEST_KEY), 800)
+
+
+class TestBallRepurchase:
+	extends GutTest
+	var _manager: Node
+
+	func before_each() -> void:
+		_manager = ItemFactory.create_manager(self)
+		var ball := ItemDefinition.new()
+		ball.key = "test_ball"
+		ball.role = &"ball"
+		ball.base_cost = 100
+		ball.cost_scaling = 2.0
+		ball.max_level = 5
+		ball.effects = []
+		_manager.items.assign([ball])
+
+	func test_ball_can_be_purchased_multiple_times() -> void:
+		_manager.economy.soul_balance = 10000
+		assert_true(_manager.purchase("test_ball"), "first purchase should succeed")
+		assert_true(_manager.purchase("test_ball"), "second purchase should succeed")
+		assert_eq(_manager.get_level("test_ball"), 2)
+
+	func test_ball_purchase_cost_doubles_each_copy() -> void:
+		_manager.economy.soul_balance = 10000
+		_manager.purchase("test_ball")
+		assert_eq(_manager.calculate_cost("test_ball"), 200, "cost should be 2x after first copy")
+		_manager.purchase("test_ball")
+		assert_eq(_manager.calculate_cost("test_ball"), 400, "cost should be 4x after second copy")
+
+	func test_ball_take_blocks_re_purchase() -> void:
+		_manager.economy.soul_balance = 10000
+		assert_true(_manager.take("test_ball"), "first take should succeed")
+		assert_false(_manager.take("test_ball"), "take must block re-purchase for ball items too")
+
+	func test_non_ball_take_blocks_re_purchase() -> void:
+		_manager = ItemFactory.create_manager(self)
+		_manager.economy.soul_balance = 10000
+		assert_true(_manager.take(TestPurchase.TEST_KEY), "first take should succeed")
+		assert_false(_manager.take(TestPurchase.TEST_KEY), "second take must fail for non-ball")
+		assert_eq(_manager.get_level(TestPurchase.TEST_KEY), 1)
+
+	func test_non_ball_take_preserves_balance_on_rejected_re_purchase() -> void:
+		_manager = ItemFactory.create_manager(self)
+		_manager.economy.soul_balance = 10000
+		_manager.take(TestPurchase.TEST_KEY)
+		var balance_before: int = _manager.get_soul_balance()
+		_manager.take(TestPurchase.TEST_KEY)
+		assert_eq(_manager.get_soul_balance(), balance_before, "rejected take must not deduct soul")
+
+
 class TestStats:
 	extends GutTest
 	const TEST_KEY := "test_speed"

--- a/tests/unit/shop/test_shop_item.gd
+++ b/tests/unit/shop/test_shop_item.gd
@@ -88,6 +88,22 @@ func test_settle_inside_shop_restores_slot() -> void:
 	assert_eq(_manager.get_level(StandardBall.key), 0, "no purchase on inside settle")
 
 
+func test_owned_ball_can_be_upgraded_from_shop() -> void:
+	_setup_item(StandardBall)
+	_manager.economy.soul_balance = 10000
+	# First purchase via the shop flow
+	_item.start_drag()
+	_item.attempt_release(Vector2(800, 300))
+	assert_eq(_manager.get_level(StandardBall.key), 1, "first purchase sets level 1")
+
+	# Second purchase: owned ball can be re-purchased for upgrade
+	_item.visible = true
+	_item.start_drag()
+	_item.attempt_release(Vector2(800, 300))
+	assert_eq(_manager.get_level(StandardBall.key), 2, "re-purchase upgrades to level 2")
+	assert_false(_item.visible, "slot hidden after re-purchase")
+
+
 func _setup_item(definition: ItemDefinition) -> void:
 	_manager = ItemFactory.create_manager(self)
 	_manager.items.assign([definition])


### PR DESCRIPTION
calculate_cost now uses pow(2.0, level) so each subsequent copy costs double. Shop _complete_purchase falls through to purchase() when the item is owned, allowing ball upgrades via the drag gesture. take() continues to block re-purchase for first-acquisition-only semantics.