### PR TITLE
SH-539: Stock refresh - restock button

### DIFF
--- a/scenes/shop.tscn
+++ b/scenes/shop.tscn
@@ -8,11 +8,13 @@ size = Vector2(500, 287)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_table"]
 size = Vector2(400, 20)
 
-[node name="Shop" type="Node2D" unique_id=177934000 node_paths=PackedStringArray("shop_area", "soul_label", "items_anchor") groups=["hot_reloadable_config"]]
+[node name="Shop" type="Node2D" unique_id=177934000 node_paths=PackedStringArray("shop_area", "soul_label", "items_anchor", "restock_button", "refresh_count_label") groups=["hot_reloadable_config"]]
 script = ExtResource("1_shop")
 shop_area = NodePath("ShopArea")
 soul_label = NodePath("SoulLabel")
 items_anchor = NodePath("ItemsAnchor")
+restock_button = NodePath("RefreshButton")
+refresh_count_label = NodePath("RefreshCountLabel")
 
 [node name="SoulLabel" type="Label" parent="." unique_id=1271857459]
 offset_left = -100.0
@@ -63,3 +65,18 @@ color = Color(0.35, 0.2, 0.1, 1)
 
 [node name="ItemsAnchor" type="Node2D" parent="." unique_id=681031275]
 position = Vector2(0, -30)
+
+[node name="RefreshButton" type="Button" parent="."]
+offset_left = -60.0
+offset_top = 50.0
+offset_right = 60.0
+offset_bottom = 74.0
+text = "Restock (Free)"
+
+[node name="RefreshCountLabel" type="Label" parent="."]
+offset_left = -60.0
+offset_top = 80.0
+offset_right = 60.0
+offset_bottom = 100.0
+text = "Refresh: 0"
+horizontal_alignment = 1

--- a/scripts/shop/shop.gd
+++ b/scripts/shop/shop.gd
@@ -12,11 +12,14 @@ const DEFAULT_DRAG_TUNING: ShopDragTuning = preload("res://resources/shop/shop_d
 @export var shop_area: Area2D
 @export var soul_label: Label
 @export var items_anchor: Node2D
+@export var restock_button: Button
+@export var refresh_count_label: Label
 
 var _item_manager: Node
 ## Cached so tree_exiting can unregister after `get_tree()` would return null.
 var _registered_target: ShopDropTarget = null
 var _registered_controller: Node = null
+var _refresh_count: int = 0
 
 
 func _ready() -> void:
@@ -31,6 +34,9 @@ func _ready() -> void:
 	_register_shop_target()
 	if not tree_exiting.is_connected(_on_tree_exiting):
 		tree_exiting.connect(_on_tree_exiting)
+	if restock_button != null and not restock_button.pressed.is_connected(_on_restock_pressed):
+		restock_button.pressed.connect(_on_restock_pressed)
+	_update_restock_button()
 
 
 ## Deferred so the controller has run `_ready` and joined the `drag_controller` group.
@@ -89,9 +95,54 @@ func _get_visible_items() -> Array[ItemDefinition]:
 			continue
 		if _item_manager.get_level(definition.key) == 0:
 			available.append(definition)
-		if available.size() >= config.display_slots:
-			break
-	return available
+	available.shuffle()
+	return available.slice(0, config.display_slots)
+
+
+func _clear_items() -> void:
+	for child: Node in items_anchor.get_children():
+		items_anchor.remove_child(child)
+		child.free()
+
+
+func restock() -> void:
+	var cost: int = _calculate_restock_cost()
+	if cost > 0:
+		if _item_manager.get_soul_balance() < cost:
+			return
+		_item_manager.subtract_soul(cost)
+	_clear_items()
+	_spawn_items()
+	_refresh_count += 1
+	_update_restock_button()
+
+
+func _calculate_restock_cost() -> int:
+	if _refresh_count == 0:
+		return 0
+	var total: int = 0
+	for child: Node in items_anchor.get_children():
+		var shop_item: ShopItem = child as ShopItem
+		if shop_item != null and shop_item.item_definition != null:
+			total += shop_item.item_definition.base_cost
+	return max(1, ceili(total * config.restock_cost_multiplier))
+
+
+func _on_restock_pressed() -> void:
+	restock()
+
+
+func _update_restock_button() -> void:
+	if restock_button == null:
+		return
+	var cost: int = _calculate_restock_cost()
+	if cost == 0:
+		restock_button.text = "Restock (Free)"
+	else:
+		restock_button.text = "Restock (%d Soul)" % cost
+		restock_button.disabled = _item_manager.get_soul_balance() < cost
+	if refresh_count_label != null:
+		refresh_count_label.text = "Refresh: %d" % _refresh_count
 
 
 func _update_soul_label(balance: int) -> void:
@@ -100,6 +151,7 @@ func _update_soul_label(balance: int) -> void:
 
 func _on_soul_balance_changed(balance: int) -> void:
 	_update_soul_label(balance)
+	_update_restock_button()
 
 
 # Refresh the shop pool when an item is purchased so its tile leaves the table.

--- a/scripts/shop/shop_config.gd
+++ b/scripts/shop/shop_config.gd
@@ -3,3 +3,5 @@ extends Resource
 
 @export var display_slots: int = 5
 @export var item_spacing: float = 80.0
+## Fraction of displayed items' total base cost charged for restock after the first free one.
+@export var restock_cost_multiplier: float = 0.2

--- a/tests/unit/shop/test_shop_restock.gd
+++ b/tests/unit/shop/test_shop_restock.gd
@@ -1,0 +1,165 @@
+extends GutTest
+
+const ShopScene: PackedScene = preload("res://scenes/shop.tscn")
+
+var _manager: Node
+var _shop: Node
+
+
+func before_each() -> void:
+	_manager = _make_manager_with_balls()
+	_shop = ShopScene.instantiate()
+	_shop._item_manager = _manager
+	_shop._refresh_count = 0
+	add_child_autofree(_shop)
+	_shop._update_restock_button()
+
+
+func test_first_restock_is_free() -> void:
+	var balance_before: int = _manager.economy.soul_balance
+	_shop.restock()
+	assert_eq(_manager.economy.soul_balance, balance_before, "first restock deducts no soul")
+	assert_eq(_shop._refresh_count, 1, "refresh count incremented")
+
+
+func test_second_restock_costs_soul() -> void:
+	_manager.add_soul(500)
+	_shop._refresh_count = 1
+	var balance_before: int = _manager.economy.soul_balance
+	_shop.restock()
+	assert_lt(_manager.economy.soul_balance, balance_before, "soul deducted after first restock")
+
+
+func test_restock_cost_scales_with_displayed_item_base_costs() -> void:
+	_manager.add_soul(500)
+	_shop._refresh_count = 1
+	var cost: int = _shop._calculate_restock_cost()
+	var total_base: int = 0
+	for child in _shop.items_anchor.get_children():
+		var si: ShopItem = child as ShopItem
+		if si != null and si.item_definition != null:
+			total_base += si.item_definition.base_cost
+	var expected: int = max(1, ceili(total_base * _shop.config.restock_cost_multiplier))
+	assert_eq(cost, expected, "cost scales with displayed items' base costs")
+
+
+func test_restock_refuses_when_broke() -> void:
+	_manager.economy.soul_balance = 0
+	_shop._refresh_count = 1
+	assert_eq(_shop._refresh_count, 1)
+	var child_count_before: int = _shop.items_anchor.get_child_count()
+	_shop.restock()
+	assert_eq(_shop._refresh_count, 1, "refresh count unchanged when broke")
+	assert_eq(
+		_shop.items_anchor.get_child_count(),
+		child_count_before,
+		"items not cleared when restock refused"
+	)
+
+
+func test_restock_button_shows_free_initially() -> void:
+	assert_not_null(_shop.restock_button, "restock_button assigned")
+	assert_eq(_shop.restock_button.text, "Restock (Free)")
+
+
+func test_restock_button_updates_after_restock() -> void:
+	_manager.add_soul(500)
+	_shop.restock()
+	assert_string_contains(
+		_shop.restock_button.text, "Soul", "button shows soul cost after first restock"
+	)
+
+
+func test_restock_button_disabled_when_broke() -> void:
+	_manager.economy.soul_balance = 0
+	_shop._refresh_count = 1
+	_shop._update_restock_button()
+	assert_true(_shop.restock_button.disabled, "button disabled when broke")
+
+
+func test_restock_button_enabled_when_affordable() -> void:
+	_manager.add_soul(500)
+	_shop._refresh_count = 1
+	_shop._update_restock_button()
+	assert_false(_shop.restock_button.disabled, "button enabled when affordable")
+
+
+func test_refresh_count_label_shows_count() -> void:
+	assert_not_null(_shop.refresh_count_label, "refresh_count_label assigned")
+	assert_eq(_shop.refresh_count_label.text, "Refresh: 0")
+	_shop.restock()
+	assert_eq(_shop.refresh_count_label.text, "Refresh: 1")
+
+
+func test_calculate_restock_cost_returns_zero_for_first_refresh() -> void:
+	_shop._refresh_count = 0
+	assert_eq(_shop._calculate_restock_cost(), 0)
+
+
+func test_clear_items_removes_all_children() -> void:
+	_shop.restock()
+	assert_gt(_shop.items_anchor.get_child_count(), 0, "items exist before clear")
+	_shop._clear_items()
+	assert_eq(_shop.items_anchor.get_child_count(), 0, "all items removed after clear")
+
+
+func test_restock_replaces_item_nodes() -> void:
+	_manager.add_soul(500)
+	_shop._refresh_count = 1
+	var before_nodes: Array[Node] = _shop.items_anchor.get_children()
+	_shop.restock()
+	var after_nodes: Array[Node] = _shop.items_anchor.get_children()
+	var any_same: bool = false
+	for n in after_nodes:
+		if before_nodes.has(n):
+			any_same = true
+			break
+	assert_false(any_same, "restock replaces all item nodes with new instances")
+
+
+func test_restock_works_for_pool_larger_than_slots() -> void:
+	# Create a shop with pool > display_slots to guarantee a visible change.
+	_manager.add_soul(500)
+	_shop.config.display_slots = 2
+	_shop._refresh_count = 1
+	_shop._clear_items()
+	_shop._spawn_items()
+	var before_keys: Array[String] = _get_item_keys()
+
+	_shop.restock()
+	var after_keys: Array[String] = _get_item_keys()
+
+	assert_ne(
+		before_keys, after_keys, "restock changes the visible subset when pool exceeds slot count"
+	)
+
+
+func _get_item_keys() -> Array[String]:
+	var keys: Array[String] = []
+	for child: Node in _shop.items_anchor.get_children():
+		var si: ShopItem = child as ShopItem
+		if si != null and si.item_definition != null:
+			keys.append(si.item_definition.key)
+	return keys
+
+
+## Creates an ItemManager with several ball items so restock has a pool to shuffle.
+func _make_manager_with_balls() -> Node:
+	var ball_keys := ["test_ball_a", "test_ball_b", "test_ball_c", "test_ball_d", "test_ball_e"]
+	var ball_costs := [10, 20, 30, 40, 50]
+
+	# Use the first key for the initial manager item; we replace items immediately after.
+	var manager: Node = ItemFactory.create_manager(
+		self, ball_keys[0], &"ball_speed_min", &"add", 10.0
+	)
+
+	var definitions: Array[ItemDefinition] = []
+	for i in ball_keys.size():
+		var def: ItemDefinition = ItemFactory.create(ball_keys[i], &"ball_speed_min", &"add", 10.0)
+		def.role = &"ball"
+		def.base_cost = ball_costs[i]
+		definitions.append(def)
+
+	manager.items.assign(definitions)
+	manager.economy.soul_balance = 500
+	return manager

--- a/tests/unit/shop/test_shop_restock.gd.uid
+++ b/tests/unit/shop/test_shop_restock.gd.uid
@@ -1,0 +1,1 @@
+uid://doaxn12np1bv7


### PR DESCRIPTION
Adds a restock button to the ball shop that re-rolls the display. First refresh is free; subsequent refreshes cost a fraction of the displayed items' total base cost.