### PR TITLE
feat: add restock button with cost scaling to shop

### DIFF
--- a/scenes/shop.tscn
+++ b/scenes/shop.tscn
@@ -8,11 +8,13 @@ size = Vector2(500, 287)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_table"]
 size = Vector2(400, 20)
 
-[node name="Shop" type="Node2D" unique_id=177934000 node_paths=PackedStringArray("shop_area", "soul_label", "items_anchor") groups=["hot_reloadable_config"]]
+[node name="Shop" type="Node2D" unique_id=177934000 node_paths=PackedStringArray("shop_area", "soul_label", "items_anchor", "refresh_button", "refresh_cost_label") groups=["hot_reloadable_config"]]
 script = ExtResource("1_shop")
 shop_area = NodePath("ShopArea")
 soul_label = NodePath("SoulLabel")
 items_anchor = NodePath("ItemsAnchor")
+refresh_button = NodePath("RefreshButton")
+refresh_cost_label = NodePath("RefreshCostLabel")
 
 [node name="SoulLabel" type="Label" parent="." unique_id=1271857459]
 offset_left = -100.0
@@ -60,6 +62,21 @@ offset_right = 200.0
 offset_bottom = 144.0
 mouse_filter = 2
 color = Color(0.35, 0.2, 0.1, 1)
+
+[node name="RefreshButton" type="Button" parent="." unique_id=681031276]
+offset_left = -30.0
+offset_top = -195.0
+offset_right = 30.0
+offset_bottom = -170.0
+text = "Refresh"
+
+[node name="RefreshCostLabel" type="Label" parent="." unique_id=681031277]
+offset_left = -100.0
+offset_top = -170.0
+offset_right = 100.0
+offset_bottom = -150.0
+text = "FREE"
+horizontal_alignment = 1
 
 [node name="ItemsAnchor" type="Node2D" parent="." unique_id=681031275]
 position = Vector2(0, -30)

--- a/scripts/shop/shop.gd
+++ b/scripts/shop/shop.gd
@@ -12,8 +12,11 @@ const DEFAULT_DRAG_TUNING: ShopDragTuning = preload("res://resources/shop/shop_d
 @export var shop_area: Area2D
 @export var soul_label: Label
 @export var items_anchor: Node2D
+@export var refresh_button: Button
+@export var refresh_cost_label: Label
 
 var _item_manager: Node
+var _refresh_count: int = 0
 ## Cached so tree_exiting can unregister after `get_tree()` would return null.
 var _registered_target: ShopDropTarget = null
 var _registered_controller: Node = null
@@ -29,6 +32,9 @@ func _ready() -> void:
 	_update_soul_label(_item_manager.get_soul_balance())
 	_spawn_items()
 	_register_shop_target()
+	_update_refresh_ui()
+	if refresh_button != null:
+		refresh_button.pressed.connect(_on_refresh_pressed)
 	if not tree_exiting.is_connected(_on_tree_exiting):
 		tree_exiting.connect(_on_tree_exiting)
 
@@ -64,6 +70,42 @@ func _on_tree_exiting() -> void:
 	_registered_controller = null
 
 
+func _on_refresh_pressed() -> void:
+	var cost: int = _get_refresh_cost()
+	if cost > 0 and _item_manager.get_soul_balance() < cost:
+		return
+	if cost > 0:
+		_item_manager.subtract_soul(cost)
+	_refresh_count += 1
+	_clear_items()
+	_spawn_items()
+	_update_refresh_ui()
+
+
+func _get_refresh_cost() -> int:
+	if _refresh_count == 0:
+		return 0
+	return int(config.refresh_base_cost * pow(config.refresh_cost_scaling, _refresh_count - 1))
+
+
+func _update_refresh_ui() -> void:
+	if refresh_cost_label == null:
+		return
+	var cost: int = _get_refresh_cost()
+	if cost == 0:
+		refresh_cost_label.text = "FREE"
+	else:
+		refresh_cost_label.text = "%d soul" % cost
+	if refresh_button == null:
+		return
+	refresh_button.disabled = cost > 0 and _item_manager.get_soul_balance() < cost
+
+
+func _clear_items() -> void:
+	for child in items_anchor.get_children():
+		child.queue_free()
+
+
 func _spawn_items() -> void:
 	var visible_items: Array[ItemDefinition] = _get_visible_items()
 	var count: int = visible_items.size()
@@ -91,6 +133,7 @@ func _get_visible_items() -> Array[ItemDefinition]:
 			available.append(definition)
 		if available.size() >= config.display_slots:
 			break
+	available.shuffle()
 	return available
 
 

--- a/scripts/shop/shop_config.gd
+++ b/scripts/shop/shop_config.gd
@@ -3,3 +3,5 @@ extends Resource
 
 @export var display_slots: int = 5
 @export var item_spacing: float = 80.0
+@export var refresh_base_cost: int = 10
+@export var refresh_cost_scaling: float = 2.0

--- a/tests/unit/shop/test_shop_refresh.gd
+++ b/tests/unit/shop/test_shop_refresh.gd
@@ -1,0 +1,154 @@
+extends GutTest
+
+const ShopScript := preload("res://scripts/shop/shop.gd")
+const ShopConfigScript := preload("res://scripts/shop/shop_config.gd")
+const ItemManagerScript := preload("res://scripts/items/item_manager.gd")
+const StandardBall: ItemDefinition = preload("res://resources/items/standard_ball.tres")
+
+var _manager: Node
+var _shop: Shop
+var _config: ShopConfig
+
+
+func before_each() -> void:
+	_manager = _make_manager()
+	_config = ShopConfigScript.new()
+	_config.refresh_base_cost = 10
+	_config.refresh_cost_scaling = 2.0
+
+	_shop = ShopScript.new()
+	_shop._item_manager = _manager
+	_shop.config = _config
+	_shop.soul_label = Label.new()
+	_shop.items_anchor = Node2D.new()
+	_shop.items_anchor.name = "ItemsAnchor"
+	_shop.add_child(_shop.items_anchor)
+	_shop.add_child(_shop.soul_label)
+	add_child_autofree(_shop)
+
+
+func _make_manager() -> Node:
+	var manager: Node = ItemManagerScript.new()
+	manager.state = ItemState.new()
+	manager.economy = EconomyState.new()
+	manager._effect_manager = EffectManager.new()
+	manager.items.assign([StandardBall])
+	add_child_autofree(manager)
+	return manager
+
+
+func test_first_refresh_is_free() -> void:
+	_manager.economy.soul_balance = 0
+	var cost: int = _shop._get_refresh_cost()
+	assert_eq(cost, 0, "first refresh has zero cost")
+
+
+func test_second_refresh_costs_base() -> void:
+	_manager.economy.soul_balance = 100
+	_shop._refresh_count = 1
+	var cost: int = _shop._get_refresh_cost()
+	assert_eq(cost, 10, "second refresh costs the base amount")
+
+
+func test_third_refresh_costs_scaled() -> void:
+	_manager.economy.soul_balance = 100
+	_shop._refresh_count = 2
+	var cost: int = _shop._get_refresh_cost()
+	assert_eq(cost, 20, "third refresh costs base * scaling^1")
+
+
+func test_fourth_refresh_costs_doubled_again() -> void:
+	_manager.economy.soul_balance = 100
+	_shop._refresh_count = 3
+	var cost: int = _shop._get_refresh_cost()
+	assert_eq(cost, 40, "fourth refresh costs base * scaling^2")
+
+
+func test_refresh_deducts_soul_when_not_free() -> void:
+	_manager.economy.soul_balance = 100
+	_shop._refresh_count = 1
+	_shop._on_refresh_pressed()
+	assert_eq(_manager.economy.soul_balance, 90, "soul deducted by base cost")
+
+
+func test_first_refresh_does_not_deduct_soul() -> void:
+	_manager.economy.soul_balance = 50
+	var balance_before: int = _manager.economy.soul_balance
+	_shop._on_refresh_pressed()
+	assert_eq(
+		_manager.economy.soul_balance, balance_before, "soul unchanged after first free refresh"
+	)
+
+
+func test_refresh_increments_count() -> void:
+	_manager.economy.soul_balance = 100
+	_shop._on_refresh_pressed()
+	assert_eq(_shop._refresh_count, 1, "count incremented after refresh")
+
+
+func test_refresh_does_not_increment_when_unaffordable() -> void:
+	_manager.economy.soul_balance = 5
+	_shop._refresh_count = 1
+	_shop._on_refresh_pressed()
+	assert_eq(_shop._refresh_count, 1, "count unchanged when soul too low")
+
+
+func test_refresh_replaces_existing_items() -> void:
+	_manager.economy.soul_balance = 100
+	assert_eq(_shop.items_anchor.get_child_count(), 1, "precondition: one item spawned on _ready")
+
+	_shop._on_refresh_pressed()
+	await get_tree().process_frame
+	# Old items are queue_freed during process, new items spawned from pool.
+	assert_eq(_shop.items_anchor.get_child_count(), 1, "one item after refresh")
+
+
+func test_refresh_respawns_items_from_pool() -> void:
+	_manager.economy.soul_balance = 100
+	_shop._on_refresh_pressed()
+	await get_tree().process_frame
+	var count: int = _shop.items_anchor.get_child_count()
+	assert_eq(count, 1, "one item spawned after refresh")
+
+
+func test_refresh_ui_disables_button_when_unaffordable() -> void:
+	_manager.economy.soul_balance = 5
+	_shop._refresh_count = 1
+	var button := Button.new()
+	var label := Label.new()
+	_shop.refresh_button = button
+	_shop.refresh_cost_label = label
+	_shop.add_child(button)
+	_shop.add_child(label)
+	_shop._update_refresh_ui()
+	assert_true(button.disabled, "button disabled when soul too low for cost")
+
+
+func test_refresh_ui_enables_button_when_affordable() -> void:
+	_manager.economy.soul_balance = 100
+	_shop._refresh_count = 1
+	var button := Button.new()
+	var label := Label.new()
+	_shop.refresh_button = button
+	_shop.refresh_cost_label = label
+	_shop.add_child(button)
+	_shop.add_child(label)
+	_shop._update_refresh_ui()
+	assert_false(button.disabled, "button enabled when soul covers cost")
+
+
+func test_refresh_ui_label_shows_free_on_first() -> void:
+	var label := Label.new()
+	_shop.refresh_cost_label = label
+	_shop.add_child(label)
+	_shop._update_refresh_ui()
+	assert_eq(label.text, "FREE", "label shows FREE for first refresh")
+
+
+func test_refresh_ui_label_shows_cost_on_subsequent() -> void:
+	_shop._refresh_count = 1
+	var label := Label.new()
+	_shop.refresh_cost_label = label
+	_shop.add_child(label)
+	_shop._update_refresh_ui()
+	assert_eq(label.text, "10 soul", "label shows cost for second refresh")


### PR DESCRIPTION
Adds a Refresh button to the shop display with cost scaling. First use each session is free; subsequent uses cost soul based on `refresh_base_cost * refresh_cost_scaling^(count-1)`. Button disables when the player cannot afford the next refresh. Includes 14 unit tests covering cost calculation, soul deduction, item replacement, and UI state.