### PR TITLE
feat: ball name overlay

### DIFF
--- a/scenes/dev_hud.tscn
+++ b/scenes/dev_hud.tscn
@@ -16,6 +16,7 @@
 [ext_resource type="Script" uid="uid://08w53i5wkvn8" path="res://scripts/dev/arc_travel_overlay.gd" id="14_tmy36"]
 [ext_resource type="PackedScene" uid="uid://dq3kw7n8sh3a7" path="res://scenes/hud/ball_drop_overlay.tscn" id="15_qtjg3"]
 [ext_resource type="Script" uid="uid://bqbdbfpsxq5qo" path="res://scripts/hud/ball_drop_overlay.gd" id="16_ikufa"]
+[ext_resource type="Script" uid="" path="res://scripts/dev/ball_name_overlay.gd" id="17_ballname"]
 
 [node name="DevHUD" type="CanvasLayer" unique_id=466042378 node_paths=PackedStringArray("clearance_button", "dev_panel_container")]
 script = ExtResource("1_ahhtf")
@@ -136,3 +137,6 @@ script = ExtResource("14_tmy36")
 
 [node name="BallDropOverlay" type="Node2D" parent="." unique_id=1579397178 instance=ExtResource("15_qtjg3")]
 script = ExtResource("16_ikufa")
+
+[node name="BallNameOverlay" type="Node2D" parent="."]
+script = ExtResource("17_ballname")

--- a/scripts/dev/ball_name_overlay.gd
+++ b/scripts/dev/ball_name_overlay.gd
@@ -1,0 +1,94 @@
+class_name BallNameOverlay
+extends CanvasLayer
+
+## Each ball on court shows its display name as a label that follows the ball.
+
+var _tracker: BallReconciler
+var _labels: Dictionary = {}
+
+
+func _ready() -> void:
+	if not OS.is_debug_build():
+		queue_free()
+		return
+
+	layer = 128
+	_tracker = get_tree().get_first_node_in_group(&"ball_trackers") as BallReconciler
+
+	if _tracker != null:
+		_attach_to_tracker()
+	else:
+		get_tree().node_added.connect(_on_node_added_waiting_for_tracker)
+
+
+func _exit_tree() -> void:
+	if is_inside_tree() and get_tree().node_added.is_connected(_on_node_added_waiting_for_tracker):
+		get_tree().node_added.disconnect(_on_node_added_waiting_for_tracker)
+
+
+func _on_node_added_waiting_for_tracker(node: Node) -> void:
+	var tracker := node as BallReconciler
+	if tracker == null:
+		return
+	get_tree().node_added.disconnect(_on_node_added_waiting_for_tracker)
+	_tracker = tracker
+	_attach_to_tracker()
+
+
+func _attach_to_tracker() -> void:
+	_tracker.ball_added.connect(_on_ball_added)
+	_tracker.ball_removed.connect(_on_ball_removed)
+
+	for ball in _tracker.get_balls():
+		_on_ball_added(ball)
+
+
+func _on_ball_added(ball: Ball) -> void:
+	if ball == null or _labels.has(ball):
+		return
+
+	var label := Label.new()
+	label.text = _get_display_name(ball)
+	label.add_theme_color_override(&"font_color", Color.WHITE)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	add_child(label)
+	_labels[ball] = label
+
+
+func _on_ball_removed(ball: Ball) -> void:
+	if not _labels.has(ball):
+		return
+
+	var label: Label = _labels[ball]
+	if is_instance_valid(label):
+		label.queue_free()
+
+	_labels.erase(ball)
+
+
+func _process(_delta: float) -> void:
+	if _labels.is_empty():
+		return
+
+	for ball: Ball in _labels.keys():
+		if not is_instance_valid(ball):
+			continue
+
+		var label: Label = _labels[ball]
+		var screen_pos := _project_to_canvas(ball.global_position)
+		label.position = screen_pos - label.size * 0.5
+
+
+func _project_to_canvas(world_pos: Vector2) -> Vector2:
+	return get_viewport().get_canvas_transform() * world_pos
+
+
+func _get_display_name(ball: Ball) -> String:
+	if ball.item_key.is_empty():
+		return "ball"
+
+	for item: ItemDefinition in ItemManager.items:
+		if item.key == ball.item_key:
+			return item.display_name
+
+	return ball.item_key

--- a/scripts/dev/ball_name_overlay.gd
+++ b/scripts/dev/ball_name_overlay.gd
@@ -1,8 +1,9 @@
 class_name BallNameOverlay
-extends CanvasLayer
+extends Node2D
 
 ## Each ball on court shows its display name as a label that follows the ball.
 
+var dev_visible: bool = false
 var _tracker: BallReconciler
 var _labels: Dictionary = {}
 
@@ -12,7 +13,11 @@ func _ready() -> void:
 		queue_free()
 		return
 
-	layer = 128
+	z_index = 4095
+	top_level = true
+	visible = false
+	add_to_group(&"dev_overlays")
+
 	_tracker = get_tree().get_first_node_in_group(&"ball_trackers") as BallReconciler
 
 	if _tracker != null:
@@ -43,6 +48,11 @@ func _attach_to_tracker() -> void:
 		_on_ball_added(ball)
 
 
+func set_dev_visible(value: bool) -> void:
+	dev_visible = value
+	visible = value
+
+
 func _on_ball_added(ball: Ball) -> void:
 	if ball == null or _labels.has(ball):
 		return
@@ -67,7 +77,7 @@ func _on_ball_removed(ball: Ball) -> void:
 
 
 func _process(_delta: float) -> void:
-	if _labels.is_empty():
+	if not dev_visible or _labels.is_empty():
 		return
 
 	for ball: Ball in _labels.keys():

--- a/scripts/dev/ball_name_overlay.gd.uid
+++ b/scripts/dev/ball_name_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://1wacrtyp4x0b

--- a/scripts/dev/dev_bounce_panel.gd
+++ b/scripts/dev/dev_bounce_panel.gd
@@ -162,6 +162,7 @@ func _build_checks() -> void:
 	_add_checkbox("Show Cone Overlay", _on_cone_toggled)
 	_add_checkbox("Show Soul Bound", _on_soul_bound_toggled)
 	_add_checkbox("Show Arc Travel", _on_arc_travel_toggled)
+	_add_checkbox("Show Ball Names", _on_ball_name_toggled)
 	_add_checkbox("Cone follows last hit", _on_cone_follow_toggled)
 
 
@@ -200,4 +201,11 @@ func _on_cone_follow_toggled(pressed: bool) -> void:
 		if overlay is DevBounceOverlay:
 			overlay.follow_last_hit = pressed
 			overlay.queue_redraw()
+			return
+
+
+func _on_ball_name_toggled(pressed: bool) -> void:
+	for overlay in get_tree().get_nodes_in_group(&"dev_overlays"):
+		if overlay is BallNameOverlay:
+			overlay.set_dev_visible(pressed)
 			return


### PR DESCRIPTION
The ball name overlay script was extending CanvasLayer while all other dev overlays use Node2D with top\_level. Changed to Node2D, added it to the dev\_overlays group so the dev panel toggle can find it, placed the node in dev\_hud.tscn, and wired a Show Ball Names checkbox in the bounce panel.