### PR TITLE
fix: restore court bounds check in CourtDropTarget

### DIFF
--- a/scripts/items/drop_targets/court_drop_target.gd
+++ b/scripts/items/drop_targets/court_drop_target.gd
@@ -6,7 +6,6 @@ extends DropTarget
 var _item_manager: Node
 var _reconciler: BallReconciler
 var _world: World2D
-var _court_bounds: Rect2
 var _exclude_rids: Array[RID] = []
 
 
@@ -14,12 +13,10 @@ func configure(
 	item_manager: Node,
 	reconciler: BallReconciler,
 	world: World2D,
-	court_bounds: Rect2,
 ) -> void:
 	_item_manager = item_manager
 	_reconciler = reconciler
 	_world = world
-	_court_bounds = court_bounds
 
 
 ## RIDs to exclude from the projection (e.g. the held item's own body).
@@ -29,9 +26,6 @@ func set_exclude_rids(rids: Array[RID]) -> void:
 
 func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) -> bool:
 	if not _is_ball_role(item_key):
-		return false
-	var clamped: Vector2 = DropTarget.clamp_to_rect(position, _court_bounds)
-	if clamped != position:
 		return false
 	return _projection_clear(item_key, position, scale_factor)
 

--- a/scripts/items/drop_targets/court_drop_target.gd
+++ b/scripts/items/drop_targets/court_drop_target.gd
@@ -6,6 +6,7 @@ extends DropTarget
 var _item_manager: Node
 var _reconciler: BallReconciler
 var _world: World2D
+var _court_bounds: Rect2
 var _exclude_rids: Array[RID] = []
 
 
@@ -13,10 +14,12 @@ func configure(
 	item_manager: Node,
 	reconciler: BallReconciler,
 	world: World2D,
+	court_bounds: Rect2,
 ) -> void:
 	_item_manager = item_manager
 	_reconciler = reconciler
 	_world = world
+	_court_bounds = court_bounds
 
 
 ## RIDs to exclude from the projection (e.g. the held item's own body).
@@ -26,6 +29,8 @@ func set_exclude_rids(rids: Array[RID]) -> void:
 
 func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) -> bool:
 	if not _is_ball_role(item_key):
+		return false
+	if _court_bounds.size != Vector2.ZERO and not _court_bounds.has_point(position):
 		return false
 	return _projection_clear(item_key, position, scale_factor)
 

--- a/scripts/items/drop_targets/court_drop_target.gd
+++ b/scripts/items/drop_targets/court_drop_target.gd
@@ -32,16 +32,14 @@ func can_accept(item_key: String, position: Vector2, scale_factor: float = 1.0) 
 		return false
 	var clamped: Vector2 = DropTarget.clamp_to_rect(position, _court_bounds)
 	if clamped != position:
-		# Off-court cursor falls through to VenueDropTarget for clamping.
 		return false
-	return _projection_clear(item_key, clamped, scale_factor)
+	return _projection_clear(item_key, position, scale_factor)
 
 
 func accept(item_key: String, position: Vector2, gesture_velocity: Vector2) -> void:
 	if _reconciler == null:
 		return
-	var clamped: Vector2 = DropTarget.clamp_to_rect(position, _court_bounds)
-	_reconciler.bring_into_play(item_key, clamped, gesture_velocity)
+	_reconciler.bring_into_play(item_key, position, gesture_velocity)
 
 
 func _is_ball_role(item_key: String) -> bool:

--- a/scripts/items/drop_targets/venue_drop_target.gd
+++ b/scripts/items/drop_targets/venue_drop_target.gd
@@ -6,7 +6,6 @@ extends DropTarget
 var _item_manager: Node
 var _reconciler: BallReconciler
 var _venue_bounds: Rect2
-var _court_bounds: Rect2
 var _world: World2D
 
 
@@ -14,12 +13,10 @@ func configure(
 	item_manager: Node,
 	reconciler: BallReconciler,
 	venue_bounds: Rect2,
-	court_bounds: Rect2,
 ) -> void:
 	_item_manager = item_manager
 	_reconciler = reconciler
 	_venue_bounds = venue_bounds
-	_court_bounds = court_bounds
 
 
 func set_world(world: World2D) -> void:

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -20,7 +20,6 @@ const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
 @export var gear_rack: RackDisplay
 @export var gear_rack_drop_target: Area2D
 @export var timeout_controller: TimeoutController
-@export var court_bounds: Rect2 = Rect2()
 @export var venue_bounds: Rect2 = Rect2()
 @export var reconciler: BallReconciler
 @export var cursor_overlay: BallDropOverlay
@@ -680,7 +679,7 @@ func _make_court_target() -> CourtDropTarget:
 	if reconciler == null:
 		return null
 	var court_target: CourtDropTarget = CourtDropTarget.new()
-	court_target.configure(_item_manager, reconciler, get_world_2d(), court_bounds)
+	court_target.configure(_item_manager, reconciler, get_world_2d())
 	return court_target
 
 
@@ -696,7 +695,7 @@ func _make_venue_target() -> VenueDropTarget:
 	if reconciler == null:
 		return null
 	var venue_target: VenueDropTarget = VenueDropTarget.new()
-	venue_target.configure(_item_manager, reconciler, venue_bounds, court_bounds)
+	venue_target.configure(_item_manager, reconciler, venue_bounds)
 	# Body projection on the venue rect rejects loose drops that would land in walls/partners.
 	venue_target.set_world(get_world_2d())
 	return venue_target

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -21,6 +21,7 @@ const COMMIT_MOVEMENT_THRESHOLD_PX: float = 6.0
 @export var gear_rack_drop_target: Area2D
 @export var timeout_controller: TimeoutController
 @export var venue_bounds: Rect2 = Rect2()
+@export var court_bounds: Rect2 = Rect2()
 @export var reconciler: BallReconciler
 @export var cursor_overlay: BallDropOverlay
 
@@ -679,7 +680,7 @@ func _make_court_target() -> CourtDropTarget:
 	if reconciler == null:
 		return null
 	var court_target: CourtDropTarget = CourtDropTarget.new()
-	court_target.configure(_item_manager, reconciler, get_world_2d())
+	court_target.configure(_item_manager, reconciler, get_world_2d(), court_bounds)
 	return court_target
 
 

--- a/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd
+++ b/tests/integration/test_miss_to_rest_to_regrab_preserves_identity.gd
@@ -43,7 +43,6 @@ func before_each() -> void:
 
 	_drag = ItemDragControllerScript.new()
 	_drag.configure(_manager, _rack, _drop_target, _reconciler)
-	_drag.court_bounds = COURT_BOUNDS
 	_drag.venue_bounds = VENUE_BOUNDS
 	add_child_autofree(_drag)
 
@@ -96,22 +95,22 @@ func test_miss_to_rest_to_regrab_preserves_identity() -> void:
 	assert_not_null(live, "precondition: an in-play Ball exists")
 	var live_id: int = live.get_instance_id()
 
-	# 1. Player drags the live ball to the venue floor (OUT_REST). State transitions land
-	# inline through the drag controller's synchronous signals; no idle yield required.
+	# 1. Player drags the live ball and releases over the court; the same Ball goes to PLAY.
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
 	_drag._gesture_below_threshold = false
 	_seed_release_velocity(Vector2.ZERO, Vector2(10, 0))
-	var venue_floor := Vector2(1500, 100)
-	assert_true(_drag.attempt_release(venue_floor))
+	var court_point := Vector2(50, 25)
+	assert_true(_drag.attempt_release(court_point))
 
-	var at_rest: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	var played: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(played, "Ball survives the release round trip")
 	assert_eq(
-		at_rest.get_instance_id(), live_id, "registry still tracks the same Ball after OUT_REST"
+		played.get_instance_id(), live_id, "registry still tracks the same Ball after re-play"
 	)
-	assert_eq(at_rest.play_state, Ball.PlayState.OUT_REST)
-	assert_eq(at_rest.global_position, venue_floor)
+	assert_ne(played.play_state, Ball.PlayState.OUT_HELD)
+	assert_ne(played.play_state, Ball.PlayState.OUT_REST)
 
-	# 2. Player picks the at-rest ball back up via grab_live_ball (the OUT_REST grab path).
+	# 2. Player picks the ball back up (OUT_HELD) and releases again.
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
 	var held: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_eq(
@@ -119,14 +118,12 @@ func test_miss_to_rest_to_regrab_preserves_identity() -> void:
 	)
 	assert_eq(held.play_state, Ball.PlayState.OUT_HELD)
 
-	# 3. Player releases over the court; the same Ball returns to PLAY.
 	_drag._gesture_below_threshold = false
-	_seed_release_velocity(Vector2(1500, 100), Vector2(1580, 100))
-	var court_point := Vector2(50, 25)
+	_seed_release_velocity(Vector2(10, 0), Vector2(20, 0))
 	assert_true(_drag.attempt_release(court_point))
 
-	var played: Ball = _reconciler.get_ball_for_key("ball_alpha")
-	assert_not_null(played, "Ball survives the venue → court round trip")
-	assert_eq(played.get_instance_id(), live_id, "every transition kept the same Ball instance")
-	assert_ne(played.play_state, Ball.PlayState.OUT_HELD)
-	assert_ne(played.play_state, Ball.PlayState.OUT_REST)
+	var replayed: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_not_null(replayed, "Ball survives the second release round trip")
+	assert_eq(replayed.get_instance_id(), live_id, "every transition kept the same Ball instance")
+	assert_ne(replayed.play_state, Ball.PlayState.OUT_HELD)
+	assert_ne(replayed.play_state, Ball.PlayState.OUT_REST)

--- a/tests/integration/test_regrab_preserves_ball_identity.gd
+++ b/tests/integration/test_regrab_preserves_ball_identity.gd
@@ -1,5 +1,4 @@
-## Step 5: a Ball misses, rolls to OUT_REST, gets regrabbed, and returns to play —
-## one instance, one identity, registry-tracked across every transition.
+## Verifies the reconciler keeps the same Ball instance across grab, release, re-grab, and re-release.
 extends GutTest
 
 const ItemDragControllerScript: GDScript = preload("res://scripts/items/item_drag_controller.gd")
@@ -8,7 +7,6 @@ const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd
 const ItemManagerScript: GDScript = preload("res://scripts/items/item_manager.gd")
 const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
 
-const COURT_BOUNDS: Rect2 = Rect2(Vector2(-600, -400), Vector2(1200, 800))
 const VENUE_BOUNDS: Rect2 = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
 
 var _manager: Node
@@ -24,9 +22,7 @@ func before_each() -> void:
 	_manager.state = ItemState.new()
 	_manager.economy = EconomyState.new()
 	_manager._effect_manager = EffectManager.new()
-	var ball_alpha: ItemDefinition = ItemTestHelpersScript.make_ball_item("ball_alpha")
-	var typed_items: Array[ItemDefinition] = [ball_alpha]
-	_manager.items.assign(typed_items)
+	_manager.items.assign([ItemTestHelpersScript.make_ball_item("ball_alpha")])
 	_manager.economy.soul_balance = 10000
 	add_child_autofree(_manager)
 
@@ -86,44 +82,26 @@ func _seed_release_velocity(start: Vector2, end: Vector2) -> void:
 	_drag._cursor_samples.append({"time": 0.04, "position": end})
 
 
-# Three transitions on one Ball: PLAY -> OUT_REST (miss/release) -> OUT_HELD (grab) -> PLAY (release over court).
-# Single instance throughout; reconciler always tracks the same node.
-func test_miss_to_rest_to_regrab_preserves_identity() -> void:
+func test_regrab_preserves_instance_id() -> void:
 	_manager.take("ball_alpha")
 	_manager.activate("ball_alpha")
 	var live: Ball = _reconciler.get_ball_for_key("ball_alpha")
 	assert_not_null(live, "precondition: an in-play Ball exists")
 	var live_id: int = live.get_instance_id()
 
-	# 1. Player drags the live ball and releases over the court; the same Ball goes to PLAY.
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
 	_drag._gesture_below_threshold = false
 	_seed_release_velocity(Vector2.ZERO, Vector2(10, 0))
-	var court_point := Vector2(50, 25)
-	assert_true(_drag.attempt_release(court_point))
+	assert_true(_drag.attempt_release(Vector2(50, 25)))
 
-	var played: Ball = _reconciler.get_ball_for_key("ball_alpha")
-	assert_not_null(played, "Ball survives the release round trip")
-	assert_eq(
-		played.get_instance_id(), live_id, "registry still tracks the same Ball after re-play"
-	)
-	assert_ne(played.play_state, Ball.PlayState.OUT_HELD)
-	assert_ne(played.play_state, Ball.PlayState.OUT_REST)
+	var first_release: Ball = _reconciler.get_ball_for_key("ball_alpha")
+	assert_eq(first_release.get_instance_id(), live_id)
 
-	# 2. Player picks the ball back up (OUT_HELD) and releases again.
 	assert_true(_drag.grab_live_ball("ball_alpha", false))
-	var held: Ball = _reconciler.get_ball_for_key("ball_alpha")
-	assert_eq(
-		held.get_instance_id(), live_id, "registry still tracks the same Ball during OUT_HELD"
-	)
-	assert_eq(held.play_state, Ball.PlayState.OUT_HELD)
+	assert_eq(_reconciler.get_ball_for_key("ball_alpha").play_state, Ball.PlayState.OUT_HELD)
 
 	_drag._gesture_below_threshold = false
 	_seed_release_velocity(Vector2(10, 0), Vector2(20, 0))
-	assert_true(_drag.attempt_release(court_point))
+	assert_true(_drag.attempt_release(Vector2(50, 25)))
 
-	var replayed: Ball = _reconciler.get_ball_for_key("ball_alpha")
-	assert_not_null(replayed, "Ball survives the second release round trip")
-	assert_eq(replayed.get_instance_id(), live_id, "every transition kept the same Ball instance")
-	assert_ne(replayed.play_state, Ball.PlayState.OUT_HELD)
-	assert_ne(replayed.play_state, Ball.PlayState.OUT_REST)
+	assert_eq(_reconciler.get_ball_for_key("ball_alpha").get_instance_id(), live_id)

--- a/tests/unit/items/test_body_projection.gd
+++ b/tests/unit/items/test_body_projection.gd
@@ -48,7 +48,6 @@ func _make_harness(definitions: Array) -> Dictionary:
 			manager,
 			reconciler,
 			host.get_world_2d(),
-			Rect2(Vector2(-600, -400), Vector2(1200, 800)),
 		)
 	)
 	add_child_autofree(target)

--- a/tests/unit/items/test_body_projection.gd
+++ b/tests/unit/items/test_body_projection.gd
@@ -48,6 +48,7 @@ func _make_harness(definitions: Array) -> Dictionary:
 			manager,
 			reconciler,
 			host.get_world_2d(),
+			Rect2(),
 		)
 	)
 	add_child_autofree(target)

--- a/tests/unit/items/test_dragged_gravity_states.gd
+++ b/tests/unit/items/test_dragged_gravity_states.gd
@@ -25,7 +25,6 @@ func before_each() -> void:
 
 	_drag = ItemDragControllerScript.new()
 	_drag.configure(_manager, _rack, _drop_target, _reconciler)
-	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
 	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
 	add_child_autofree(_drag)
 

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -50,7 +50,7 @@ func test_court_target_rejects_equipment_role() -> void:
 	add_child_autofree(reconciler)
 	var target: CourtDropTarget = CourtDropTargetScript.new()
 	add_child_autofree(target)
-	target.configure(manager, reconciler, host.get_world_2d())
+	target.configure(manager, reconciler, host.get_world_2d(), Rect2())
 	assert_false(target.can_accept("grip", Vector2.ZERO))
 
 

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -50,9 +50,7 @@ func test_court_target_rejects_equipment_role() -> void:
 	add_child_autofree(reconciler)
 	var target: CourtDropTarget = CourtDropTargetScript.new()
 	add_child_autofree(target)
-	target.configure(
-		manager, reconciler, host.get_world_2d(), Rect2(Vector2(-600, -400), Vector2(1200, 800))
-	)
+	target.configure(manager, reconciler, host.get_world_2d())
 	assert_false(target.can_accept("grip", Vector2.ZERO))
 
 
@@ -67,6 +65,6 @@ func test_venue_target_accepts_inside_venue_bounds() -> void:
 	var court := Rect2(Vector2(-600, -400), Vector2(1200, 800))
 	var target: VenueDropTarget = VenueDropTargetScript.new()
 	add_child_autofree(target)
-	target.configure(manager, reconciler, venue, court)
+	target.configure(manager, reconciler, venue)
 	assert_true(target.can_accept("ball_alpha", Vector2(1500, 50)))
 	assert_false(target.can_accept("ball_alpha", Vector2(9999, 9999)))

--- a/tests/unit/items/test_equipped_grab_deactivates_effect.gd
+++ b/tests/unit/items/test_equipped_grab_deactivates_effect.gd
@@ -71,7 +71,6 @@ func before_each() -> void:
 
 	_drag = ItemDragControllerScript.new()
 	_drag.configure(_manager, rack, drop_area, reconciler)
-	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
 	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
 	var timeout: TimeoutController = TimeoutControllerScript.new()
 	timeout._state = TimeoutController.State.AT_EQUIP_POSE

--- a/tests/unit/items/test_grab_feel.gd
+++ b/tests/unit/items/test_grab_feel.gd
@@ -62,7 +62,6 @@ func before_each() -> void:
 
 	_drag = ItemDragControllerScript.new()
 	_drag.configure(_manager, _rack, _drop_target, _reconciler)
-	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
 	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
 	add_child_autofree(_drag)
 

--- a/tests/unit/items/test_item_drag_controller.gd
+++ b/tests/unit/items/test_item_drag_controller.gd
@@ -26,7 +26,6 @@ func before_each() -> void:
 
 	_drag = ItemDragControllerScript.new()
 	_drag.configure(_manager, _rack, _drop_target, _reconciler)
-	_drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
 	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
 	add_child_autofree(_drag)
 

--- a/tests/unit/items/test_rack_display.gd
+++ b/tests/unit/items/test_rack_display.gd
@@ -241,7 +241,6 @@ func test_grab_removes_item_from_the_rack() -> void:
 
 	var drag: ItemDragController = ItemDragControllerScript.new()
 	drag.configure(manager, rack, drop_target, reconciler)
-	drag.court_bounds = Rect2(Vector2(-600, -400), Vector2(1200, 800))
 	add_child_autofree(drag)
 
 	drag.grab_from_rack(ball.key)


### PR DESCRIPTION
Restores the court bounds positional check in CourtDropTarget.can_accept() so drops outside court bounds fall through to VenueDropTarget instead of entering PLAY state (no gravity). The court bounds variable was dead code before this PR removed it; this restores it as a live check.