### PR TITLE
refactor: drop targets self-register as scene nodes

### DIFF
--- a/designs/01-prototype/tech/drag-controller-zero-exports.md
+++ b/designs/01-prototype/tech/drag-controller-zero-exports.md
@@ -1,0 +1,194 @@
+# Drag Controller: Zero Export Vars
+
+Implementation spec for stripping every `@export` from `ItemDragController`, part of
+[SH-542](https://linear.app/shuck-games/issue/SH-542).
+
+## Current state
+
+`ItemDragController` carries eleven `@export` references, all set via NodePath in `court.tscn`:
+
+```
+@export var rack: RackDisplay
+@export var rack_drop_target: Area2D
+@export var gear_rack: RackDisplay
+@export var gear_rack_drop_target: Area2D
+@export var timeout_controller: TimeoutController
+@export var venue_bounds: Rect2
+@export var court_bounds: Rect2
+@export var reconciler: BallReconciler
+@export var cursor_overlay: BallDropOverlay
+```
+
+These are the controller's runtime collaborators: rack for signal wiring and position
+lookups, reconciler for ball lifecycle, timeout for rally gates. The Rect2 bounds drive
+`CourtDropTarget` and `VenueDropTarget` projection checks. Every collaborator is wired by a
+NodePath string in the scene file, invisible to grep, invisible to the IDE, breakable on
+rename.
+
+Drop targets (`CourtDropTarget`, `VenueDropTarget`, `RackDropTarget`, `CharacterDropTarget`)
+are created by `_register_builtin_targets()` as plain Node children of the controller. They
+cannot live as scene nodes because their dependencies (reconciler, item manager, world2d)
+arrive through the controller's own exports.
+
+## Target state
+
+Zero `@export` vars on `ItemDragController`. Every collaborator resolves itself or
+self-registers. The controller moves from Court child to Venue child since it handles drops
+across the full venue.
+
+## How each export disappears
+
+### `rack` and `gear_rack`
+
+The controller needs rack references for two things: connecting to `slot_pressed` signals,
+and calling `get_slot_position_for()`, `hide_slot_for()`, `reveal_slot_for()`, and
+`refresh()` on the rack during drag.
+
+Signal connections move to the controller's `_ready()` via group lookup. Racks join
+`&"racks"` group, distinguished by `role`:
+
+```gdscript
+for rack: RackDisplay in get_tree().get_nodes_in_group(&"racks"):
+    rack.slot_pressed.connect(_on_rack_slot_pressed)
+```
+
+The `_on_rack_slot_pressed` handler already receives the rack's `role` implicitly: the
+controller can read `rack.role` to know whether it is ball or gear.
+
+Rack method calls (`hide_slot_for`, `reveal_slot_for`) are replaced by signal-driven
+visibility. The rack listens to `pickup_started` and `drop_completed` on the controller and
+manages its own hide/reveal. `get_slot_position_for` is called when the controller needs a
+slot position during drag: the controller looks this up from the rack that emitted
+`slot_pressed` (stored as `_origin_rack` during the grab).
+
+`rack.refresh()` during grab is replaced by a `rack_slots_changed` signal the rack already
+emits. The controller does not need to call refresh directly.
+
+### `rack_drop_target` and `gear_rack_drop_target`
+
+`RackDropTarget` becomes a self-registering scene node. It lives as a child of the rack,
+finds the controller via `&"drag_controller"` group, and calls `register_target(self)` in
+`_ready()`. The Area2D reference is an `@export` on the `RackDropTarget` itself, wired in
+the rack scene. The controller never sees it.
+
+### `reconciler`
+
+`BallReconciler` is already in the `&"ball_trackers"` group. The controller finds it there:
+
+```gdscript
+reconciler = get_tree().get_first_node_in_group(&"ball_trackers")
+```
+
+### `timeout_controller`
+
+Used only once, in `grab_equipped_from_character`, for `RallyGate.removal_allowed()`.
+Resolved by a new `&"timeout"` group on `TimeoutController`, or by walking the Court scene.
+
+### `cursor_overlay`
+
+Used only once, in `_set_cursor_state`, to call `BallDropOverlay.update_state()`. Found by
+a `&"cursor_overlay"` group on `BallDropOverlay`. One-shot lookup in `_ready()`.
+
+### `venue_bounds` and `court_bounds`
+
+Gone. Replaced by `Area2D` nodes on each drop target. `CourtDropTarget` holds an `@export
+var court_area: Area2D` pointing at a `RectangleShape2D`-backed `Area2D` child of Court in
+`court.tscn`. `VenueDropTarget` holds the same for venue. The existing Rect2 approach
+hardcoded magic numbers that missed venue edges and could not be visually adjusted. Area2D
+is editor-visible, resizable, and matches the rest of the drop target pattern (rack drop
+targets already use Area2D).
+
+## Drop target self-registration
+
+Every built-in drop target becomes a scene node that self-registers in `_ready()`:
+
+```gdscript
+# CourtDropTarget._ready():
+var ctrl: ItemDragController = get_tree().get_first_node_in_group(&"drag_controller")
+if ctrl != null:
+    ctrl.register_target(self)
+```
+
+`CourtDropTarget`, `VenueDropTarget`, `RackDropTarget`, and `CharacterDropTarget` all follow
+this pattern. `ShopDropTarget` already does it. `_register_builtin_targets()` is deleted.
+
+Each drop target holds its own `@export` dependencies: `CourtDropTarget` exports
+`reconciler`, `item_manager`, and `court_area`. `VenueDropTarget` exports the same plus
+`venue_area`. `RackDropTarget` exports `item_manager` and `drop_area`. These are wired in
+the scene where the target lives, visible and refactorable.
+
+## Scene changes
+
+**`court.tscn`:**
+- Remove `ItemDragController` node.
+- Add `CourtDropZone` (Area2D, `input_pickable = false`, RectangleShape2D 1600x720) as
+  child of Court.
+
+**`venue.tscn`:**
+- Add `ItemDragController` as direct child of Venue.
+- Add `VenueDropZone` (Area2D, `input_pickable = false`, RectangleShape2D 2400x1440) as
+  child of Venue.
+
+**`court.gd`:**
+- Replace `@export var drag_controller: ItemDragController` with group lookup.
+- Wire `set_character_drop_target()` from `_ready()` as before (that is a method call, not
+  an export).
+
+**`item_drag_controller.gd`:**
+- Remove all `@export var` declarations.
+- Add group-based collaborator lookups in `_ready()`.
+- Delete `_register_builtin_targets()`.
+- Delete `configure()`.
+- Delete `_make_court_target()`, `_make_venue_target()`, `_make_rack_target()`.
+
+## Removes
+
+- All `@export` vars from `ItemDragController`.
+- `configure()` public API.
+- `_register_builtin_targets()` and its three factory methods.
+- `venue_bounds: Rect2` and `court_bounds: Rect2` from `ItemDragController`,
+  `CourtDropTarget`, and `VenueDropTarget`.
+
+## Preserves
+
+- `register_target()` and `unregister_target()` on the controller.
+- Group-based discovery of controller from consumers.
+- All drag controller tests pass without calling `configure()`. Tests wire targets by
+  calling `register_target()` directly, a pure API with no exports to mock.
+
+## Delivery: outcome-oriented PR sequence
+
+Four PRs carry this refactor, and each one closes a concern end to end rather than a layer
+of the stack. Production code, scenes, tests, and any consumer land together; the old
+surface for that concern is deleted in the same PR, so main never sits on a half-migrated
+seam.
+
+**PR 1: drop targets self-register.** `CourtDropTarget`, `VenueDropTarget`, `RackDropTarget`,
+and `CharacterDropTarget` become scene nodes that register themselves with the controller on
+`_ready()`. `_register_builtin_targets()` and its three factory methods are gone. Bounds and
+collaborator wiring stay on whatever mechanism they use today; this PR only moves *where*
+the targets live, not *how* they resolve their dependencies. Closes the "drop targets live
+as scene nodes, not runtime-constructed" acceptance criterion on its own.
+
+**PR 2: Rect2 bounds become Area2D drop zones.** `court_bounds` and `venue_bounds` stop
+being hardcoded rectangles and become `Area2D` nodes a designer can see and resize in the
+editor. `shop_item.gd`'s `venue_bounds` fix rides along since it depends on the same zone.
+
+**PR 3: collaborators resolve by group, the controller moves under Venue.** `rack`,
+`gear_rack`, `reconciler`, `timeout_controller`, and `cursor_overlay` stop being NodePath
+exports and start resolving through group lookups in `_ready()`. The controller becomes a
+child of Venue instead of Court, since its job (routing a drag to whichever target accepts
+it) spans the whole venue, not just the court. `configure()` is deleted once nothing calls
+it anymore. `shop_item.gd`'s reconciler fix rides along for the same reason as PR 2's.
+
+**PR 4: state-machine enum.** `IDLE` / `DRAGGING` / `PENDING_RELEASE` replace the scattered
+booleans (`_mouse_button_down`, `_release_pending`, `_gesture_below_threshold`) that
+currently track gesture state by hand.
+
+PR 4 is not a zero-export change; the export count is already at zero by the time it lands.
+It is folded into SH-542 anyway, as a deliberate scope choice: the exports and the gesture
+booleans are the same file, the same reviewer, and the same mental model of "state this
+class shouldn't be carrying implicitly." Splitting the enum work into its own ticket would
+mean touching `item_drag_controller.gd` a fifth time for a change that belongs with the
+other three. A future reader of this doc should take the PR 4 inclusion as intentional, not
+as scope creep that slipped past review.

--- a/scenes/ball_rack.tscn
+++ b/scenes/ball_rack.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://bxyckxy4cf7r0"]
 
 [ext_resource type="Script" uid="uid://brl2uxlwp7fvg" path="res://scripts/items/rack_display.gd" id="1_rack"]
+[ext_resource type="Script" uid="uid://bmqkgc57u27r6" path="res://scripts/items/drop_targets/rack_drop_target.gd" id="2_rdt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ball_rack_drop"]
 size = Vector2(180, 120)
@@ -59,3 +60,8 @@ monitoring = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DropTarget" unique_id=1349315970]
 shape = SubResource("RectangleShape2D_ball_rack_drop")
+
+[node name="RackDropTarget" type="Node" parent="." unique_id=1349315971 node_paths=PackedStringArray("drop_area")]
+script = ExtResource("2_rdt")
+drop_area = NodePath("../DropTarget")
+role = &"ball"

--- a/scenes/court.tscn
+++ b/scenes/court.tscn
@@ -21,6 +21,8 @@
 [ext_resource type="Script" uid="uid://dkqyrxx74rbvd" path="res://scripts/items/ball_reconciler.gd" id="21_reconciler"]
 [ext_resource type="Script" uid="uid://ddo3h77danynw" path="res://scripts/items/item_drag_controller.gd" id="22_drag"]
 [ext_resource type="Resource" uid="uid://b66666sh366cc" path="res://resources/court_config.tres" id="25_courtcfg"]
+[ext_resource type="Script" uid="uid://cbjvktojqsqqd" path="res://scripts/items/drop_targets/court_drop_target.gd" id="26_cdt"]
+[ext_resource type="Script" uid="uid://clyfa8heojc04" path="res://scripts/items/drop_targets/venue_drop_target.gd" id="27_vdt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vert"]
 size = Vector2(22, 1005.5)
@@ -210,3 +212,13 @@ timeout_controller = NodePath("../TimeoutController")
 venue_bounds = Rect2(-1200, -720, 2400, 1440)
 court_bounds = Rect2(-800, -360, 1600, 720)
 reconciler = NodePath("../BallReconciler")
+
+[node name="CourtDropTarget" type="Node" parent="." unique_id=1902001003 node_paths=PackedStringArray("reconciler")]
+script = ExtResource("26_cdt")
+reconciler = NodePath("../BallReconciler")
+court_bounds = Rect2(-800, -360, 1600, 720)
+
+[node name="VenueDropTarget" type="Node" parent="." unique_id=1902001004 node_paths=PackedStringArray("reconciler")]
+script = ExtResource("27_vdt")
+reconciler = NodePath("../BallReconciler")
+venue_bounds = Rect2(-1200, -720, 2400, 1440)

--- a/scenes/gear_rack.tscn
+++ b/scenes/gear_rack.tscn
@@ -1,6 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://mws700v36gko"]
 
 [ext_resource type="Script" path="res://scripts/items/rack_display.gd" id="1_rack"]
+[ext_resource type="Script" uid="uid://bmqkgc57u27r6" path="res://scripts/items/drop_targets/rack_drop_target.gd" id="2_rdt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_gear_rack_drop"]
 size = Vector2(180, 120)
@@ -61,3 +62,8 @@ monitorable = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DropTarget" unique_id=1742093713]
 shape = SubResource("RectangleShape2D_gear_rack_drop")
+
+[node name="RackDropTarget" type="Node" parent="." unique_id=1742093714 node_paths=PackedStringArray("drop_area")]
+script = ExtResource("2_rdt")
+drop_area = NodePath("../DropTarget")
+role = &"equipment"

--- a/scenes/player_paddle.tscn
+++ b/scenes/player_paddle.tscn
@@ -11,6 +11,7 @@
 [ext_resource type="Script" uid="uid://buqpbmh1c35bs" path="res://scripts/dev/ground_ray_overlay.gd" id="9_ray"]
 [ext_resource type="Script" uid="uid://4xd1ibgc7g5s" path="res://scripts/dev/animation_state_label.gd" id="10_label"]
 [ext_resource type="Script" uid="uid://bqb2k2jh41jwo" path="res://scripts/components/hover_bob.gd" id="11_lx3j3"]
+[ext_resource type="Script" uid="uid://dxoon5i51g8oe" path="res://scripts/items/drop_targets/character_drop_target.gd" id="12_cdt"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ut3sq"]
 size = Vector2(90, 201.715)
@@ -69,6 +70,7 @@ visible = false
 collision_layer = 0
 collision_mask = 0
 input_pickable = false
+script = ExtResource("12_cdt")
 
 [node name="DropCollision" type="CollisionShape2D" parent="CharacterDropTarget" unique_id=2001000011]
 position = Vector2(-8, 22.5)

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -78,7 +78,11 @@ func _ready() -> void:
 	if drag_controller != null:
 		var character_area: Area2D = player_paddle.get_node_or_null("CharacterDropTarget")
 		if character_area != null:
-			drag_controller.set_character_drop_target(character_area, player_paddle)
+			# Deferred: CharacterDropTarget registers itself with the controller on a deferred
+			# call too, so this waits for that registration to land first.
+			drag_controller.call_deferred(
+				&"set_character_drop_target", character_area, player_paddle
+			)
 
 	if ball_system != null:
 		ball_system.spawn_origin = global_position

--- a/scripts/items/drop_targets/character_drop_target.gd
+++ b/scripts/items/drop_targets/character_drop_target.gd
@@ -13,6 +13,18 @@ var _timeout_controller: TimeoutController
 var _paddle: Node
 
 
+func _ready() -> void:
+	# Deferred: the paddle spawns dynamically inside Court._ready, so a same-frame lookup
+	# can race the controller joining the group depending on instantiation order.
+	call_deferred(&"_register_with_controller")
+
+
+func _register_with_controller() -> void:
+	var ctrl: Node = get_tree().get_first_node_in_group(&"drag_controller")
+	if ctrl != null:
+		ctrl.register_target(self)
+
+
 func configure(
 	item_manager: Node,
 	drop_area: Area2D,

--- a/scripts/items/drop_targets/court_drop_target.gd
+++ b/scripts/items/drop_targets/court_drop_target.gd
@@ -3,19 +3,45 @@ extends DropTarget
 
 ## Accepts ball-role items at positions whose authored shape clears walls, partners, and other balls.
 
-var _item_manager: ItemManager
+@export var item_manager: Node
+@export var reconciler: BallReconciler
+@export var court_bounds: Rect2 = Rect2()
+
+var _item_manager: Node
 var _reconciler: BallReconciler
 var _world: World2D
 var _court_bounds: Rect2
 var _exclude_rids: Array[RID] = []
+## True once `configure()` has run; `_ready()` then leaves the test-seam values alone.
+var _configured_directly: bool = false
 
 
+func _ready() -> void:
+	if not _configured_directly:
+		_item_manager = item_manager if item_manager != null else ItemManager
+		_reconciler = reconciler
+		_court_bounds = court_bounds
+		_world = get_viewport().find_world_2d()
+
+	# Deferred: sibling _ready order is declaration order, so a same-frame group lookup can
+	# race the controller joining the group.
+	call_deferred(&"_register_with_controller")
+
+
+func _register_with_controller() -> void:
+	var ctrl: Node = get_tree().get_first_node_in_group(&"drag_controller")
+	if ctrl != null:
+		ctrl.register_target(self)
+
+
+## Test seam / back-compat: direct construction still wires collaborators without scene exports.
 func configure(
 	item_manager: Node,
 	reconciler: BallReconciler,
 	world: World2D,
 	court_bounds: Rect2,
 ) -> void:
+	_configured_directly = true
 	_item_manager = item_manager
 	_reconciler = reconciler
 	_world = world

--- a/scripts/items/drop_targets/rack_drop_target.gd
+++ b/scripts/items/drop_targets/rack_drop_target.gd
@@ -3,9 +3,29 @@ extends DropTarget
 
 ## Accepts role-matched items inside the rack's drop area; deactivates on-court items so the rack regrows.
 
-var _item_manager: ItemManager
+@export var item_manager: Node
+@export var drop_area: Area2D
+@export var role: StringName = &"ball"
+
+var _item_manager: Node
 var _drop_area: Area2D
 var _role: StringName
+
+
+func _ready() -> void:
+	_item_manager = item_manager if item_manager != null else ItemManager
+	_drop_area = drop_area
+	_role = role
+
+	# Deferred: sibling _ready order is declaration order, and this node can precede the
+	# controller, so a same-frame group lookup can race the controller joining the group.
+	call_deferred(&"_register_with_controller")
+
+
+func _register_with_controller() -> void:
+	var ctrl: Node = get_tree().get_first_node_in_group(&"drag_controller")
+	if ctrl != null:
+		ctrl.register_target(self)
 
 
 func configure(

--- a/scripts/items/drop_targets/venue_drop_target.gd
+++ b/scripts/items/drop_targets/venue_drop_target.gd
@@ -3,17 +3,43 @@ extends DropTarget
 
 ## Accepts releases inside the venue rect; the controller branches on this type to keep the body alive after release.
 
-var _item_manager: ItemManager
+@export var item_manager: Node
+@export var reconciler: BallReconciler
+@export var venue_bounds: Rect2 = Rect2()
+
+var _item_manager: Node
 var _reconciler: BallReconciler
 var _venue_bounds: Rect2
 var _world: World2D
+## True once `configure()` has run; `_ready()` then leaves the test-seam values alone.
+var _configured_directly: bool = false
 
 
+func _ready() -> void:
+	if not _configured_directly:
+		_item_manager = item_manager if item_manager != null else ItemManager
+		_reconciler = reconciler
+		_venue_bounds = venue_bounds
+		_world = get_viewport().find_world_2d()
+
+	# Deferred: sibling _ready order is declaration order, so a same-frame group lookup can
+	# race the controller joining the group.
+	call_deferred(&"_register_with_controller")
+
+
+func _register_with_controller() -> void:
+	var ctrl: Node = get_tree().get_first_node_in_group(&"drag_controller")
+	if ctrl != null:
+		ctrl.register_target(self)
+
+
+## Test seam / back-compat: direct construction still wires collaborators without scene exports.
 func configure(
 	item_manager: Node,
 	reconciler: BallReconciler,
 	venue_bounds: Rect2,
 ) -> void:
+	_configured_directly = true
 	_item_manager = item_manager
 	_reconciler = reconciler
 	_venue_bounds = venue_bounds

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -43,6 +43,8 @@ var _cursor_state: int = CursorStateScript.State.DEFAULT
 var _release_pending: bool = false
 
 var _character_target: CharacterDropTargetScript = null
+## Self-registered targets stay parented in their own scene (Court, Rack, PlayerPaddle), not the controller.
+var _targets: Array[DropTarget] = []
 
 
 func configure(
@@ -79,8 +81,6 @@ func _ready() -> void:
 	if reconciler != null:
 		if not reconciler.ball_spawned.is_connected(_on_reconciler_ball_spawned):
 			reconciler.ball_spawned.connect(_on_reconciler_ball_spawned)
-
-	_register_builtin_targets()
 
 
 func _process(_delta: float) -> void:
@@ -145,24 +145,27 @@ func get_cursor_state() -> int:
 	return _cursor_state
 
 
-## Lets subsystems with their own area resources (Shop) join the target poll without owning the held body.
+## Lets a target register itself (self-registering scene node, or a subsystem like Shop) without the
+## controller owning or reparenting it.
 func register_target(target: DropTarget) -> void:
 	if target == null:
 		return
-	add_child(target)
+	if _targets.has(target):
+		assert(false, "ItemDragController.register_target: %s already registered" % target)
+		return
+	_targets.append(target)
+	if target is CharacterDropTargetScript:
+		_character_target = target
 
 
 func unregister_target(target: DropTarget) -> void:
-	remove_child(target)
-	target.queue_free()
+	_targets.erase(target)
+	if target == _character_target:
+		_character_target = null
 
 
 func get_registered_targets() -> Array[DropTarget]:
-	var result: Array[DropTarget] = []
-	for child in get_children():
-		if child is DropTarget:
-			result.append(child as DropTarget)
-	return result
+	return _targets.duplicate()
 
 
 ## Activation defers to release-over-court so a click-without-movement is a no-op.
@@ -481,12 +484,9 @@ func get_loose_body_host() -> Node:
 
 ## Returns true if a release at `world_position` would be accepted by the court drop target.
 func can_court_accept_at(item_key: String, world_position: Vector2) -> bool:
-	for child in get_children():
-		if child is CourtDropTarget:
-			var target: CourtDropTarget = child as CourtDropTarget
-			if target.can_accept(item_key, world_position, 1.0):
-				return true
-			return false
+	for target in _targets:
+		if target is CourtDropTarget:
+			return (target as CourtDropTarget).can_accept(item_key, world_position, 1.0)
 	return false
 
 
@@ -556,10 +556,7 @@ func _apply_preserved_speed_after_accept(item_key: String) -> void:
 func _find_accepting_target(
 	item_key: String, world_position: Vector2, scale_factor: float
 ) -> DropTarget:
-	for child in get_children():
-		var target: DropTarget = child as DropTarget
-		if target == null:
-			continue
+	for target in _targets:
 		if target.can_accept(item_key, world_position, scale_factor):
 			return target
 	return null
@@ -615,9 +612,9 @@ func _reset_gesture_state() -> void:
 
 
 func _set_court_exclude_rids(rids: Array[RID]) -> void:
-	for child in get_children():
-		if child is CourtDropTarget:
-			(child as CourtDropTarget).set_exclude_rids(rids)
+	for target in _targets:
+		if target is CourtDropTarget:
+			(target as CourtDropTarget).set_exclude_rids(rids)
 			return
 
 
@@ -644,62 +641,13 @@ func _spawn_held_body(item_key: String, spawn_position: Vector2, is_temporary: b
 	return true
 
 
-## Wires the character drop area once the player paddle is spawned; rebuilds the priority list so the character target slots in after court.
+## Hands the self-registered CharacterDropTarget its runtime collaborators once the paddle spawns.
 func set_character_drop_target(area: Area2D, paddle: Node = null) -> void:
-	for child in get_children():
-		if child is CharacterDropTarget:
-			var target: CharacterDropTarget = child as CharacterDropTarget
-			target.configure(_item_manager, area, timeout_controller, paddle)
-			_character_target = target
-			if not target.equipped_art_pressed.is_connected(_on_equipped_art_pressed):
-				target.equipped_art_pressed.connect(_on_equipped_art_pressed)
-			return
-
-
-## Priority order: character equip, role-aware racks, court projection, venue catch-all last.
-func _register_builtin_targets() -> void:
-	for child in get_children():
-		if child is DropTarget:
-			remove_child(child)
-			child.queue_free()
-	_character_target = null
-
-	for target: DropTarget in [
-		CharacterDropTarget.new(),
-		_make_rack_target(rack_drop_target, &"ball"),
-		_make_rack_target(gear_rack_drop_target, &"equipment"),
-		_make_court_target(),
-		_make_venue_target(),
-	]:
-		if target == null:
-			continue
-		add_child(target)
-
-
-func _make_court_target() -> CourtDropTarget:
-	if reconciler == null:
-		return null
-	var court_target: CourtDropTarget = CourtDropTarget.new()
-	court_target.configure(_item_manager, reconciler, get_world_2d(), court_bounds)
-	return court_target
-
-
-func _make_rack_target(area: Area2D, role: StringName) -> RackDropTarget:
-	if area == null:
-		return null
-	var rack_target: RackDropTarget = RackDropTarget.new()
-	rack_target.configure(_item_manager, area, role)
-	return rack_target
-
-
-func _make_venue_target() -> VenueDropTarget:
-	if reconciler == null:
-		return null
-	var venue_target: VenueDropTarget = VenueDropTarget.new()
-	venue_target.configure(_item_manager, reconciler, venue_bounds)
-	# Body projection on the venue rect rejects loose drops that would land in walls/partners.
-	venue_target.set_world(get_world_2d())
-	return venue_target
+	if _character_target == null:
+		return
+	_character_target.configure(_item_manager, area, timeout_controller, paddle)
+	if not _character_target.equipped_art_pressed.is_connected(_on_equipped_art_pressed):
+		_character_target.equipped_art_pressed.connect(_on_equipped_art_pressed)
 
 
 func _track_cursor_motion(sample_position: Vector2) -> void:

--- a/scripts/shop/shop.gd
+++ b/scripts/shop/shop.gd
@@ -67,6 +67,8 @@ func _on_tree_exiting() -> void:
 		and _registered_controller.has_method("unregister_target")
 	):
 		_registered_controller.unregister_target(_registered_target)
+	# The controller no longer parents registered targets, so Shop owns freeing its own.
+	_registered_target.free()
 	_registered_target = null
 	_registered_controller = null
 

--- a/tests/integration/test_regrab_preserves_ball_identity.gd
+++ b/tests/integration/test_regrab_preserves_ball_identity.gd
@@ -6,6 +6,15 @@ const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconci
 const RackDisplayScript: GDScript = preload("res://scripts/items/rack_display.gd")
 const ItemManagerScript: GDScript = preload("res://scripts/items/item_manager.gd")
 const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/item_test_helpers.gd")
+const CourtDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/court_drop_target.gd"
+)
+const VenueDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/venue_drop_target.gd"
+)
+const RackDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/rack_drop_target.gd"
+)
 
 const VENUE_BOUNDS: Rect2 = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
 
@@ -39,8 +48,25 @@ func before_each() -> void:
 
 	_drag = ItemDragControllerScript.new()
 	_drag.configure(_manager, _rack, _drop_target, _reconciler)
-	_drag.venue_bounds = VENUE_BOUNDS
 	add_child_autofree(_drag)
+
+	# Targets normally self-register from their own `_ready()`; wired by hand here, out of the
+	# tree, so deferred self-registration on add-to-tree cannot double-fire. Rack before court
+	# before venue matches the production priority order.
+	var rack_target: RackDropTarget = RackDropTargetScript.new()
+	rack_target.configure(_manager, _drop_target, &"ball")
+	autofree(rack_target)
+	_drag.register_target(rack_target)
+
+	var court_target: CourtDropTarget = CourtDropTargetScript.new()
+	court_target.configure(_manager, _reconciler, _host.get_world_2d(), Rect2())
+	autofree(court_target)
+	_drag.register_target(court_target)
+
+	var venue_target: VenueDropTarget = VenueDropTargetScript.new()
+	venue_target.configure(_manager, _reconciler, VENUE_BOUNDS)
+	autofree(venue_target)
+	_drag.register_target(venue_target)
 
 
 func after_each() -> void:

--- a/tests/unit/items/test_drop_targets.gd
+++ b/tests/unit/items/test_drop_targets.gd
@@ -13,6 +13,7 @@ const VenueDropTargetScript: GDScript = preload(
 	"res://scripts/items/drop_targets/venue_drop_target.gd"
 )
 const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const ItemDragControllerScript: GDScript = preload("res://scripts/items/item_drag_controller.gd")
 
 
 func after_each() -> void:
@@ -68,3 +69,18 @@ func test_venue_target_accepts_inside_venue_bounds() -> void:
 	target.configure(manager, reconciler, venue)
 	assert_true(target.can_accept("ball_alpha", Vector2(1500, 50)))
 	assert_false(target.can_accept("ball_alpha", Vector2(9999, 9999)))
+
+
+func test_court_target_self_registers_with_controller_on_ready() -> void:
+	var drag: ItemDragController = ItemDragControllerScript.new()
+	add_child_autofree(drag)
+
+	var target: CourtDropTarget = CourtDropTargetScript.new()
+	add_child_autofree(target)
+	# Self-registration runs on a deferred call so it lands after every sibling's _ready.
+	await get_tree().process_frame
+
+	assert_true(
+		drag.get_registered_targets().has(target),
+		"CourtDropTarget should register itself with the drag_controller-group controller",
+	)

--- a/tests/unit/items/test_item_drag_controller.gd
+++ b/tests/unit/items/test_item_drag_controller.gd
@@ -3,6 +3,18 @@ extends GutTest
 const ItemDragControllerScript: GDScript = preload("res://scripts/items/item_drag_controller.gd")
 const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
 const TimeoutControllerScript: GDScript = preload("res://scripts/core/timeout_controller.gd")
+const CourtDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/court_drop_target.gd"
+)
+const VenueDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/venue_drop_target.gd"
+)
+const RackDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/rack_drop_target.gd"
+)
+const CharacterDropTargetScript: GDScript = preload(
+	"res://scripts/items/drop_targets/character_drop_target.gd"
+)
 
 var _manager: Node
 var _rack: RackDisplay
@@ -26,8 +38,25 @@ func before_each() -> void:
 
 	_drag = ItemDragControllerScript.new()
 	_drag.configure(_manager, _rack, _drop_target, _reconciler)
-	_drag.venue_bounds = Rect2(Vector2(-2000, -1200), Vector2(4000, 2400))
 	add_child_autofree(_drag)
+
+	# Targets normally self-register from their own `_ready()`; these tests wire them by hand
+	# and keep them out of the tree so that deferred self-registration cannot double-fire.
+	# Registration order matches the production priority: rack before court before venue.
+	var rack_target: RackDropTarget = RackDropTargetScript.new()
+	rack_target.configure(_manager, _drop_target, &"ball")
+	autofree(rack_target)
+	_drag.register_target(rack_target)
+
+	var court_target: CourtDropTarget = CourtDropTargetScript.new()
+	court_target.configure(_manager, _reconciler, get_tree().root.get_world_2d(), Rect2())
+	autofree(court_target)
+	_drag.register_target(court_target)
+
+	var venue_target: VenueDropTarget = VenueDropTargetScript.new()
+	venue_target.configure(_manager, _reconciler, Rect2(Vector2(-2000, -1200), Vector2(4000, 2400)))
+	autofree(venue_target)
+	_drag.register_target(venue_target)
 
 
 func after_each() -> void:
@@ -113,6 +142,15 @@ func test_grab_equipped_from_character_and_release_on_rack_unequips() -> void:
 	_drag.timeout_controller = timeout
 	_drag.gear_rack = _rack
 	_drag.gear_rack_drop_target = _drop_target
+
+	var gear_rack_target: RackDropTarget = RackDropTargetScript.new()
+	gear_rack_target.configure(_manager, _drop_target, &"equipment")
+	autofree(gear_rack_target)
+	_drag.register_target(gear_rack_target)
+
+	var character_target: CharacterDropTarget = CharacterDropTargetScript.new()
+	autofree(character_target)
+	_drag.register_target(character_target)
 	_drag.set_character_drop_target(
 		ItemTestHelpers.make_drop_area(Vector2(0, 0), Vector2(40, 80), self)
 	)


### PR DESCRIPTION
Court, Venue, Rack, and Character drop targets now live as scene nodes and join the drag controller via `register_target()` in their own `_ready()`, instead of the controller building them by hand. This is PR 1 of the SH-542 zero-export split; bounds and collaborator wiring on the controller itself are untouched here, and `configure()` stays for now (PR 3 removes it once the controller's own exports go).

Related: #1075

Agent-Role: gdscript-implementer