### PR TITLE
fix: use instance key for shop items

### DIFF
--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -70,16 +70,20 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
 	var drag_target: Node2D = _drag_target()
+
 	if drag_target == null:
 		_set_cursor_state(CursorStateScript.State.DEFAULT, _cursor_position())
 		return
+
 	var cursor_target: Vector2 = _cursor_position()
 	drag_target.global_position = cursor_target
 	_track_cursor_motion(cursor_target)
+
 	if _gesture_below_threshold:
 		if cursor_target.distance_to(_press_position) >= COMMIT_MOVEMENT_THRESHOLD_PX:
 			_gesture_below_threshold = false
 	_update_cursor_state(cursor_target)
+
 	if not _mouse_button_down:
 		if not attempt_release(cursor_target):
 			pass

--- a/scripts/items/item_drag_controller.gd
+++ b/scripts/items/item_drag_controller.gd
@@ -231,34 +231,39 @@ func _adopt_live_ball_as_held(ball: Ball, item_key: String) -> void:
 	_track_cursor_motion(spawn_position)
 
 
-## Routes a just-purchased item to whatever target accepts the release position; venue/rack/court all valid.
-func spawn_purchased_at(
+## Purchases and spawns an item based on the resolution of the prioritised drop target.
+func try_purchase_and_spawn(
 	item_key: String, world_position: Vector2, gesture_velocity: Vector2
 ) -> bool:
 	var target: DropTarget = _find_accepting_target(item_key, world_position, 1.0)
 	if target == null:
 		return false
+
+	var instance_key: String = _item_manager.take(item_key)
+	if instance_key.is_empty():
+		return false
+
 	if target is CourtDropTarget:
-		target.accept(item_key, world_position, gesture_velocity)
+		target.accept(instance_key, world_position, gesture_velocity)
 		return true
+
 	if target is VenueDropTarget:
-		_release_to_rest(item_key, world_position, gesture_velocity)
+		_release_to_rest(instance_key, world_position, gesture_velocity)
 		return true
+
 	if target is RackDropTarget:
-		# Rack landing adopts a STORED Ball at the slot; rack accept's deactivate branch
-		# is a no-op for a just-purchased, not-on-court item.
-		_adopt_purchased_into_rack(item_key)
+		_adopt_purchased_into_rack(instance_key)
 		return true
-	target.accept(item_key, world_position, gesture_velocity)
+
+	target.accept(instance_key, world_position, gesture_velocity)
+
 	return true
 
 
-func _adopt_purchased_into_rack(item_key: String) -> void:
-	if reconciler == null or rack == null:
+func _adopt_purchased_into_rack(instance_key: String) -> void:
+	if reconciler == null:
 		return
-	if reconciler.get_ball_for_key(item_key) != null:
-		return
-	reconciler.spawn_stored(item_key, rack.get_slot_position_for(item_key))
+	reconciler.ensure_stored_ball_for_key(instance_key)
 
 
 ## Funnels venue-floor releases into the reconciler with the loose-in-venue overlay set.

--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -364,15 +364,17 @@ func take_ball(item_key: String) -> bool:
 	return true
 
 
-## Acquires a ball item without registering its effects; false if unaffordable.
-func take(item_key: String) -> bool:
+## Acquires a ball item without registering its effects. Returns the new instance
+## key on success, "" if unaffordable.
+func take(item_key: String) -> String:
 	var item := _get_item(item_key)
 	if item == null:
-		return false
+		return ""
 	if not take_ball(item_key):
-		return false
-	register_instance(generate_instance_key(item_key))
-	return true
+		return ""
+	var instance_key: String = generate_instance_key(item_key)
+	register_instance(instance_key)
+	return instance_key
 
 
 ## Returns points to the balance without counting them as newly earned.

--- a/scripts/items/item_manager.gd
+++ b/scripts/items/item_manager.gd
@@ -364,16 +364,18 @@ func take_ball(item_key: String) -> bool:
 	return true
 
 
-## Acquires a ball item without registering its effects. Returns the new instance
-## key on success, "" if unaffordable.
+## Acquires a ball item without registering its effects.
 func take(item_key: String) -> String:
 	var item := _get_item(item_key)
 	if item == null:
 		return ""
+
 	if not take_ball(item_key):
 		return ""
+
 	var instance_key: String = generate_instance_key(item_key)
 	register_instance(instance_key)
+
 	return instance_key
 
 

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -130,30 +130,35 @@ func start_drag() -> bool:
 	return true
 
 
-## Release outcomes branch on inside-shop vs outside, plus travel-threshold for inside drags.
+## Tries to release item to a drop target
 func attempt_release(release_position: Vector2) -> bool:
 	if _held_token == null:
 		return false
 
 	var inside_shop: bool = _is_position_inside_shop(release_position)
 	if not inside_shop:
-		# Held until the cursor reaches somewhere a target will take, so a refused drop costs nothing.
 		if not _any_target_accepts(release_position):
 			return false
 
 		var instance_key: String = _complete_purchase()
 		if instance_key.is_empty():
 			return false
+
 		var controller: Node = _drag_controller()
 		var spawned: bool = false
+
 		if controller != null and controller.has_method("spawn_purchased_at"):
 			spawned = controller.spawn_purchased_at(
 				instance_key, release_position, _release_velocity()
 			)
+
 		if not spawned:
 			_drop_falling_body(release_position)
+
 		_finalise_gesture(release_position, true)
+
 		visible = false
+
 		return true
 
 	# Inside-shop branch: revert to shelf position, no ball spawn.

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -229,7 +229,7 @@ func notify_body_settled(ball: Ball, settled_position: Vector2) -> void:
 	var reconciler: Node = _resolve_reconciler(controller)
 
 	if not is_owned():
-		if not _complete_purchase():
+		if _complete_purchase().is_empty():
 			_release_ball_from_registry(reconciler, ball)
 			visible = true
 			return

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -141,13 +141,14 @@ func attempt_release(release_position: Vector2) -> bool:
 		if not _any_target_accepts(release_position):
 			return false
 
-		if not _complete_purchase():
+		var instance_key: String = _complete_purchase()
+		if instance_key.is_empty():
 			return false
 		var controller: Node = _drag_controller()
 		var spawned: bool = false
 		if controller != null and controller.has_method("spawn_purchased_at"):
 			spawned = controller.spawn_purchased_at(
-				item_definition.key, release_position, _release_velocity()
+				instance_key, release_position, _release_velocity()
 			)
 		if not spawned:
 			_drop_falling_body(release_position)
@@ -285,11 +286,12 @@ func _start_drag() -> void:
 	pickup_started.emit(item_definition.key)
 
 
-func _complete_purchase() -> bool:
+## Returns the newly minted instance key on success, "" on failure.
+func _complete_purchase() -> String:
 	if not can_be_owned():
-		return false
+		return ""
 	if _item_manager.get_owned_count(item_definition.key) >= item_definition.max_level:
-		return false
+		return ""
 	return _item_manager.take(item_definition.key)
 
 

--- a/scripts/shop/shop_item.gd
+++ b/scripts/shop/shop_item.gd
@@ -137,23 +137,19 @@ func attempt_release(release_position: Vector2) -> bool:
 
 	var inside_shop: bool = _is_position_inside_shop(release_position)
 	if not inside_shop:
-		if not _any_target_accepts(release_position):
-			return false
-
-		var instance_key: String = _complete_purchase()
-		if instance_key.is_empty():
-			return false
-
 		var controller: Node = _drag_controller()
 		var spawned: bool = false
 
-		if controller != null and controller.has_method("spawn_purchased_at"):
-			spawned = controller.spawn_purchased_at(
-				instance_key, release_position, _release_velocity()
+		if controller != null and controller.has_method("try_purchase_and_spawn"):
+			spawned = controller.try_purchase_and_spawn(
+				item_definition.key, release_position, _release_velocity()
 			)
+		elif _any_target_accepts(release_position) and not _complete_purchase().is_empty():
+			_drop_falling_body(release_position)
+			spawned = true
 
 		if not spawned:
-			_drop_falling_body(release_position)
+			return false
 
 		_finalise_gesture(release_position, true)
 
@@ -174,11 +170,11 @@ func attempt_release(release_position: Vector2) -> bool:
 	return true
 
 
-func _drag_controller() -> Node:
+func _drag_controller() -> ItemDragController:
 	var tree: SceneTree = get_tree()
 	if tree == null:
 		return null
-	return tree.get_first_node_in_group(&"drag_controller")
+	return tree.get_first_node_in_group(&"drag_controller") as ItemDragController
 
 
 ## The fallback drop spawns wherever it is told, so the caller checks the position is on a target first.

--- a/tests/integration/test_repeat_purchase_spawns_distinct_balls.gd
+++ b/tests/integration/test_repeat_purchase_spawns_distinct_balls.gd
@@ -1,0 +1,69 @@
+extends GutTest
+
+const ShopItemScene: PackedScene = preload("res://scenes/shop_item.tscn")
+const ItemDragControllerScript: GDScript = preload("res://scripts/items/item_drag_controller.gd")
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const StandardBall: ItemDefinition = preload("res://resources/items/standard_ball.tres")
+
+var _manager: Node
+var _reconciler: BallReconciler
+var _drag: ItemDragController
+var _item: ShopItem
+
+
+func before_each() -> void:
+	_manager = ItemFactory.create_manager(self)
+	_manager.items.assign([StandardBall] as Array[ItemDefinition])
+	_manager.economy.soul_balance = 10000
+
+	var rack: RackDisplay = ItemTestHelpers.make_rack(_manager, self)
+	var rack_drop_area: Area2D = ItemTestHelpers.make_drop_area(
+		Vector2(-1000, 0), Vector2(300, 200), self
+	)
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	add_child_autofree(_reconciler)
+
+	_drag = ItemDragControllerScript.new()
+	_drag.configure(_manager, rack, rack_drop_area, _reconciler)
+	add_child_autofree(_drag)
+
+	ItemTestHelpers.make_drop_targets(_manager, _reconciler, rack_drop_area.position, self)
+
+	_item = ShopItemScene.instantiate()
+	_item._item_manager = _manager
+	add_child_autofree(_item)
+	_item.configure(_manager, StandardBall)
+
+
+func after_each() -> void:
+	await get_tree().process_frame
+
+
+func test_second_purchase_released_on_court_spawns_a_second_distinct_ball() -> void:
+	_item.start_drag()
+	assert_true(_item.attempt_release(Vector2(100, 50)))
+	var first_ball: Ball = _reconciler.get_ball_for_key(StandardBall.key)
+	assert_not_null(first_ball)
+
+	_item.visible = true
+	_item.start_drag()
+	assert_true(_item.attempt_release(Vector2(200, 60)))
+
+	assert_eq(_manager.get_owned_count(StandardBall.key), 2)
+	assert_true(
+		is_instance_valid(first_ball),
+		"the first purchased ball should not be replaced or freed by the second purchase",
+	)
+	assert_eq(
+		first_ball.global_position,
+		Vector2(100, 50),
+		"the second purchase must not move the first ball",
+	)
+
+	var balls_on_court: int = 0
+	for ball: Ball in _reconciler.get_balls():
+		if _manager.is_on_court(ball.item_key):
+			balls_on_court += 1
+	assert_eq(balls_on_court, 2, "both purchased balls should be distinct and both on the court")

--- a/tests/integration/test_repeat_purchase_spawns_distinct_balls.gd.uid
+++ b/tests/integration/test_repeat_purchase_spawns_distinct_balls.gd.uid
@@ -1,0 +1,1 @@
+uid://cg2y7k36rbh8h

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -246,10 +246,10 @@ class TestTake:
 		ball.effects = []
 		_manager.items.assign([ball] as Array[ItemDefinition])
 
-	func test_take_returns_false_when_balance_too_low() -> void:
+	func test_take_returns_empty_string_when_balance_too_low() -> void:
 		assert_eq(_manager.take(TEST_KEY), "")
 
-	func test_take_returns_true_when_affordable() -> void:
+	func test_take_returns_instance_key_when_affordable() -> void:
 		_manager.economy.soul_balance = 100
 		assert_eq(_manager.take(TEST_KEY), TEST_INSTANCE_KEY)
 

--- a/tests/unit/items/test_item_manager.gd
+++ b/tests/unit/items/test_item_manager.gd
@@ -247,11 +247,11 @@ class TestTake:
 		_manager.items.assign([ball] as Array[ItemDefinition])
 
 	func test_take_returns_false_when_balance_too_low() -> void:
-		assert_false(_manager.take(TEST_KEY))
+		assert_eq(_manager.take(TEST_KEY), "")
 
 	func test_take_returns_true_when_affordable() -> void:
 		_manager.economy.soul_balance = 100
-		assert_true(_manager.take(TEST_KEY))
+		assert_eq(_manager.take(TEST_KEY), TEST_INSTANCE_KEY)
 
 	func test_take_marks_instance_as_owned() -> void:
 		_manager.economy.soul_balance = 100


### PR DESCRIPTION
A shop purchase released directly onto the court kept ItemManager.take()'s generated instance key discarded, so the placement path used the bare item definition key instead. A second purchase of the same ball type then collided with the first under that shared key rather than getting its own instance, which is what let a standard or old ball's court state get corrupted after being bought and later re-grabbed.

ItemManager.take() now returns the minted instance key, and ShopItem threads it through to the court/rack placement call instead of the base key.

Added an integration test that buys the same ball twice, releasing each straight onto the court, and asserts both end up as distinct, independently tracked balls. It fails against the old code (the second purchase moves/overwrites the first) and passes with the fix.