### PR TITLE
ci: log promote failures with the failing oid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,17 @@ jobs:
 
       - name: Promote preview objects to release
         run: |
-          curl -fsSL -X POST \
+          status=$(curl -sS -o response.json -w "%{http_code}" -X POST \
             -H "Authorization: Basic $(printf 'volley:%s' "${{ secrets.LFS_PROMOTE_KEY }}" | base64 -w0)" \
             -H "Content-Type: application/json" \
             -d "{\"oids\": $(cat oids.json)}" \
-            https://volley-lfs-proxy.volcanoem.workers.dev/promote
+            https://volley-lfs-proxy.volcanoem.workers.dev/promote)
+          cat response.json
+          echo
+          if [ "$status" -ne 200 ]; then
+            echo "::error::promote request failed with HTTP $status; failing oids listed above"
+            exit 1
+          fi
 
   deploy-production:
     name: Deploy to Production


### PR DESCRIPTION
The release pipeline's LFS promote step used \`curl -fsSL\`, which discards the response body on any non-2xx status. When it fails, CI only shows a bare 502 with no indication of which LFS object was missing or why, so diagnosing a failure means guessing at recently changed assets and re-uploading them one at a time.

The Worker already returns a JSON body naming each failing oid and its reason; this just captures and prints that body before failing the step.