### PR TITLE
ci: promote LFS objects on merge to main, not on release publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,40 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
+  promote-lfs:
+    name: Promote LFS objects to preview
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+
+      - name: Collect LFS oids
+        id: oids
+        run: |
+          git lfs ls-files --long | awk '{print $1}' | jq -Rsc 'split("\n") | map(select(. != ""))' > oids.json
+
+      - name: Promote objects for preview and future release fetch
+        run: |
+          status=$(curl -sS -o response.json -w "%{http_code}" -X POST \
+            -H "Authorization: Basic $(printf 'volley:%s' "${{ secrets.LFS_PROMOTE_KEY }}" | base64 -w0)" \
+            -H "Content-Type: application/json" \
+            -d "{\"oids\": $(cat oids.json)}" \
+            https://volley-lfs-proxy.volcanoem.workers.dev/promote)
+          cat response.json
+          echo
+          if [ "$status" -ne 200 ]; then
+            echo "::error::promote request failed with HTTP $status; failing oids listed above"
+            exit 1
+          fi
+
   deploy-preview:
     name: Deploy to Preview
-    needs: test
+    needs: promote-lfs
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,37 +25,6 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
-  promote-lfs:
-    name: Promote LFS objects to release
-    needs: test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          lfs: false
-
-      - name: Collect released LFS oids
-        id: oids
-        run: |
-          git lfs ls-files --long | awk '{print $1}' | jq -Rsc 'split("\n") | map(select(. != ""))' > oids.json
-
-      - name: Promote preview objects to release
-        run: |
-          status=$(curl -sS -o response.json -w "%{http_code}" -X POST \
-            -H "Authorization: Basic $(printf 'volley:%s' "${{ secrets.LFS_PROMOTE_KEY }}" | base64 -w0)" \
-            -H "Content-Type: application/json" \
-            -d "{\"oids\": $(cat oids.json)}" \
-            https://volley-lfs-proxy.volcanoem.workers.dev/promote)
-          cat response.json
-          echo
-          if [ "$status" -ne 200 ]; then
-            echo "::error::promote request failed with HTTP $status; failing oids listed above"
-            exit 1
-          fi
-
   deploy-production:
     name: Deploy to Production
     needs: test


### PR DESCRIPTION
The preview deploy pulls LFS assets from a proxy that only serves objects promoted via a prior published release. Since previews run on every push to main, any asset merged since the last published release 404s until the next release runs. Moves the promotion step from release.yml (release-published trigger) to publish.yml (main-push trigger), so preview always has what it needs and release inherits already-promoted objects.