### PR TITLE
ci: drop misleading preview-specific wording from the promote job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   promote-lfs:
-    name: Promote LFS objects to preview
+    name: Promote LFS objects
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -42,7 +42,7 @@ jobs:
         run: |
           git lfs ls-files --long | awk '{print $1}' | jq -Rsc 'split("\n") | map(select(. != ""))' > oids.json
 
-      - name: Promote objects for preview and future release fetch
+      - name: Promote objects on the proxy
         run: |
           status=$(curl -sS -o response.json -w "%{http_code}" -X POST \
             -H "Authorization: Basic $(printf 'volley:%s' "${{ secrets.LFS_PROMOTE_KEY }}" | base64 -w0)" \


### PR DESCRIPTION
The promote job's name and its POST step's log line said "to preview"/"for preview," but the /promote call is the same generic proxy action release.yml always made, just now firing on merge to main instead of on release-publish. Nothing about it is preview-specific.