### PR TITLE
chore: remove dead godotiq references from CI and docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,8 +85,6 @@ jobs:
 
       - name: Strip dev addons
         run: |
-          sed -i '/GodotIQRuntime=/d' project.godot
-          sed -i 's|"res://addons/godotiq/plugin.cfg", ||g' project.godot
           sed -i 's|"res://addons/gut/plugin.cfg", ||g' project.godot
           sed -i 's|, "res://addons/gut/plugin.cfg"||g' project.godot
           rm -rf addons/coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
 
       - name: Strip dev addons
         run: |
-          sed -i '/GodotIQRuntime=/d' project.godot
-          sed -i 's|"res://addons/godotiq/plugin.cfg", ||g' project.godot
           sed -i 's|"res://addons/gut/plugin.cfg", ||g' project.godot
           sed -i 's|, "res://addons/gut/plugin.cfg"||g' project.godot
           rm -rf addons/coverage

--- a/designs/art/tech-pipeline.md
+++ b/designs/art/tech-pipeline.md
@@ -296,7 +296,7 @@ Budgets are re-verified with `perf_snapshot` once representative content ships. 
 
 Volley! targets **Godot 4.6.2** (the version pinned in `project.godot`). Parallax2D requires 4.3 or later; CanvasModulate, AnimatedSprite2D, and Light2D have been stable since 4.0.
 
-Rendering-adjacent addons currently enabled: none. The pipeline above ships in core Godot. GodotIQ, GUT, config_hot_reload, gdfxr, and item_preview are authoring-side only and do not affect runtime rendering.
+Rendering-adjacent addons currently enabled: none. The pipeline above ships in core Godot. GUT, config_hot_reload, gdfxr, and item_preview are authoring-side only and do not affect runtime rendering.
 
 ---
 


### PR DESCRIPTION
The addon isn't installed and project.godot never had it registered, so the strip-step sed commands in publish.yml/release.yml were already no-ops. Drops those plus the one design-doc mention. Local .claude/agents/** definitions referencing godotiq tools were also cleaned up directly (that directory is gitignored, so those edits aren't part of this PR).