### PR TITLE
fix: fall back to base stats when a ball definition omits stats

### DIFF
--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -381,8 +381,10 @@ func _apply_item_art() -> void:
 
 
 ## Ball-scoped stats when a definition is known (ball_key set); the shared default otherwise
-## (unadopted balls, test stubs).
+## (unadopted balls, test stubs, and definitions whose .tres omits a `stats` line, where the
+## script's initialiser does not run).
 func get_stats() -> BaseBallStats:
 	if ball_key == "":
 		return GameRules.base
-	return _ball_manager.get_item(ball_key).stats
+	var stats: BaseBallStats = _ball_manager.get_item(ball_key).stats
+	return stats if stats != null else GameRules.base


### PR DESCRIPTION
Spawning a ball from the shop raised `get_stats() returned null` and left the ball without speed limits. The cause was not the instance-key lookup this branch was named for: `BallManager._get_item` resolved `old_ball_1` to its definition correctly the whole time.

The null came from `BallDefinition.stats`. The property carries a script-level initialiser that loads the shared base resource, but a `.tres` applies only the properties it actually writes, and none of the three shipped ball resources write a `stats` line. Every resource-loaded ball therefore deserialised with `stats` set to null, while definitions built in code through `BallDefinition.new()` picked the initialiser up, which is why the unit suite never saw it. This has been latent since stats were scoped per ball in 627931f9.

`get_stats()` now honours the fallback its docstring already promised, returning the shared default when a definition carries no stats of its own. Balls run on base stats until a definition is given its own resource to diverge with.