### PR TITLE
fix: match top-level assets/*.png files in the PR preview glob

### DIFF
--- a/.github/workflows/pr-asset-preview.yml
+++ b/.github/workflows/pr-asset-preview.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Find changed assets
         id: changed
         run: |
-          git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" -- 'assets/**/*.png' > /tmp/changed.txt
+          git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" -- 'assets/**.png' > /tmp/changed.txt
           echo "count=$(wc -l < /tmp/changed.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Pull LFS objects


### PR DESCRIPTION
The preview workflow's changed-asset detection used the pathspec assets/**/*.png, which requires at least one directory between assets/ and the filename. A PNG added directly under assets/ (e.g. assets/ball_box.png) never matched, so the workflow silently found zero changed assets and skipped posting a preview. assets/**.png matches both top-level and nested files.