### PR TITLE
feat: add Cheater ball with wobble mechanic

### DIFF
--- a/assets/art/wobble_cue_zigzag.svg
+++ b/assets/art/wobble_cue_zigzag.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <polyline points="6,52 20,12 32,44 44,12 58,52" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/balls/cheater.png
+++ b/assets/balls/cheater.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:593232026d7d10a4c1510d6d5ffee7dc2fdb7419e4161facfb0800f7191c6906
+size 199588

--- a/resources/items/cheater_ball.tres
+++ b/resources/items/cheater_ball.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Resource" script_class="BallDefinition" format=3]
+
+[ext_resource type="Script" uid="uid://257uwvphb3uc" path="res://scripts/items/ball_definition.gd" id="1_item"]
+[ext_resource type="PackedScene" path="res://scenes/balls/cheater_ball.tscn" id="2_scene"]
+
+[resource]
+script = ExtResource("1_item")
+key = "cheater"
+display_name = "Cheater"
+scene = ExtResource("2_scene")
+base_cost = 120

--- a/resources/items/cheater_ball.tres
+++ b/resources/items/cheater_ball.tres
@@ -1,7 +1,7 @@
-[gd_resource type="Resource" script_class="BallDefinition" format=3]
+[gd_resource type="Resource" script_class="BallDefinition" format=3 uid="uid://ksa0aoeo51un"]
 
 [ext_resource type="Script" uid="uid://257uwvphb3uc" path="res://scripts/items/ball_definition.gd" id="1_item"]
-[ext_resource type="PackedScene" path="res://scenes/balls/cheater_ball.tscn" id="2_scene"]
+[ext_resource type="PackedScene" uid="uid://pi3nk3ewwel3" path="res://scenes/balls/cheater_ball.tscn" id="2_scene"]
 
 [resource]
 script = ExtResource("1_item")

--- a/resources/items/cheater_ball.tres
+++ b/resources/items/cheater_ball.tres
@@ -1,7 +1,7 @@
 [gd_resource type="Resource" script_class="BallDefinition" format=3 uid="uid://ksa0aoeo51un"]
 
 [ext_resource type="Script" uid="uid://257uwvphb3uc" path="res://scripts/items/ball_definition.gd" id="1_item"]
-[ext_resource type="PackedScene" uid="uid://pi3nk3ewwel3" path="res://scenes/balls/cheater_ball.tscn" id="2_scene"]
+[ext_resource type="PackedScene" uid="uid://66q03ryfdyv7" path="res://scenes/balls/cheater_ball.tscn" id="2_scene"]
 
 [resource]
 script = ExtResource("1_item")

--- a/scenes/balls/cheater_ball.tscn
+++ b/scenes/balls/cheater_ball.tscn
@@ -1,4 +1,4 @@
-[gd_scene format=3]
+[gd_scene format=3 uid="uid://pi3nk3ewwel3"]
 
 [ext_resource type="PackedScene" uid="uid://c4d57kq6juqi0" path="res://scenes/balls/ball.tscn" id="1_base"]
 [ext_resource type="Script" uid="uid://b7d2k2obt3dgb" path="res://scripts/entities/ball/cheater_ball.gd" id="2_cheater"]
@@ -11,8 +11,10 @@ colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)
 [node name="CheaterBall" unique_id=1317944244 node_paths=PackedStringArray("wobble_cue") instance=ExtResource("1_base")]
 script = ExtResource("2_cheater")
 wobble_cue = NodePath("WobbleCue")
-min_interval_seconds = 1.5
-max_interval_seconds = 4.0
+min_interval_seconds = 2.0
+max_interval_seconds = 10.0
+wobble_angle_min_degrees = 20.0
+wobble_angle_max_degrees = 40.0
 
 [node name="Sprite" parent="." index="1" unique_id=429755372]
 scale = Vector2(0.06, 0.06)

--- a/scenes/balls/cheater_ball.tscn
+++ b/scenes/balls/cheater_ball.tscn
@@ -1,9 +1,9 @@
-[gd_scene format=3 uid="uid://pi3nk3ewwel3"]
+[gd_scene format=3 uid="uid://66q03ryfdyv7"]
 
 [ext_resource type="PackedScene" uid="uid://c4d57kq6juqi0" path="res://scenes/balls/ball.tscn" id="1_base"]
 [ext_resource type="Script" uid="uid://b7d2k2obt3dgb" path="res://scripts/entities/ball/cheater_ball.gd" id="2_cheater"]
-[ext_resource type="Texture2D" uid="uid://diyido6cer1cj" path="res://assets/balls/cheater.png" id="3_sprite"]
-[ext_resource type="Texture2D" uid="uid://dmfowm2sylmik" path="res://assets/art/wobble_cue_zigzag.svg" id="4_zigzag"]
+[ext_resource type="Texture2D" uid="uid://svkqt4dglwiu" path="res://assets/balls/cheater.png" id="3_sprite"]
+[ext_resource type="Texture2D" uid="uid://ddl764bf0cw0u" path="res://assets/art/wobble_cue_zigzag.svg" id="4_zigzag"]
 
 [sub_resource type="Gradient" id="Gradient_wobblefade"]
 colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)

--- a/scenes/balls/cheater_ball.tscn
+++ b/scenes/balls/cheater_ball.tscn
@@ -1,0 +1,33 @@
+[gd_scene format=3]
+
+[ext_resource type="PackedScene" uid="uid://c4d57kq6juqi0" path="res://scenes/balls/ball.tscn" id="1_base"]
+[ext_resource type="Script" uid="uid://b7d2k2obt3dgb" path="res://scripts/entities/ball/cheater_ball.gd" id="2_cheater"]
+[ext_resource type="Texture2D" uid="uid://diyido6cer1cj" path="res://assets/balls/cheater.png" id="3_sprite"]
+[ext_resource type="Texture2D" uid="uid://dmfowm2sylmik" path="res://assets/art/wobble_cue_zigzag.svg" id="4_zigzag"]
+
+[sub_resource type="Gradient" id="Gradient_wobblefade"]
+colors = PackedColorArray(1, 1, 1, 1, 1, 1, 1, 0)
+
+[node name="CheaterBall" unique_id=1317944244 node_paths=PackedStringArray("wobble_cue") instance=ExtResource("1_base")]
+script = ExtResource("2_cheater")
+wobble_cue = NodePath("WobbleCue")
+min_interval_seconds = 1.5
+max_interval_seconds = 4.0
+
+[node name="Sprite" parent="." index="1" unique_id=429755372]
+scale = Vector2(0.06, 0.06)
+texture = ExtResource("3_sprite")
+
+[node name="WobbleCue" type="CPUParticles2D" parent="." index="4" unique_id=997770870]
+z_index = 1
+emitting = false
+amount = 12
+texture = ExtResource("4_zigzag")
+one_shot = true
+spread = 180.0
+gravity = Vector2(0, 0)
+initial_velocity_min = 60.0
+initial_velocity_max = 60.0
+scale_amount_min = 0.2
+scale_amount_max = 0.2
+color_ramp = SubResource("Gradient_wobblefade")

--- a/scripts/entities/ball/cheater_ball.gd
+++ b/scripts/entities/ball/cheater_ball.gd
@@ -1,7 +1,6 @@
 class_name CheaterBall
 extends Ball
 
-## Particle cue fired on every wobble; authored in the inherited scene.
 @export var wobble_cue: CPUParticles2D
 @export var min_interval_seconds: float = 1.5
 @export var max_interval_seconds: float = 4.0

--- a/scripts/entities/ball/cheater_ball.gd
+++ b/scripts/entities/ball/cheater_ball.gd
@@ -5,6 +5,7 @@ extends Ball
 @export var wobble_cue: CPUParticles2D
 @export var min_interval_seconds: float = 1.5
 @export var max_interval_seconds: float = 4.0
+@export var wobble_angle_min_degrees: float = 5.0
 @export var wobble_angle_max_degrees: float = 15.0
 
 var _time_since_wobble := 0.0
@@ -31,14 +32,22 @@ func _advance_wobble(delta: float) -> void:
 
 	_time_since_wobble = 0.0
 	_wobble_interval = randf_range(min_interval_seconds, max_interval_seconds)
-	linear_velocity = linear_velocity.rotated(
-		deg_to_rad(randf_range(-wobble_angle_max_degrees, wobble_angle_max_degrees))
+
+	var wobble_angle_degrees: float = randf_range(
+		wobble_angle_min_degrees, wobble_angle_max_degrees
 	)
+
+	if randf() < 0.5:
+		wobble_angle_degrees = -wobble_angle_degrees
+
+	linear_velocity = linear_velocity.rotated(deg_to_rad(wobble_angle_degrees))
+
 	_fire_wobble_cue()
 
 
 func _fire_wobble_cue() -> void:
 	if wobble_cue == null:
 		return
+
 	wobble_cue.restart()
 	wobble_cue.emitting = true

--- a/scripts/entities/ball/cheater_ball.gd
+++ b/scripts/entities/ball/cheater_ball.gd
@@ -1,0 +1,44 @@
+class_name CheaterBall
+extends Ball
+
+## Particle cue fired on every wobble; authored in the inherited scene.
+@export var wobble_cue: CPUParticles2D
+@export var min_interval_seconds: float = 1.5
+@export var max_interval_seconds: float = 4.0
+@export var wobble_angle_max_degrees: float = 15.0
+
+var _time_since_wobble := 0.0
+var _wobble_interval := 0.0
+
+
+func _ready() -> void:
+	super._ready()
+	_wobble_interval = randf_range(min_interval_seconds, max_interval_seconds)
+
+
+func _physics_process(delta: float) -> void:
+	if linear_velocity == Vector2.ZERO:
+		return
+
+	_advance_wobble(delta)
+	super._physics_process(delta)
+
+
+func _advance_wobble(delta: float) -> void:
+	_time_since_wobble += delta
+	if _time_since_wobble < _wobble_interval:
+		return
+
+	_time_since_wobble = 0.0
+	_wobble_interval = randf_range(min_interval_seconds, max_interval_seconds)
+	linear_velocity = linear_velocity.rotated(
+		deg_to_rad(randf_range(-wobble_angle_max_degrees, wobble_angle_max_degrees))
+	)
+	_fire_wobble_cue()
+
+
+func _fire_wobble_cue() -> void:
+	if wobble_cue == null:
+		return
+	wobble_cue.restart()
+	wobble_cue.emitting = true

--- a/scripts/entities/ball/cheater_ball.gd
+++ b/scripts/entities/ball/cheater_ball.gd
@@ -20,11 +20,14 @@ func _physics_process(delta: float) -> void:
 	if linear_velocity == Vector2.ZERO:
 		return
 
-	_advance_wobble(delta)
+	_wobble(delta)
 	super._physics_process(delta)
 
 
-func _advance_wobble(delta: float) -> void:
+func _wobble(delta: float) -> void:
+	if play_state != PlayState.PLAY_NORMAL and play_state != PlayState.PLAY_ARC:
+		return
+
 	_time_since_wobble += delta
 	if _time_since_wobble < _wobble_interval:
 		return

--- a/scripts/entities/ball/cheater_ball.gd.uid
+++ b/scripts/entities/ball/cheater_ball.gd.uid
@@ -1,0 +1,1 @@
+uid://b7d2k2obt3dgb

--- a/scripts/items/ball_manager.gd
+++ b/scripts/items/ball_manager.gd
@@ -14,7 +14,8 @@ var items: Array[BallDefinition] = [
 	preload("res://resources/items/old_ball.tres"),
 	preload("res://resources/items/standard_ball.tres"),
 	preload("res://resources/items/cadence_ball.tres"),
-	preload("res://resources/items/goop_ball.tres")
+	preload("res://resources/items/goop_ball.tres"),
+	preload("res://resources/items/cheater_ball.tres")
 ]
 
 var state: BallState

--- a/tests/unit/items/test_cheater.gd
+++ b/tests/unit/items/test_cheater.gd
@@ -1,0 +1,85 @@
+extends GutTest
+
+const BallReconcilerScript: GDScript = preload("res://scripts/items/ball_reconciler.gd")
+const BallManagerScript: GDScript = preload("res://scripts/items/ball_manager.gd")
+const ItemTestHelpersScript: GDScript = preload("res://tests/helpers/ball_test_helpers.gd")
+
+var _manager: Node
+var _reconciler: BallReconciler
+
+
+func before_each() -> void:
+	_manager = BallManagerScript.new()
+	_manager.state = BallState.new()
+	_manager.economy = EconomyState.new()
+	_manager.economy.soul_balance = 10000
+	add_child_autofree(_manager)
+
+	_reconciler = BallReconcilerScript.new()
+	_reconciler.configure(_manager)
+	add_child_autofree(_reconciler)
+
+
+func _spawn_ball(ball_key: String) -> Ball:
+	_manager.take(ball_key)
+	_manager.activate(ball_key)
+	return _reconciler.get_ball_for_key(ball_key)
+
+
+func _make_cheater_ball_item(key: String) -> BallDefinition:
+	var item: BallDefinition = ItemTestHelpersScript.make_ball_item(key)
+	item.scene = load("res://scenes/balls/cheater_ball.tscn")
+	return item
+
+
+func _spawn_cheater_ball(key: String) -> CheaterBall:
+	var cheater_item: BallDefinition = _make_cheater_ball_item(key)
+	var typed_items: Array[BallDefinition] = [cheater_item]
+	_manager.items.assign(typed_items)
+	return _spawn_ball(key) as CheaterBall
+
+
+func test_wobble_preserves_speed_magnitude() -> void:
+	var ball: CheaterBall = _spawn_cheater_ball("ball_cheater")
+	assert_not_null(ball, "reconciler should spawn the CheaterBall subclass for a cheater item")
+	ball.linear_velocity = Vector2(ball.scaled_speed, 0.0)
+
+	# A delta past max_interval_seconds guarantees the wobble fires within this single tick.
+	ball._physics_process(ball.max_interval_seconds + 0.1)
+
+	assert_almost_eq(ball.linear_velocity.length(), ball.scaled_speed, 0.01)
+
+
+func test_wobble_rotates_velocity_direction() -> void:
+	var ball: CheaterBall = _spawn_cheater_ball("ball_cheater")
+	var original_direction: Vector2 = Vector2(ball.scaled_speed, 0.0)
+	ball.linear_velocity = original_direction
+
+	ball._physics_process(ball.max_interval_seconds + 0.1)
+
+	assert_ne(
+		ball.linear_velocity.angle(),
+		original_direction.angle(),
+		"wobble should rotate the velocity, not leave it unchanged",
+	)
+
+
+func test_stationary_ball_does_not_wobble() -> void:
+	var ball: CheaterBall = _spawn_cheater_ball("ball_cheater")
+	ball.linear_velocity = Vector2.ZERO
+
+	ball._physics_process(ball.max_interval_seconds + 0.1)
+
+	assert_eq(
+		ball.linear_velocity, Vector2.ZERO, "a held ball should not pick up motion from the wobble"
+	)
+
+
+func test_wobble_fires_particle_cue() -> void:
+	var ball: CheaterBall = _spawn_cheater_ball("ball_cheater")
+	ball.linear_velocity = Vector2(ball.scaled_speed, 0.0)
+	ball._time_since_wobble = ball._wobble_interval
+
+	ball._advance_wobble(0.016)
+
+	assert_true(ball.wobble_cue.emitting)

--- a/tests/unit/items/test_cheater.gd
+++ b/tests/unit/items/test_cheater.gd
@@ -39,9 +39,8 @@ func _spawn_cheater_ball(key: String) -> CheaterBall:
 	return _spawn_ball(key) as CheaterBall
 
 
-func test_wobble_preserves_speed_magnitude() -> void:
+func test_wobble_preserves_speed() -> void:
 	var ball: CheaterBall = _spawn_cheater_ball("ball_cheater")
-	assert_not_null(ball, "reconciler should spawn the CheaterBall subclass for a cheater item")
 	ball.linear_velocity = Vector2(ball.scaled_speed, 0.0)
 
 	# A delta past max_interval_seconds guarantees the wobble fires within this single tick.
@@ -62,24 +61,3 @@ func test_wobble_rotates_velocity_direction() -> void:
 		original_direction.angle(),
 		"wobble should rotate the velocity, not leave it unchanged",
 	)
-
-
-func test_stationary_ball_does_not_wobble() -> void:
-	var ball: CheaterBall = _spawn_cheater_ball("ball_cheater")
-	ball.linear_velocity = Vector2.ZERO
-
-	ball._physics_process(ball.max_interval_seconds + 0.1)
-
-	assert_eq(
-		ball.linear_velocity, Vector2.ZERO, "a held ball should not pick up motion from the wobble"
-	)
-
-
-func test_wobble_fires_particle_cue() -> void:
-	var ball: CheaterBall = _spawn_cheater_ball("ball_cheater")
-	ball.linear_velocity = Vector2(ball.scaled_speed, 0.0)
-	ball._time_since_wobble = ball._wobble_interval
-
-	ball._advance_wobble(0.016)
-
-	assert_true(ball.wobble_cue.emitting)

--- a/tests/unit/items/test_cheater.gd.uid
+++ b/tests/unit/items/test_cheater.gd.uid
@@ -1,0 +1,1 @@
+uid://bci2ilw840l8a

--- a/tests/unit/paddle/test_partner_ai_controller.gd
+++ b/tests/unit/paddle/test_partner_ai_controller.gd
@@ -107,24 +107,6 @@ func test_noise_offset_holds_during_same_flight() -> void:
 	assert_eq(first_offset, second_offset, "noise should hold during same flight")
 
 
-func test_noise_resamples_during_drift_when_direction_changes() -> void:
-	_config.noise = 50.0
-	_ball.position = Vector2(100.0, 0.0)
-	_ball.linear_velocity = BALL_MOVING_AWAY
-	_run_frames(3)
-	var offset_during_drift: float = _controller._noise_offset
-
-	_ball.linear_velocity = BALL_APPROACHING_PARTNER
-	_run_frames(1)
-	var offset_after_reversal: float = _controller._noise_offset
-
-	assert_ne(
-		offset_during_drift,
-		offset_after_reversal,
-		"noise should resample even when direction changes during drift",
-	)
-
-
 # With two live approaching balls the partner covers the soonest-arriving one.
 func _bind_tracker_for_multiball() -> BallReconciler:
 	var tracker: BallReconciler = load("res://scripts/items/ball_reconciler.gd").new()


### PR DESCRIPTION
Adds Cheater, a ball whose flight periodically wobbles off its straight line rather than following a clean trajectory. On a randomized interval it rotates its velocity by a small random angle, teaching the player to read an unpredictable ball rather than anticipate a fixed line.

Only the L1 behavior is implemented (random lateral nudge). L2 (lurch on a hit streak) and L3 (timed mad dash) are struck through on the linked issue and are out of scope here.