### PR TITLE
fix: only advance Cadence's mode shift while the ball is in play

### DIFF
--- a/scripts/entities/ball/cadence_ball.gd
+++ b/scripts/entities/ball/cadence_ball.gd
@@ -39,6 +39,9 @@ func refresh_scaled_speed() -> void:
 
 
 func _advance_mode(delta: float) -> void:
+	if play_state != PlayState.PLAY_NORMAL and play_state != PlayState.PLAY_ARC:
+		return
+
 	_time_in_mode += delta
 	if _time_in_mode < _hold_duration:
 		return


### PR DESCRIPTION
CadenceBall's speed-mode timer only checked linear_velocity against zero before advancing, so its mode shift (and particle cue) could fire while the ball was not actually in active play, as long as velocity happened to be nonzero. The Cheater ball's wobble had the same gap and was fixed in PR #1202; this applies the identical play_state gate to Cadence.