### PR TITLE
fix: gate volley-count reset on last ball in play

### DIFF
--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -36,7 +36,6 @@ var _partners: PartnersState
 var _progression_config: ProgressionConfig
 var _ball_manager: BallManager
 var _is_autoplay_active := false
-var _soul_accumulator := 0.0
 var _tier_reward_handler: TierRewardHandler
 var _volley_streak_tracker: VolleyStreakTracker
 
@@ -146,8 +145,6 @@ func _on_ball_missed(missed_ball: Ball) -> void:
 	if has_ball_in_play:
 		return
 
-	_soul_accumulator = 0.0
-
 
 func _on_auto_play_changed(is_active: bool) -> void:
 	_is_autoplay_active = is_active
@@ -216,7 +213,6 @@ func _on_partner_ball_added(incoming_ball: Ball) -> void:
 		partner_paddle.set_ball(incoming_ball)
 
 
-## Fractional accumulation; remainder from a reduced autoplay rate carries between hits.
 func _accumulate_soul() -> void:
 	var rate: float = _progression_config.autoplay_soul_rate
 	var base_points: float = GameRules.base.soul_per_hit
@@ -224,8 +220,4 @@ func _accumulate_soul() -> void:
 	var points_to_add: float = (
 		(base_points * multiplier * rate) if _is_autoplay_active else base_points * multiplier
 	)
-	_soul_accumulator += points_to_add
-	var whole_points: int = int(_soul_accumulator)
-	if whole_points > 0:
-		_ball_manager.add_soul(whole_points)
-		_soul_accumulator -= float(whole_points)
+	_ball_manager.add_soul_fractional(points_to_add)

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -47,10 +47,10 @@ func _ready() -> void:
 	add_to_group(&"courts")
 	assert(autoplay_controller != null, "court.gd: autoplay_controller export must be assigned")
 
-	_tier_reward_handler = load("res://scripts/court/tier_reward_handler.gd").new()
+	_tier_reward_handler = TierRewardHandler.new()
 	add_child(_tier_reward_handler)
 
-	_volley_streak_tracker = load("res://scripts/court/volley_streak_tracker.gd").new()
+	_volley_streak_tracker = VolleyStreakTracker.new()
 	_volley_streak_tracker.volley_count_changed.connect(volley_count_changed.emit)
 
 	if _records == null:
@@ -141,9 +141,6 @@ func _on_ball_missed(missed_ball: Ball) -> void:
 
 	var has_ball_in_play: bool = ball_system.has_ball_in_play()
 	_volley_streak_tracker.record_miss(has_ball_in_play)
-
-	if has_ball_in_play:
-		return
 
 
 func _on_auto_play_changed(is_active: bool) -> void:

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -140,8 +140,6 @@ func _on_ball_tier_advanced(_ball: Ball, new_tier: int) -> void:
 func _on_ball_missed(missed_ball: Ball) -> void:
 	_tier_reward_handler.reset_rally(missed_ball)
 
-	# Ball._on_missed (same signal, connected first) has already flipped the missed ball to
-	# OUT_REST by the time this fires, so has_ball_in_play() reads the other balls cleanly.
 	var has_ball_in_play: bool = ball_system.has_ball_in_play()
 	_volley_streak_tracker.record_miss(has_ball_in_play)
 
@@ -149,10 +147,6 @@ func _on_ball_missed(missed_ball: Ball) -> void:
 		return
 
 	_soul_accumulator = 0.0
-
-	player_paddle.reset_streak()
-	if partner_paddle != null:
-		partner_paddle.reset_streak()
 
 
 func _on_auto_play_changed(is_active: bool) -> void:

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -138,9 +138,7 @@ func _on_ball_tier_advanced(_ball: Ball, new_tier: int) -> void:
 
 func _on_ball_missed(missed_ball: Ball) -> void:
 	_tier_reward_handler.reset_rally(missed_ball)
-
-	var has_ball_in_play: bool = ball_system.has_ball_in_play()
-	_volley_streak_tracker.record_miss(has_ball_in_play)
+	_volley_streak_tracker.record_miss(ball_system.has_ball_in_play())
 
 
 func _on_auto_play_changed(is_active: bool) -> void:

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -52,7 +52,6 @@ func _ready() -> void:
 	add_child(_tier_reward_handler)
 
 	_volley_streak_tracker = load("res://scripts/court/volley_streak_tracker.gd").new()
-	add_child(_volley_streak_tracker)
 	_volley_streak_tracker.volley_count_changed.connect(volley_count_changed.emit)
 
 	if _records == null:

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -31,7 +31,6 @@ var ball: Ball
 var player_paddle: Paddle
 var partner_paddle: PartnerPaddle
 
-var _volley_count := 0
 var _records: RecordsState
 var _partners: PartnersState
 var _progression_config: ProgressionConfig
@@ -39,6 +38,7 @@ var _ball_manager: BallManager
 var _is_autoplay_active := false
 var _soul_accumulator := 0.0
 var _tier_reward_handler: TierRewardHandler
+var _volley_streak_tracker: VolleyStreakTracker
 
 # Ball that triggered the current volley hit; available during the hit-processing window.
 var _hitting_ball: Ball
@@ -50,6 +50,10 @@ func _ready() -> void:
 
 	_tier_reward_handler = load("res://scripts/court/tier_reward_handler.gd").new()
 	add_child(_tier_reward_handler)
+
+	_volley_streak_tracker = load("res://scripts/court/volley_streak_tracker.gd").new()
+	add_child(_volley_streak_tracker)
+	_volley_streak_tracker.volley_count_changed.connect(volley_count_changed.emit)
 
 	if _records == null:
 		_records = SaveManager.records
@@ -120,14 +124,12 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func _on_paddle_hit(hitting_ball: Ball) -> void:
 	_hitting_ball = hitting_ball
-	_volley_count += 1
+	_volley_streak_tracker.record_hit()
 	_accumulate_soul()
 
-	if _volley_count > _records.personal_volley_best:
-		_records.personal_volley_best = _volley_count
+	if _volley_streak_tracker.count > _records.personal_volley_best:
+		_records.personal_volley_best = _volley_streak_tracker.count
 		personal_volley_best_changed.emit(_records.personal_volley_best)
-
-	volley_count_changed.emit(_volley_count)
 
 	_hitting_ball = null
 
@@ -139,11 +141,15 @@ func _on_ball_tier_advanced(_ball: Ball, new_tier: int) -> void:
 func _on_ball_missed(missed_ball: Ball) -> void:
 	_tier_reward_handler.reset_rally(missed_ball)
 
-	# Each ball owns its speed: it resets itself off its own `missed` signal.
-	# Court still owns the shared streak counter and resets the paddles' hit-cooldown trackers.
-	_volley_count = 0
+	# Ball._on_missed (same signal, connected first) has already flipped the missed ball to
+	# OUT_REST by the time this fires, so has_ball_in_play() reads the other balls cleanly.
+	var has_ball_in_play: bool = ball_system.has_ball_in_play()
+	_volley_streak_tracker.record_miss(has_ball_in_play)
+
+	if has_ball_in_play:
+		return
+
 	_soul_accumulator = 0.0
-	volley_count_changed.emit(_volley_count)
 
 	player_paddle.reset_streak()
 	if partner_paddle != null:

--- a/scripts/core/hit_tracker.gd
+++ b/scripts/core/hit_tracker.gd
@@ -3,7 +3,6 @@ extends Node
 
 const COOLDOWN := 0.2
 
-var streak := 0
 var _cooldown := 0.0
 
 
@@ -16,10 +15,8 @@ func try_hit() -> bool:
 	if _cooldown > 0.0:
 		return false
 	_cooldown = COOLDOWN
-	streak += 1
 	return true
 
 
 func reset() -> void:
-	streak = 0
 	_cooldown = 0.0

--- a/scripts/court/volley_streak_tracker.gd
+++ b/scripts/court/volley_streak_tracker.gd
@@ -1,5 +1,5 @@
 class_name VolleyStreakTracker
-extends Node
+extends RefCounted
 
 ## Owns the shared volley-count streak: increments on every hit, resets on a miss
 ## that leaves no ball in play.

--- a/scripts/court/volley_streak_tracker.gd
+++ b/scripts/court/volley_streak_tracker.gd
@@ -1,0 +1,24 @@
+class_name VolleyStreakTracker
+extends Node
+
+## Owns the shared volley-count streak: increments on every hit, resets on a miss
+## that leaves no ball in play.
+
+signal volley_count_changed(count: int)
+
+var count := 0
+
+
+func record_hit() -> void:
+	count += 1
+	volley_count_changed.emit(count)
+
+
+## has_ball_in_play: true when another ball is still live; the streak survives a
+## miss until the last ball in play is gone.
+func record_miss(has_ball_in_play: bool) -> void:
+	if has_ball_in_play:
+		return
+
+	count = 0
+	volley_count_changed.emit(count)

--- a/scripts/court/volley_streak_tracker.gd.uid
+++ b/scripts/court/volley_streak_tracker.gd.uid
@@ -1,0 +1,1 @@
+uid://l88hsuwt1jaj

--- a/scripts/entities/paddle.gd
+++ b/scripts/entities/paddle.gd
@@ -68,7 +68,6 @@ func on_ball_hit(ball: Ball = null) -> bool:
 	if not tracker.try_hit():
 		return false
 
-	hit_sound.pitch_scale = 1.0 + (tracker.streak * 0.05)
 	hit_sound.play()
 	paddle_hit.emit(ball)
 	return true
@@ -80,10 +79,6 @@ func _on_racket_body_entered(body: Node) -> void:
 		if _lane_x * ball.linear_velocity.x <= 0:
 			return
 		ball.hit_by_paddle(self)
-
-
-func reset_streak() -> void:
-	tracker.reset()
 
 
 func drive(velocity_y: float) -> void:

--- a/scripts/items/ball_manager.gd
+++ b/scripts/items/ball_manager.gd
@@ -22,6 +22,9 @@ var items: Array[BallDefinition] = [
 var state: BallState
 var economy: EconomyState
 
+## Fractional soul carried between hits
+var _soul_fraction := 0.0
+
 
 func _ready() -> void:
 	if state == null:
@@ -227,6 +230,16 @@ func add_soul(points: int) -> void:
 	economy.soul_balance += points
 	economy.total_soul_earned += points
 	soul_balance_changed.emit(economy.soul_balance)
+
+
+## Fractional earning path; banks the remainder so a reduced per-hit rate
+## (e.g. autoplay) doesn't lose value to truncation across hits.
+func add_soul_fractional(points: float) -> void:
+	_soul_fraction += points
+	var whole_points: int = int(_soul_fraction)
+	if whole_points > 0:
+		add_soul(whole_points)
+		_soul_fraction -= float(whole_points)
 
 
 ## Subtracts soul (clamped to zero) and emits balance changed signal.

--- a/scripts/items/ball_manager.gd
+++ b/scripts/items/ball_manager.gd
@@ -232,11 +232,12 @@ func add_soul(points: int) -> void:
 	soul_balance_changed.emit(economy.soul_balance)
 
 
-## Fractional earning path; banks the remainder so a reduced per-hit rate
-## (e.g. autoplay) doesn't lose value to truncation across hits.
+## Adds a fraction of a soul to the overall amount.
+## So that it is not truncated across hits.
 func add_soul_fractional(points: float) -> void:
 	_soul_fraction += points
 	var whole_points: int = int(_soul_fraction)
+
 	if whole_points > 0:
 		add_soul(whole_points)
 		_soul_fraction -= float(whole_points)

--- a/tests/stubs/paddle_stub.gd
+++ b/tests/stubs/paddle_stub.gd
@@ -1,9 +1,5 @@
 extends Paddle
 
 
-func reset_streak() -> void:
-	pass
-
-
 func set_ball(_ball: Ball) -> void:
 	pass

--- a/tests/unit/court/test_volley_streak_tracker.gd
+++ b/tests/unit/court/test_volley_streak_tracker.gd
@@ -1,0 +1,31 @@
+extends GutTest
+
+const VolleyStreakTrackerScript: GDScript = preload("res://scripts/court/volley_streak_tracker.gd")
+
+var _tracker: VolleyStreakTracker
+
+
+func before_each() -> void:
+	_tracker = VolleyStreakTrackerScript.new()
+
+
+func test_miss_with_ball_still_in_play_does_not_reset_streak() -> void:
+	_tracker.record_hit()
+	_tracker.record_hit()
+	watch_signals(_tracker)
+
+	_tracker.record_miss(true)
+
+	assert_eq(_tracker.count, 2, "streak survives a miss while another ball is still in play")
+	assert_signal_not_emitted(_tracker, "volley_count_changed")
+
+
+func test_miss_with_no_ball_in_play_resets_streak_to_zero() -> void:
+	_tracker.record_hit()
+	_tracker.record_hit()
+	watch_signals(_tracker)
+
+	_tracker.record_miss(false)
+
+	assert_eq(_tracker.count, 0, "the last ball leaving play resets the streak")
+	assert_signal_emitted_with_parameters(_tracker, "volley_count_changed", [0])

--- a/tests/unit/court/test_volley_streak_tracker.gd.uid
+++ b/tests/unit/court/test_volley_streak_tracker.gd.uid
@@ -1,0 +1,1 @@
+uid://cbmp700ov7jxe

--- a/tests/unit/progression/test_hit_tracker.gd
+++ b/tests/unit/progression/test_hit_tracker.gd
@@ -13,20 +13,9 @@ func test_try_hit_returns_true_when_ready() -> void:
 	assert_true(_tracker.try_hit())
 
 
-func test_try_hit_increments_streak() -> void:
-	_tracker.try_hit()
-	assert_eq(_tracker.streak, 1)
-
-
 func test_try_hit_returns_false_during_cooldown() -> void:
 	_tracker.try_hit()
 	assert_false(_tracker.try_hit())
-
-
-func test_try_hit_during_cooldown_does_not_increment_streak() -> void:
-	_tracker.try_hit()
-	_tracker.try_hit()
-	assert_eq(_tracker.streak, 1)
 
 
 func test_try_hit_allowed_after_cooldown_expires() -> void:
@@ -35,20 +24,7 @@ func test_try_hit_allowed_after_cooldown_expires() -> void:
 	assert_true(_tracker.try_hit())
 
 
-func test_streak_increments_after_cooldown_expires() -> void:
-	_tracker.try_hit()
-	_tracker._process(HitTracker.COOLDOWN)
-	_tracker.try_hit()
-	assert_eq(_tracker.streak, 2)
-
-
 # --- reset ---
-func test_reset_clears_streak() -> void:
-	_tracker.try_hit()
-	_tracker.reset()
-	assert_eq(_tracker.streak, 0)
-
-
 func test_hit_allowed_immediately_after_reset() -> void:
 	_tracker.try_hit()
 	_tracker.reset()

--- a/tests/unit/progression/test_soul.gd
+++ b/tests/unit/progression/test_soul.gd
@@ -26,7 +26,7 @@ func before_each() -> void:
 	var progression_config: ProgressionConfig = ProgressionConfig.new()
 	progression_config.autoplay_soul_rate = 0.5
 
-	_game = load("res://scripts/core/court.gd").new()
+	_game = Court.new()
 	_game.ball = _ball_stub
 	_game.player_paddle = _paddle_stub
 	_game.autoplay_controller = _autoplay_controller_stub
@@ -90,18 +90,9 @@ func test_soul_fractional_remainder_carries_over_between_autoplay_hits() -> void
 	assert_eq(_last_soul_balance, 2)
 
 
-func test_soul_accumulator_carries_over_when_autoplay_ends() -> void:
+func test_soul_fraction_carries_over_when_autoplay_ends() -> void:
 	_autoplay_controller_stub.autoplay_toggled.emit(true)
 	_hit()
-	_autoplay_controller_stub.autoplay_toggled.emit(false)
-	_hit()
-	assert_eq(_last_soul_balance, 1)
-
-
-func test_soul_accumulator_carries_over_a_miss() -> void:
-	_autoplay_controller_stub.autoplay_toggled.emit(true)
-	_hit()
-	_ball_stub.missed.emit(_ball_stub)
 	_autoplay_controller_stub.autoplay_toggled.emit(false)
 	_hit()
 	assert_eq(_last_soul_balance, 1)

--- a/tests/unit/progression/test_soul.gd
+++ b/tests/unit/progression/test_soul.gd
@@ -98,7 +98,7 @@ func test_soul_accumulator_carries_over_when_autoplay_ends() -> void:
 	assert_eq(_last_soul_balance, 1)
 
 
-func test_soul_accumulator_resets_on_miss() -> void:
+func test_soul_accumulator_carries_over_a_miss() -> void:
 	_autoplay_controller_stub.autoplay_toggled.emit(true)
 	_hit()
 	_ball_stub.missed.emit(_ball_stub)


### PR DESCRIPTION
Court zeroed the shared volley streak on any single ball miss, even when another ball was still live in a multi-ball rally; the reset now only fires once BallReconciler.has_ball_in_play() reports no ball remains in play. Also extracts the streak's increment/reset bookkeeping out of Court into a new VolleyStreakTracker (scripts/court/volley_streak_tracker.gd), following the existing TierRewardHandler delegation pattern, so Court just wires signals rather than owning the counter state directly.

Closes SH-574