### PR TITLE
fix: load ball items at runtime, not parse time, in BallManager

### DIFF
--- a/resources/items/comeback_ball.tres
+++ b/resources/items/comeback_ball.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="BallDefinition" format=3]
+[gd_resource type="Resource" script_class="BallDefinition" format=3 uid="uid://dhjqg6wrksome"]
 
 [ext_resource type="Script" uid="uid://257uwvphb3uc" path="res://scripts/items/ball_definition.gd" id="1_item"]
 [ext_resource type="PackedScene" uid="uid://cqh0hj8f44vbl" path="res://scenes/balls/comeback_ball.tscn" id="2_scene"]

--- a/scripts/items/ball_manager.gd
+++ b/scripts/items/ball_manager.gd
@@ -10,14 +10,17 @@ signal rack_slots_changed
 ## Emitted after every rack-state mutation so consumers derive from one signal.
 signal ball_manager_state_changed
 
-var items: Array[BallDefinition] = [
-	preload("res://resources/items/old_ball.tres"),
-	preload("res://resources/items/standard_ball.tres"),
-	preload("res://resources/items/cadence_ball.tres"),
-	preload("res://resources/items/goop_ball.tres"),
-	preload("res://resources/items/cheater_ball.tres"),
-	preload("res://resources/items/comeback_ball.tres")
+const _ITEM_PATHS: Array[String] = [
+	"res://resources/items/old_ball.tres",
+	"res://resources/items/standard_ball.tres",
+	"res://resources/items/cadence_ball.tres",
+	"res://resources/items/goop_ball.tres",
+	"res://resources/items/cheater_ball.tres",
+	"res://resources/items/comeback_ball.tres",
 ]
+
+## Populated in _ready via load() rather than a preload initializer, avoiding a parse-time cycle the web export can't tolerate.
+var items: Array[BallDefinition] = []
 
 var state: BallState
 var economy: EconomyState
@@ -27,6 +30,9 @@ var _soul_fraction := 0.0
 
 
 func _ready() -> void:
+	for path in _ITEM_PATHS:
+		items.append(load(path))
+
 	if state == null:
 		state = SaveManager.items
 


### PR DESCRIPTION
Root cause: BallManager preloaded all six ball .tres files in its `items` array initializer, a parse-time reference. goop_ball.tres and comeback_ball.tres pull in scenes whose scripts hold typed `BallReconciler` references, so compiling ball_reconciler.gd needs to resolve members on BallManager while BallManager is itself still mid-load, a cycle desktop tolerates but the web export's cyclic-load path does not (returns null, ball_reconciler.gd fails to compile with "Could not resolve external class member", court.gd's `BallReconciler.new()` fails, no reconciler exists, and rack drag is dead in the web build only).

Fix: populate `items` via `load()` in `_ready` instead of a preload initializer; autoloads finish `_ready` before any scene node's `_ready`, so this is safe. Also gives comeback_ball.tres a resource `uid`, the one .tres in this set that was missing one, per #1209.