### PR TITLE
fix: load progression resources at runtime, not parse time, in ProgressionManager

### DIFF
--- a/scripts/progression/progression_manager.gd
+++ b/scripts/progression/progression_manager.gd
@@ -9,11 +9,14 @@ signal partner_recruited(partner_key: StringName)
 # preload workaround for autoload class_name ordering (godotengine/godot#75582)
 @warning_ignore("shadowed_global_identifier")
 const PartnerDefinition = preload("res://scripts/partners/partner_definition.gd")
-const DEFAULT_CONFIG: ProgressionConfig = preload("res://resources/progression_config.tres")
 
-var partners_roster: Array[PartnerDefinition] = [
-	preload("res://resources/partners/martha.tres"),
+const _CONFIG_PATH := "res://resources/progression_config.tres"
+const _PARTNER_PATHS: Array[String] = [
+	"res://resources/partners/martha.tres",
 ]
+
+## Populated in _ready via load() rather than a preload initializer, avoiding a parse-time cycle the web export can't tolerate.
+var partners_roster: Array[PartnerDefinition] = []
 
 var economy: EconomyState
 var records: RecordsState
@@ -26,6 +29,9 @@ var _save_manager: SaveManager
 
 
 func _ready() -> void:
+	for path in _PARTNER_PATHS:
+		partners_roster.append(load(path))
+
 	if _save_manager == null:
 		_save_manager = SaveManager
 
@@ -42,7 +48,7 @@ func _ready() -> void:
 		partners = _save_manager.partners
 
 	if _config == null:
-		_config = DEFAULT_CONFIG
+		_config = load(_CONFIG_PATH)
 
 	if _ball_manager == null:
 		_ball_manager = BallManager


### PR DESCRIPTION
SH-589's rack-drag breakage came from an autoload pulling .tres resources in at parse time; #1210 fixed BallManager. ProgressionManager carries the identical latent shape: a const preload of the progression config and a preload-initialized partner roster. This converts both to load() at ready before any consumer can read them. Preventive only; no live failure exists today, so no web-build verification beyond a clean compile. The PartnerDefinition script preload stays, as it is the documented workaround for autoload class_name ordering (godotengine/godot#75582).

Closes #1211