### PR TITLE
fix: give each swing animation its own anticipation contact timing

### DIFF
--- a/scenes/player_paddle.tscn
+++ b/scenes/player_paddle.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="Script" uid="uid://dfc28jj4bws1v" path="res://scripts/entities/racket_hitbox.gd" id="12_rckthbx"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_k7j1o"]
-size = Vector2(21, 94.325)
+size = Vector2(21, 128.1225)
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_qaqj4"]
 radius = 110.89
@@ -28,13 +28,13 @@ metadata/_edit_group_ = true
 [node name="Sprite" type="AnimatedSprite2D" parent="." unique_id=955212656]
 scale = Vector2(0.245, 0.245)
 sprite_frames = ExtResource("4_samframes")
-animation = &"swing_grounded_low"
+animation = &"swing_grounded"
 
 [node name="LowRacketAnchor" type="Marker2D" parent="." unique_id=2002814800]
-position = Vector2(8, 59.29)
+position = Vector2(-20, 59.29)
 
 [node name="MidRacketAnchor" type="Marker2D" parent="." unique_id=1540538403]
-position = Vector2(-20, 50.58)
+position = Vector2(-20, 8.580002)
 
 [node name="HitSound" type="AudioStreamPlayer" parent="." unique_id=804052244]
 stream = ExtResource("2_sfxr")
@@ -52,6 +52,7 @@ script = ExtResource("12_rckthbx")
 collision = NodePath("RacketCollision")
 
 [node name="RacketCollision" type="CollisionShape2D" parent="RacketHitbox" unique_id=1404787416]
+position = Vector2(0, 0.101249695)
 shape = SubResource("RectangleShape2D_k7j1o")
 
 [node name="SwingZone" type="Area2D" parent="." unique_id=-1077560471]

--- a/scenes/player_paddle.tscn
+++ b/scenes/player_paddle.tscn
@@ -13,9 +13,10 @@ size = Vector2(21, 94.325)
 [sub_resource type="CircleShape2D" id="CircleShape2D_qaqj4"]
 radius = 110.89
 
-[node name="PlayerPaddle" type="CharacterBody2D" unique_id=1437655624 node_paths=PackedStringArray("low_anchor", "hit_sound", "sprite", "tracker", "racket_hitbox", "swing_zone", "ground_ray")]
+[node name="PlayerPaddle" type="CharacterBody2D" unique_id=1437655624 node_paths=PackedStringArray("low_anchor", "mid_anchor", "hit_sound", "sprite", "tracker", "racket_hitbox", "swing_zone", "ground_ray")]
 script = ExtResource("1_mo4dg")
 low_anchor = NodePath("LowRacketAnchor")
+mid_anchor = NodePath("MidRacketAnchor")
 hit_sound = NodePath("HitSound")
 sprite = NodePath("Sprite")
 tracker = NodePath("HitTracker")
@@ -25,13 +26,15 @@ ground_ray = NodePath("GroundRay")
 metadata/_edit_group_ = true
 
 [node name="Sprite" type="AnimatedSprite2D" parent="." unique_id=955212656]
-position = Vector2(0, -47)
 scale = Vector2(0.245, 0.245)
 sprite_frames = ExtResource("4_samframes")
-animation = &"swing_grounded"
+animation = &"swing_grounded_low"
 
 [node name="LowRacketAnchor" type="Marker2D" parent="." unique_id=2002814800]
 position = Vector2(8, 59.29)
+
+[node name="MidRacketAnchor" type="Marker2D" parent="." unique_id=1540538403]
+position = Vector2(-20, 50.58)
 
 [node name="HitSound" type="AudioStreamPlayer" parent="." unique_id=804052244]
 stream = ExtResource("2_sfxr")
@@ -62,7 +65,7 @@ position = Vector2(-88, 0)
 shape = SubResource("CircleShape2D_qaqj4")
 
 [node name="GroundRay" type="RayCast2D" parent="." unique_id=394874363]
-position = Vector2(-48, 96)
+position = Vector2(-48, 115)
 target_position = Vector2(0, 10)
 
 [node name="HoverBob" type="Node" parent="." unique_id=519261022 node_paths=PackedStringArray("sprite")]

--- a/scenes/player_paddle.tscn
+++ b/scenes/player_paddle.tscn
@@ -25,9 +25,10 @@ ground_ray = NodePath("GroundRay")
 metadata/_edit_group_ = true
 
 [node name="Sprite" type="AnimatedSprite2D" parent="." unique_id=955212656]
+position = Vector2(0, -47)
 scale = Vector2(0.245, 0.245)
 sprite_frames = ExtResource("4_samframes")
-animation = &"swing_grounded_low"
+animation = &"swing_grounded"
 
 [node name="LowRacketAnchor" type="Marker2D" parent="." unique_id=2002814800]
 position = Vector2(8, 59.29)

--- a/scripts/core/paddle_animation_controller.gd
+++ b/scripts/core/paddle_animation_controller.gd
@@ -5,9 +5,16 @@ signal state_changed(state: StringName)
 
 const PaddleSwingMathScript: GDScript = preload("res://scripts/core/paddle_swing_math.gd")
 
-## Contact frame and fps of the 5fps swing animations in resources/animations/sam.tres.
-const SWING_CONTACT_FRAME_INDEX: int = 3
-const SWING_ANIMATION_BASE_FPS: float = 5.0
+## Per-swing-animation contact timing, from resources/animations/sam.tres. `contact_frames` is
+## how many frame-durations (at `base_fps`) elapse before the contact moment: for a multi-frame
+## swing that's its contact frame's index (time to reach it); for swing_grounded_low, whose single
+## frame IS the contact frame from the first tick, it's 1 (that frame's own duration), so the
+## frame stretches to hold until contact instead of computing a zero-length wait.
+const SWING_TIMING_BY_STATE: Dictionary[StringName, Dictionary] = {
+	&"swing_flying": {"contact_frames": 3, "base_fps": 5.0},
+	&"swing_grounded": {"contact_frames": 2, "base_fps": 5.0},
+	&"swing_grounded_low": {"contact_frames": 1, "base_fps": 2.0},
+}
 
 ## Physical ceiling on swing playback speed; not a designer tunable.
 const MAX_SWING_SPEED_SCALE: float = 3.0
@@ -40,7 +47,11 @@ func start_swing(grounded: bool, crouching: bool = false) -> void:
 ## Playback speed so the swing's contact frame lands when the ball reaches `racket_position`, or
 ## -1.0 if a swing is already pending or the ball's contact time can't be determined.
 func compute_zone_entry_speed_scale(
-	ball_position: Vector2, ball_velocity: Vector2, racket_position: Vector2
+	ball_position: Vector2,
+	ball_velocity: Vector2,
+	racket_position: Vector2,
+	grounded: bool,
+	crouching: bool = false,
 ) -> float:
 	if is_swing_pending():
 		return -1.0
@@ -51,8 +62,13 @@ func compute_zone_entry_speed_scale(
 	if contact_time < 0.0:
 		return -1.0
 
+	var swing_state: StringName = PaddleAnimationStateMachine.resolve_swing_state(
+		grounded, crouching
+	)
+	var timing: Dictionary = SWING_TIMING_BY_STATE[swing_state]
+
 	return PaddleSwingMathScript.speed_scale_for_contact_time(
-		contact_time, SWING_CONTACT_FRAME_INDEX, SWING_ANIMATION_BASE_FPS, MAX_SWING_SPEED_SCALE
+		contact_time, timing["contact_frames"], timing["base_fps"], MAX_SWING_SPEED_SCALE
 	)
 
 

--- a/scripts/core/paddle_animation_controller.gd
+++ b/scripts/core/paddle_animation_controller.gd
@@ -5,14 +5,10 @@ signal state_changed(state: StringName)
 
 const PaddleSwingMathScript: GDScript = preload("res://scripts/core/paddle_swing_math.gd")
 
-## Per-swing-animation contact timing, from resources/animations/sam.tres. `contact_frames` is
-## how many frame-durations (at `base_fps`) elapse before the contact moment: for a multi-frame
-## swing that's its contact frame's index (time to reach it); for swing_grounded_low, whose single
-## frame IS the contact frame from the first tick, it's 1 (that frame's own duration), so the
-## frame stretches to hold until contact instead of computing a zero-length wait.
+## Per-swing-animation contact frame count and fps, from resources/animations/sam.tres.
 const SWING_TIMING_BY_STATE: Dictionary[StringName, Dictionary] = {
 	&"swing_flying": {"contact_frames": 3, "base_fps": 5.0},
-	&"swing_grounded": {"contact_frames": 2, "base_fps": 5.0},
+	&"swing_grounded": {"contact_frames": 1, "base_fps": 5.0},
 	&"swing_grounded_low": {"contact_frames": 1, "base_fps": 2.0},
 }
 

--- a/scripts/core/paddle_animation_state_machine.gd
+++ b/scripts/core/paddle_animation_state_machine.gd
@@ -52,9 +52,7 @@ static func _resolve_state(
 	grounded: bool, vertical_motion: float, swing_pending: bool, crouching: bool = false
 ) -> StringName:
 	if swing_pending:
-		if grounded:
-			return &"swing_grounded_low" if crouching else &"swing_grounded"
-		return &"swing_flying"
+		return resolve_swing_state(grounded, crouching)
 
 	if grounded:
 		return &"ready_grounded_low" if crouching else &"ready_grounded"
@@ -63,3 +61,12 @@ static func _resolve_state(
 		return &"flying_up" if vertical_motion < 0.0 else &"flying_down"
 
 	return &"ready_flying"
+
+
+## The swing state a pending swing resolves to for `grounded`/`crouching`, independent of whether
+## a swing is currently pending; lets a caller look up per-state config (e.g. anticipation timing)
+## before actually starting one.
+static func resolve_swing_state(grounded: bool, crouching: bool = false) -> StringName:
+	if grounded:
+		return &"swing_grounded_low" if crouching else &"swing_grounded"
+	return &"swing_flying"

--- a/scripts/entities/paddle.gd
+++ b/scripts/entities/paddle.gd
@@ -169,8 +169,15 @@ func _on_swing_zone_entered(body: Node) -> void:
 	if _lane_x * ball.linear_velocity.x <= 0:
 		return
 
-	var speed_scale: float = _animation_controller.compute_zone_entry_speed_scale(
-		ball.global_position, ball.linear_velocity, racket_hitbox.global_position
+	var speed_scale: float = (
+		_animation_controller
+		. compute_zone_entry_speed_scale(
+			ball.global_position,
+			ball.linear_velocity,
+			racket_hitbox.global_position,
+			is_grounded(),
+			_is_crouching(),
+		)
 	)
 	if speed_scale < 0.0:
 		return

--- a/scripts/entities/player_paddle.gd
+++ b/scripts/entities/player_paddle.gd
@@ -4,8 +4,12 @@ extends Paddle
 ## Racket position while grounded-low; swapped in for crouch/low-hit animation states.
 @export var low_anchor: Marker2D
 
+## Racket position while grounded, upright; swapped in for the standing ready/swing animations.
+@export var mid_anchor: Marker2D
+
 var _default_racket_position: Vector2
 var _low_states := [&"ready_grounded_low", &"swing_grounded_low"]
+var _mid_states := [&"ready_grounded", &"swing_grounded"]
 
 
 func _ready() -> void:
@@ -32,6 +36,8 @@ func _on_animation_state_changed(state: StringName) -> void:
 
 	if state in _low_states:
 		racket_hitbox.position = low_anchor.position
+	elif state in _mid_states:
+		racket_hitbox.position = mid_anchor.position
 	else:
 		racket_hitbox.position = _default_racket_position
 

--- a/tests/unit/paddle/paddle_animation_controller/test_anticipation.gd
+++ b/tests/unit/paddle/paddle_animation_controller/test_anticipation.gd
@@ -10,8 +10,9 @@ func before_each() -> void:
 
 
 func test_zone_entry_speed_scale_matches_the_ball_actual_contact_time() -> void:
+	# Flying swing: contact_frames=3 at base_fps=5.0 -> 0.6s natural, matching this contact_time.
 	var speed_scale: float = _controller.compute_zone_entry_speed_scale(
-		Vector2(-580.0, 0.0), Vector2(-200.0, 0.0), Vector2(-700.0, 0.0)
+		Vector2(-580.0, 0.0), Vector2(-200.0, 0.0), Vector2(-700.0, 0.0), false
 	)
 
 	assert_almost_eq(speed_scale, 1.0, 0.001)
@@ -19,7 +20,7 @@ func test_zone_entry_speed_scale_matches_the_ball_actual_contact_time() -> void:
 
 func test_zone_entry_speed_scale_is_negative_for_a_stationary_ball() -> void:
 	var speed_scale: float = _controller.compute_zone_entry_speed_scale(
-		Vector2(-580.0, 0.0), Vector2(0.5, 0.0), Vector2(-700.0, 0.0)
+		Vector2(-580.0, 0.0), Vector2(0.5, 0.0), Vector2(-700.0, 0.0), false
 	)
 
 	assert_lt(speed_scale, 0.0)
@@ -29,10 +30,19 @@ func test_zone_entry_speed_scale_is_negative_while_a_swing_is_already_pending() 
 	_controller.start_swing(true)
 
 	var speed_scale: float = _controller.compute_zone_entry_speed_scale(
-		Vector2(-580.0, 0.0), Vector2(-200.0, 0.0), Vector2(-700.0, 0.0)
+		Vector2(-580.0, 0.0), Vector2(-200.0, 0.0), Vector2(-700.0, 0.0), true
 	)
 
 	assert_lt(speed_scale, 0.0)
+
+
+func test_zone_entry_speed_scale_for_low_swing_stretches_its_one_frame_to_contact_time() -> void:
+	# Crouching (swing_grounded_low): contact_frames=1 at base_fps=2.0 -> 0.5s natural.
+	var speed_scale: float = _controller.compute_zone_entry_speed_scale(
+		Vector2(-590.0, 0.0), Vector2(-20.0, 0.0), Vector2(-600.0, 0.0), true, true
+	)
+
+	assert_almost_eq(speed_scale, 1.0, 0.001)
 
 
 func test_state_changed_forwards_the_state_machines_signal() -> void:

--- a/tests/unit/paddle/test_paddle_animation_state_machine.gd
+++ b/tests/unit/paddle/test_paddle_animation_state_machine.gd
@@ -91,3 +91,19 @@ func test_grounded_swing_cancels_when_the_paddle_leaves_the_ground() -> void:
 
 	assert_eq(_machine.get_state(), &"flying_up")
 	assert_false(_machine.is_swing_pending())
+
+
+func test_swing_grounded_low_animation_fires_when_hit_while_crouching() -> void:
+	_machine.start_swing(true, 0.0, true)
+	assert_eq(_machine.get_state(), &"swing_grounded_low")
+
+
+func test_resolve_swing_state_matches_grounded_crouching_combinations() -> void:
+	assert_eq(PaddleAnimationStateMachine.resolve_swing_state(true, false), &"swing_grounded")
+	assert_eq(PaddleAnimationStateMachine.resolve_swing_state(true, true), &"swing_grounded_low")
+	assert_eq(PaddleAnimationStateMachine.resolve_swing_state(false, false), &"swing_flying")
+	assert_eq(
+		PaddleAnimationStateMachine.resolve_swing_state(false, true),
+		&"swing_flying",
+		"airborne always resolves to the flying swing regardless of crouch input",
+	)


### PR DESCRIPTION
swing_grounded_low has one frame, unlike the other two swings' three.

Signed-off-by: Josh <josh@shuck.gg>