### PR TITLE
feat: consolidation soul burst payout

### DIFF
--- a/resources/speed_tier_table.tres
+++ b/resources/speed_tier_table.tres
@@ -14,14 +14,12 @@ script = ExtResource("2_tier")
 key = &"tier_one"
 floor_fraction = 0.47
 ceiling_fraction = 0.72
-reward = "tier_one_final"
 
 [sub_resource type="Resource" id="Tier2"]
 script = ExtResource("2_tier")
 key = &"top_tier"
 floor_fraction = 0.65
 ceiling_fraction = 1.0
-reward = "top_tier_final"
 
 [resource]
 script = ExtResource("1_table")

--- a/scripts/core/base_ball_stats.gd
+++ b/scripts/core/base_ball_stats.gd
@@ -3,9 +3,12 @@ extends Resource
 
 ## Slowest a ball ever travels; reset target on miss-to-rest and rally start.
 @export var ball_speed_min := 450.0
+
 ## Fastest a ball may travel.
 @export var ball_speed_max := 790.0
+
 ## Speed bump applied to the ball on each successful paddle hit.
 @export var ball_speed_increment := 17.0
-## Soul awarded per paddle hit; items can percentage-modify.
-@export var soul_per_hit := 1.0
+
+## Scales the consolidation reward
+@export var consolidation_multiplier := 1.0

--- a/scripts/core/base_ball_stats.gd
+++ b/scripts/core/base_ball_stats.gd
@@ -10,5 +10,5 @@ extends Resource
 ## Speed bump applied to the ball on each successful paddle hit.
 @export var ball_speed_increment := 17.0
 
-## Scales the consolidation reward
+## Scales the consolidation reward.
 @export var consolidation_multiplier := 1.0

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -4,7 +4,7 @@ extends Node2D
 signal volley_count_changed(count: int)
 signal personal_volley_best_changed(best: int)
 signal ball_tier_advanced(new_tier: int)
-signal auto_play_changed(is_active: bool, soul_rate: float)
+signal auto_play_changed(is_active: bool)
 signal partner_changed
 
 ## Apex ceiling in pixels above the soul bound; passed to every ball this court spawns.
@@ -31,9 +31,6 @@ var partner_paddle: PartnerPaddle
 
 var _records: RecordsState
 var _partners: PartnersState
-var _progression_config: ProgressionConfig
-var _ball_manager: BallManager
-var _is_autoplay_active := false
 var _tier_reward_handler: TierRewardHandler
 var _volley_streak_tracker: VolleyStreakTracker
 
@@ -53,12 +50,6 @@ func _ready() -> void:
 
 	if _partners == null:
 		_partners = SaveManager.partners
-
-	if _progression_config == null:
-		_progression_config = ProgressionManager.get_config()
-
-	if _ball_manager == null:
-		_ball_manager = BallManager
 
 	if player_paddle == null:
 		player_paddle = player_paddle_scene.instantiate()
@@ -98,7 +89,6 @@ func _unhandled_input(event: InputEvent) -> void:
 func _on_paddle_hit(hitting_ball: Ball) -> void:
 	_hitting_ball = hitting_ball
 	_volley_streak_tracker.record_hit()
-	_accumulate_soul()
 
 	if _volley_streak_tracker.count > _records.personal_volley_best:
 		_records.personal_volley_best = _volley_streak_tracker.count
@@ -116,8 +106,7 @@ func _on_ball_missed(_missed_ball: Ball) -> void:
 
 
 func _on_auto_play_changed(is_active: bool) -> void:
-	_is_autoplay_active = is_active
-	auto_play_changed.emit(is_active, _progression_config.autoplay_soul_rate)
+	auto_play_changed.emit(is_active)
 
 
 func _on_partner_recruited(_partner_key: StringName) -> void:
@@ -172,13 +161,3 @@ func _on_partner_ball_added(incoming_ball: Ball) -> void:
 
 	if partner_paddle.has_method("set_ball"):
 		partner_paddle.set_ball(incoming_ball)
-
-
-func _accumulate_soul() -> void:
-	var rate: float = _progression_config.autoplay_soul_rate
-	var base_points: float = GameRules.base.soul_per_hit
-	var multiplier: float = _hitting_ball.soul_multiplier if _hitting_ball != null else 1.0
-	var points_to_add: float = (
-		(base_points * multiplier * rate) if _is_autoplay_active else base_points * multiplier
-	)
-	_ball_manager.add_soul_fractional(points_to_add)

--- a/scripts/core/court.gd
+++ b/scripts/core/court.gd
@@ -34,9 +34,6 @@ var _partners: PartnersState
 var _tier_reward_handler: TierRewardHandler
 var _volley_streak_tracker: VolleyStreakTracker
 
-# Ball that triggered the current volley hit; available during the hit-processing window.
-var _hitting_ball: Ball
-
 
 func _ready() -> void:
 	_tier_reward_handler = TierRewardHandler.new()
@@ -86,15 +83,12 @@ func _unhandled_input(event: InputEvent) -> void:
 		autoplay_controller.toggle()
 
 
-func _on_paddle_hit(hitting_ball: Ball) -> void:
-	_hitting_ball = hitting_ball
+func _on_paddle_hit(_hitting_ball: Ball) -> void:
 	_volley_streak_tracker.record_hit()
 
 	if _volley_streak_tracker.count > _records.personal_volley_best:
 		_records.personal_volley_best = _volley_streak_tracker.count
 		personal_volley_best_changed.emit(_records.personal_volley_best)
-
-	_hitting_ball = null
 
 
 func _on_ball_tier_advanced(_ball: Ball, new_tier: int) -> void:

--- a/scripts/core/speed_tier.gd
+++ b/scripts/core/speed_tier.gd
@@ -9,5 +9,3 @@ extends Resource
 @export_range(0.0, 1.0) var floor_fraction := 0.0
 ## Tier ceiling speed as a fraction of BALL_WORLD_MAX_SPEED; crossing it completes the tier.
 @export_range(0.0, 1.0) var ceiling_fraction := 0.0
-## Reward key fired on tier completion; empty means no reward.
-@export var reward := ""

--- a/scripts/court/auto_indicator.gd
+++ b/scripts/court/auto_indicator.gd
@@ -8,7 +8,7 @@ func _ready() -> void:
 	court.auto_play_changed.connect(_on_auto_play_changed)
 
 
-func _on_auto_play_changed(is_active: bool, soul_rate: float) -> void:
+func _on_auto_play_changed(is_active: bool) -> void:
 	visible = is_active
 	if is_active:
-		text = "AUTO (%.0f%% Soul)" % (soul_rate * 100)
+		text = "AUTO"

--- a/scripts/court/tier_reward_handler.gd
+++ b/scripts/court/tier_reward_handler.gd
@@ -3,17 +3,20 @@ extends Node
 
 ## Handles the consolidation reward on every tier-up.
 
-## Fired after the tier-up is processed so Court can read the updated soul_multiplier.
-signal consolidation_fired
+## Soul payout
+signal consolidated(ball: Ball)
 
 
-func _ready() -> void:
-	add_to_group(&"tier_reward_handlers")
-
-
-## Pays the consolidation reward for whichever ball crossed a tier; driven by BallTracker.ball_tier_advanced.
+## Pays the consolidation reward for whichever ball crossed a tier.
 func on_tier_advanced(ball: Ball, _new_tier: int) -> void:
-	if ball != null:
-		ball.increment_soul_multiplier(1.0)
+	if ball == null:
+		return
 
-	consolidation_fired.emit()
+	ball.increment_soul_multiplier(1.0)
+
+	var payout := roundi(ball.accumulated_soul * ball.get_stats().consolidation_multiplier)
+
+	BallManager.add_soul(payout)
+	ball.reset_accumulated_soul()
+
+	consolidated.emit(ball)

--- a/scripts/court/tier_reward_handler.gd
+++ b/scripts/court/tier_reward_handler.gd
@@ -3,9 +3,6 @@ extends Node
 
 ## Handles the consolidation reward on every tier-up.
 
-## Soul payout
-signal consolidated(ball: Ball)
-
 
 ## Pays the consolidation reward for whichever ball crossed a tier.
 func on_tier_advanced(ball: Ball, _new_tier: int) -> void:
@@ -18,5 +15,3 @@ func on_tier_advanced(ball: Ball, _new_tier: int) -> void:
 
 	BallManager.add_soul(payout)
 	ball.reset_accumulated_soul()
-
-	consolidated.emit(ball)

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -291,16 +291,14 @@ func increase_speed() -> void:
 	_apply_speed()
 
 
-# Crossing a tier ceiling advances to the next, plateaus at max tier.
+# Crossing a tier ceiling advances to the next tier, or repeats the top tier's range.
 func advance_tier() -> void:
 	var is_top_tier: bool = current_tier >= get_speed_tiers().tier_count() - 1
 
-	if is_top_tier:
-		speed = tier_ceiling
-	else:
+	if not is_top_tier:
 		current_tier += 1
-		speed = tier_floor
 
+	speed = tier_floor
 	_apply_speed()
 
 	tier_advanced.emit(self, current_tier)

--- a/scripts/entities/ball/ball.gd
+++ b/scripts/entities/ball/ball.gd
@@ -55,6 +55,9 @@ var current_tier := 0
 ## Accumulated soul multiplier for this ball; incremented by each consolidation event, reset on miss.
 var soul_multiplier: float = 1.0
 
+## Soul counter for this ball, released on consolidation, reset on miss.
+var accumulated_soul: float = 0.0
+
 ## Entry speed of the current tier, derived from the table fraction of the world max.
 var tier_floor: float:
 	get:
@@ -177,6 +180,7 @@ func hit_by_paddle(paddle: Paddle) -> void:
 	var hit_registered: bool = paddle.on_ball_hit(self)
 	if hit_registered:
 		increase_speed()
+		accumulated_soul += soul_multiplier
 	_process_hit(paddle)
 
 
@@ -194,6 +198,7 @@ func _on_miss_zone_body_entered(body: Node) -> void:
 
 func _on_missed(_ball: Ball) -> void:
 	reset_soul_multiplier()
+	reset_accumulated_soul()
 	enter_out_rest()
 
 
@@ -205,6 +210,11 @@ func reset_soul_multiplier() -> void:
 ## Adds amount to this ball's soul multiplier.
 func increment_soul_multiplier(amount: float) -> void:
 	soul_multiplier += amount
+
+
+## Resets accumulated soul count to zero.
+func reset_accumulated_soul() -> void:
+	accumulated_soul = 0.0
 
 
 # Single funnel for play_state writes. Idempotent: a same-state call is a no-op.

--- a/scripts/entities/ball/comeback_ball.gd
+++ b/scripts/entities/ball/comeback_ball.gd
@@ -99,8 +99,8 @@ func _rescue_sweep_sign() -> float:
 	if paddle_position == null:
 		return 1.0
 
-	var sign: float = signf(global_position.y - paddle_position.y)
-	return sign if sign != 0.0 else 1.0
+	var sweep_sign: float = signf(global_position.y - paddle_position.y)
+	return sweep_sign if sweep_sign != 0.0 else 1.0
 
 
 func rescuing(delta: float) -> void:

--- a/scripts/items/ball_manager.gd
+++ b/scripts/items/ball_manager.gd
@@ -24,8 +24,6 @@ var items: Array[BallDefinition] = []
 var economy: EconomyState
 
 var _state: BallState
-## Fractional soul carried between hits
-var _soul_fraction := 0.0
 
 
 func _ready() -> void:
@@ -287,17 +285,6 @@ func add_soul(points: int) -> void:
 	economy.soul_balance += points
 	economy.total_soul_earned += points
 	soul_balance_changed.emit(economy.soul_balance)
-
-
-## Adds a fraction of a soul to the overall amount.
-## So that it is not truncated across hits.
-func add_soul_fractional(points: float) -> void:
-	_soul_fraction += points
-	var whole_points: int = int(_soul_fraction)
-
-	if whole_points > 0:
-		add_soul(whole_points)
-		_soul_fraction -= float(whole_points)
 
 
 ## Subtracts soul (clamped to zero) and emits balance changed signal.

--- a/scripts/items/kit_slot.gd
+++ b/scripts/items/kit_slot.gd
@@ -59,8 +59,8 @@ func get_displayed_key() -> String:
 
 
 ## Hides the icon while the ball is held elsewhere; the slot still reports itself as the occupant.
-func set_icon_hidden(hidden: bool) -> void:
-	_icon_hidden = hidden
+func set_icon_hidden(hid: bool) -> void:
+	_icon_hidden = hid
 	_apply_icon()
 
 

--- a/scripts/progression/progression_config.gd
+++ b/scripts/progression/progression_config.gd
@@ -2,5 +2,3 @@ class_name ProgressionConfig
 extends Resource
 
 @export var shop_unlock_threshold: int = 50
-## Soul earned per hit during autoplay, as a fraction of the active play rate.
-@export var autoplay_soul_rate: float = 0.5


### PR DESCRIPTION
Soul is now released as one burst instead of from each hit.
On miss, accumulated soul is discarded

Fixed final speed tiering so that hitting the ceiling now repeats that tier's range and keeps consolidating each lap, rather than plateauing silently after the first consolidation. Previously the ball would stall at max speed with no further reward once it maxed out.

Removed the now-dead SpeedTier.reward field (never read anywhere), the unused tier_reward_handlers group, and the autoplay soul-rate discount, since payout no longer happens per hit, autoplay no longer needs its own rate.

Closes SH-536.