### PR TITLE
ci: push the web build on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,11 @@ jobs:
           unzip butler.zip
           chmod +x butler
 
+      - name: Push Web to Itch.io
+        run: ./butler push "${{ steps.export.outputs.build_directory }}/WebThreaded" ${{ env.ITCH_PROJECT }}:web --userversion ${{ github.event.release.tag_name }}
+        env:
+          BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+
       - name: Push Linux to Itch.io
         run: ./butler push "${{ steps.export.outputs.build_directory }}/Linux" ${{ env.ITCH_PROJECT }}:linux --userversion ${{ github.event.release.tag_name }}
         env:


### PR DESCRIPTION
The live release pushed Linux, Windows and macOS but no web build, so the browser embed on the itch page has been serving an April build while every desktop channel stayed current. Production moved off web in #185, which removed the push and never restored it once the desktop channels were added.

The release now pushes the `WebThreaded` export to a `web` channel. The old live web channel is named `html5-preview`, a leftover from when production was the preview, updated to web.