### PR TITLE
Fix autoplay low-ball crouching

### DIFF
--- a/scripts/core/autoplay_controller.gd
+++ b/scripts/core/autoplay_controller.gd
@@ -15,6 +15,9 @@ func set_enabled(value: bool) -> void:
 	if value and ball == null:
 		return
 	_enabled = value
+	
+	if not _enabled:
+		paddle.wants_low_stance = false
 
 
 func _court_side_sign() -> float:

--- a/scripts/core/autoplay_controller.gd
+++ b/scripts/core/autoplay_controller.gd
@@ -15,7 +15,7 @@ func set_enabled(value: bool) -> void:
 	if value and ball == null:
 		return
 	_enabled = value
-	
+
 	if not _enabled:
 		paddle.wants_low_stance = false
 

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -115,6 +115,8 @@ func _track() -> void:
 			paddle_travel_bound,
 		)
 	)
+	# Update the player's low stance from the predicted ball position
+	_update_low_stance(predicted_y, bound_y)
 	var noisy_target: float = predicted_y + _noise_offset
 
 	var delayed_target: float = _apply_reaction_delay(noisy_target)
@@ -134,6 +136,17 @@ func _track() -> void:
 
 	paddle.drive(smoothed_velocity)
 
+## Uses the predicted ball height to switch between grounded stance and
+## low stance when the incoming ball reaches the low-stance threshold.
+func _update_low_stance(predicted_y: float, ball_bounce_y: float) -> void:
+	if not paddle.is_grounded():
+		paddle.wants_low_stance = false
+		return
+		
+	var grounded_y: float = paddle.global_position.y
+	var low_stance_threshold_y: float = (grounded_y + ball_bounce_y) * 0.25
+	
+	paddle.wants_low_stance = predicted_y >= low_stance_threshold_y
 
 func _drift_to_center() -> void:
 	var center_difference: float = -paddle.position.y

--- a/scripts/core/paddle_ai_controller.gd
+++ b/scripts/core/paddle_ai_controller.gd
@@ -136,17 +136,19 @@ func _track() -> void:
 
 	paddle.drive(smoothed_velocity)
 
+
 ## Uses the predicted ball height to switch between grounded stance and
 ## low stance when the incoming ball reaches the low-stance threshold.
 func _update_low_stance(predicted_y: float, ball_bounce_y: float) -> void:
 	if not paddle.is_grounded():
 		paddle.wants_low_stance = false
 		return
-		
+
 	var grounded_y: float = paddle.global_position.y
 	var low_stance_threshold_y: float = (grounded_y + ball_bounce_y) * 0.25
-	
+
 	paddle.wants_low_stance = predicted_y >= low_stance_threshold_y
+
 
 func _drift_to_center() -> void:
 	var center_difference: float = -paddle.position.y

--- a/scripts/entities/paddle.gd
+++ b/scripts/entities/paddle.gd
@@ -25,6 +25,9 @@ signal paddle_hit(ball: Ball)
 ## Suppresses input for auto-play.
 var input_blocked: bool = false
 
+## Whether autoplay wants the paddle to use the low stance
+var wants_low_stance: bool = false
+
 var _ball_manager: BallManager
 
 var _lane_x: float = 0.0

--- a/scripts/entities/player_paddle.gd
+++ b/scripts/entities/player_paddle.gd
@@ -41,10 +41,11 @@ func _on_animation_state_changed(state: StringName) -> void:
 	else:
 		racket_hitbox.position = _default_racket_position
 
+
 ## Manual play uses down key; autoplay usus AI's predicted low-stance decision
 func _is_crouching() -> bool:
 	if not is_grounded():
-			return false
+		return false
 	if input_blocked:
 		return wants_low_stance
 	return Input.is_action_pressed("paddle_down")

--- a/scripts/entities/player_paddle.gd
+++ b/scripts/entities/player_paddle.gd
@@ -41,6 +41,10 @@ func _on_animation_state_changed(state: StringName) -> void:
 	else:
 		racket_hitbox.position = _default_racket_position
 
-
+## Manual play uses down key; autoplay usus AI's predicted low-stance decision
 func _is_crouching() -> bool:
-	return is_grounded() and Input.is_action_pressed("paddle_down")
+	if not is_grounded():
+			return false
+	if input_blocked:
+		return wants_low_stance
+	return Input.is_action_pressed("paddle_down")


### PR DESCRIPTION
Fixes #1228.

Autoplay now uses the predicted incoming ball position to determine when the player should enter the low stance. The low stance is cleared when autoplay is disabled or when the paddle is not grounded.

Tested in-game with autoplay enabled and low incoming balls.